### PR TITLE
Experiment framework + observability fixes (v0.1.5)

### DIFF
--- a/configs/experiment/write_contention.yaml
+++ b/configs/experiment/write_contention.yaml
@@ -1,0 +1,54 @@
+# `nova experiment` — observe the effect of heavy writes on steady-state reads.
+#
+#   nova experiment configs/experiment/write_contention.yaml --dry-run
+#   nova experiment configs/experiment/write_contention.yaml
+#
+# Timeline: launch a distributed read load (storm-dist) at the cluster, let it
+# stabilize, then run a heavy local write load (load) against the SAME cluster
+# and watch read p99 degrade + recover. The write window is bracketed by
+# `writes:start` / `writes:end` events — use those as Grafana annotations over
+# the read-latency panel (filter by this experiment in the Run/Experiment view).
+
+experiment:
+  name: write_contention
+  subject: "qdrant://products"      # informational: the shared subject under test
+
+  # Phase events + child-run linkage land here. Same backend the units stream to,
+  # so reads and the write window share one timeline in Grafana.
+  metrics:
+    type: postgres
+    dsn: ${SN_METRICS_DB_URL}
+
+  cooldown_s: 180                   # keep observing reads after writes stop (recovery)
+
+  steps:
+    # Steady-state reads across an in-region fleet. `launcher: true` because
+    # storm-dist returns once the fleet is dispatched — reads then run on their
+    # own `duration_s` (set that long enough to cover warmup + writes + cooldown).
+    - id: reads
+      run: storm-dist
+      config: configs/storm/poshmark.yaml
+      launcher: true
+
+    # Heavy writes against the same cluster. Foreground: the experiment brackets
+    # it with writes:start / writes:end while the read fleet keeps measuring.
+    - id: writes
+      run: load
+      config: ~/.nova/poshmark.yaml
+      # --no-manage-indexing: just insert into the EXISTING collection storm is
+      # reading — don't recreate it or run the defer/enable-indexing lifecycle.
+      # (Indexing then builds live during the writes — the realistic contention load.)
+      args: ["--no-manage-indexing"]
+      delay_s: 240                  # warmup: let the fleet come up + reads settle
+      timeout_s: 600                # bounded write burst — stop after 10 min, however
+                                    # big the corpus is (omit to load the whole thing)
+
+# All-local variant (no SkyPilot): swap the reads step to a local, backgrounded
+# storm so it overlaps the writes —
+#   - id: reads
+#     run: storm
+#     config: ~/.nova/poshmark-storm.yaml
+#     background: true            # concurrent local reader; torn down at the end
+# Set that storm's duration_s >= delay_s + timeout_s + cooldown_s so it doesn't
+# self-exit before teardown. (Local reads measure laptop->cluster RTT, so absolute
+# p99 is inflated — the bump-and-recover shape is still what you're after.)

--- a/deploy/observability/grafana/provisioning/dashboards/json/storm.json
+++ b/deploy/observability/grafana/provisioning/dashboards/json/storm.json
@@ -3,10 +3,35 @@
   "title": "Supernova — Storm",
   "editable": true,
   "schemaVersion": 39,
-  "version": 4,
+  "version": 5,
   "refresh": "5s",
   "timezone": "browser",
   "time": { "from": "now-3h", "to": "now" },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "name": "Experiment phases",
+        "datasource": { "type": "postgres", "uid": "${ds}" },
+        "enable": true,
+        "iconColor": "semi-dark-orange",
+        "target": {
+          "refId": "anno",
+          "rawQuery": true,
+          "format": "table",
+          "rawSql": "SELECT ts AS time, message AS text FROM events WHERE run_id = (SELECT experiment_id FROM runs WHERE run_id = '$run') AND $__timeFilter(ts) ORDER BY ts"
+        }
+      }
+    ]
+  },
   "templating": {
     "list": [
       {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "supernova"
-version = "0.1.4"
+version = "0.1.5"
 description = "Stream massive datasets, embed at scale, store as parquet in S3."
 readme = "README.md"
 license = "Apache-2.0"

--- a/supernova/cli/cli.py
+++ b/supernova/cli/cli.py
@@ -35,6 +35,10 @@ _LAZY_COMMANDS: dict[str, tuple[str, str]] = {
         "supernova.cli.run_storm_distributed:storm_dist",
         "Distributed load test via SkyPilot pool (replicated).",
     ),
+    "experiment": (
+        "supernova.cli.run_experiment:experiment",
+        "Compose units over a timeline (workload tests).",
+    ),
     "generate-queries": (
         "supernova.cli.run_generate_queries:generate_queries",
         "Sample N rows as eval queries (launches EC2; --local to run here).",

--- a/supernova/cli/run_experiment.py
+++ b/supernova/cli/run_experiment.py
@@ -115,7 +115,13 @@ def experiment(config, dry_run):
     metrics_backend = build_metrics(exp.get("metrics"))
     set_current(metrics_backend)
     metrics_backend.init()
-    metrics_backend.start(experiment_id, {"command": "experiment", "config": cfg})
+    # Self-tag experiment_id == run_id so the Grafana annotation query (which
+    # keys phase events off the selected run's experiment_id) also resolves when
+    # the experiment run itself is selected, not only its child storm runs.
+    metrics_backend.start(
+        experiment_id,
+        {"command": "experiment", "experiment_id": experiment_id, "config": cfg},
+    )
     logger.info("experiment run: %s", experiment_id)
 
     # Children inherit the experiment id; they each mint their own run_id but tag

--- a/supernova/cli/run_experiment.py
+++ b/supernova/cli/run_experiment.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""`nova experiment` — compose units over a timeline against one shared subject.
+
+The local-first spine (V1): a declarative timeline of steps, each shelling a unit
+CLI (`storm-dist`, `load`, ...) with `NOVA_EXPERIMENT_ID` forwarded so every child
+run is grouped under one experiment. Phase events become Grafana annotations.
+
+Config shape:
+
+    experiment:
+      name: write_contention          # optional; used to mint the experiment id
+      metrics:                         # where phase events + child runs are linked
+        type: postgres
+        dsn: ${SN_METRICS_DB_URL}
+      cooldown_s: 120                  # keep observing after the last step
+      steps:
+        - id: reads
+          run: storm-dist              # launcher: dispatches a fleet, returns
+          config: configs/storm/poshmark.yaml
+          launcher: true
+        - id: writes
+          run: load                    # foreground: runs to completion
+          config: ~/.nova/poshmark.yaml
+          delay_s: 180                 # warmup: let reads stabilize first
+"""
+
+import logging
+import os
+
+import click
+import yaml
+
+from supernova.metrics import build_metrics, generate_run_name, make_run_id, set_current
+from supernova.experiment.runner import run_experiment
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(name="experiment", help="Compose units over a timeline (workload tests).")
+@click.argument("config")
+@click.option("--dry-run", is_flag=True, help="Parse + print the plan, launch nothing.")
+def experiment(config, dry_run):
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S"
+    )
+
+    from supernova.cli.run_loader import resolve_config
+
+    with open(config) as f:
+        cfg = resolve_config(yaml.safe_load(f))
+
+    exp = cfg["experiment"]
+    steps = exp.get("steps") or []
+    if not steps:
+        raise click.UsageError("experiment.steps is empty — nothing to run")
+
+    base_name = exp.get("name") or generate_run_name()
+    experiment_id = os.environ.get("NOVA_EXPERIMENT_ID") or make_run_id(base_name)
+    cooldown = exp.get("cooldown_s", 0)
+
+    # Normalize step keys (delay_s -> delay) so the runner stays terse, and
+    # validate dispositions up front (loud over silent — see the Qdrant params guard).
+    known = {"id", "run", "config", "launcher", "background", "delay_s", "timeout_s", "args"}
+    norm_steps = []
+    for s in steps:
+        unknown = set(s) - known
+        if unknown:
+            raise click.UsageError(
+                f"step {s.get('id', '?')!r}: unknown keys {sorted(unknown)}. Valid: {sorted(known)}"
+            )
+        if s.get("launcher") and s.get("background"):
+            raise click.UsageError(
+                f"step {s['id']!r}: 'launcher' and 'background' are mutually exclusive"
+            )
+        if s.get("launcher") and not str(s["run"]).endswith("-dist"):
+            click.echo(
+                f"  warning: step {s['id']!r} is 'launcher' but '{s['run']}' isn't a *-dist "
+                f"dispatcher — a local command runs in the foreground and will block the "
+                f"timeline (reads won't overlap writes). Did you mean 'background: true'?",
+                err=True,
+            )
+        norm_steps.append(
+            {
+                "id": s["id"],
+                "run": s["run"],
+                # Paths in the YAML aren't shell-expanded; do it here so child
+                # units receive a real path (open() doesn't grok '~').
+                "config": os.path.expanduser(s["config"]),
+                "launcher": bool(s.get("launcher")),
+                "background": bool(s.get("background")),
+                "delay": s.get("delay_s", 0),
+                "timeout_s": s.get("timeout_s"),
+                "args": s.get("args") or [],
+            }
+        )
+
+    if dry_run:
+        click.echo("=" * 60)
+        click.echo(f"experiment: {experiment_id}")
+        click.echo(f"subject:    {exp.get('subject', '(unspecified)')}")
+        for s in norm_steps:
+            disp = "background" if s["background"] else "launcher" if s["launcher"] else "foreground"
+            cap = f" timeout={s['timeout_s']}s" if s["timeout_s"] else ""
+            extra = (" " + " ".join(s["args"])) if s["args"] else ""
+            click.echo(
+                f"  + delay {s['delay']:>4}s  {s['id']:<10} {disp:<10}{cap}  "
+                f"nova {s['run']} {s['config']}{extra}"
+            )
+        click.echo(f"  + cooldown {cooldown}s")
+        click.echo("=" * 60)
+        return
+
+    # The orchestrator itself IS a run (run_id == experiment_id); child runs point
+    # back via experiment_id, and phase events land under this run.
+    metrics_backend = build_metrics(exp.get("metrics"))
+    set_current(metrics_backend)
+    metrics_backend.init()
+    metrics_backend.start(experiment_id, {"command": "experiment", "config": cfg})
+    logger.info("experiment run: %s", experiment_id)
+
+    # Children inherit the experiment id; they each mint their own run_id but tag
+    # this experiment so Grafana can group them.
+    child_env = dict(os.environ)
+    child_env["NOVA_EXPERIMENT_ID"] = experiment_id
+
+    status = "ok"
+    try:
+        status = run_experiment(experiment_id, norm_steps, cooldown=cooldown, env=child_env)
+    finally:
+        metrics_backend.finish(status)
+        logger.info("experiment %s finished: %s", experiment_id, status)
+
+
+if __name__ == "__main__":
+    experiment()

--- a/supernova/cli/run_storm.py
+++ b/supernova/cli/run_storm.py
@@ -125,7 +125,15 @@ def storm(config, duration, concurrency, qps):
     metrics_backend = build_metrics(cfg.get("metrics"))
     set_current(metrics_backend)
     metrics_backend.init()
-    metrics_backend.start(run_id, {"command": "storm", "node_id": node_id, "config": cfg})
+    metrics_backend.start(
+        run_id,
+        {
+            "command": "storm",
+            "node_id": node_id,
+            "experiment_id": os.environ.get("NOVA_EXPERIMENT_ID"),
+            "config": cfg,
+        },
+    )
     logger.info("storm run: %s (node %s)", run_id, node_id)
 
     status = "ok"

--- a/supernova/cli/run_storm_distributed.py
+++ b/supernova/cli/run_storm_distributed.py
@@ -9,6 +9,7 @@ mid-run would corrupt the measurement window.
 
 import json
 import logging
+import os
 import re
 from pathlib import Path
 
@@ -138,6 +139,11 @@ def storm_dist(config, dry_run, num_workers, pool_name, spot):
     referenced = sorted(set(re.findall(r"\$\{(\w+)\}", Path(config).read_text())))
     envs = build_env_dict(referenced)
     envs["NOVA_RUN_ID"] = metrics_run_id  # every worker writes into this one run
+    # When launched under `nova experiment`, tag this run's workers with the
+    # experiment so Grafana can group reads + the write phase on one timeline.
+    exp_id = os.environ.get("NOVA_EXPERIMENT_ID")
+    if exp_id:
+        envs["NOVA_EXPERIMENT_ID"] = exp_id
     logger.info("Creating pool '%s' with %d workers...", pool_name_eff, num_workers_eff)
     launch_pool_and_jobs(pool_name_eff, pool_path, job_path, num_workers_eff, envs)
 

--- a/supernova/experiment/__init__.py
+++ b/supernova/experiment/__init__.py
@@ -1,0 +1,8 @@
+"""Experiment orchestration — compose units over a timeline against one subject.
+
+See ``runner.run_experiment``. The CLI lives in ``supernova.cli.run_experiment``.
+"""
+
+from .runner import run_experiment
+
+__all__ = ["run_experiment"]

--- a/supernova/experiment/runner.py
+++ b/supernova/experiment/runner.py
@@ -1,0 +1,132 @@
+"""Experiment runner — drive a timeline of steps against one shared subject.
+
+An experiment composes the existing units (`storm`/`storm-dist`/`load`/...) over
+time so you can observe how ONE subject behaves under a sequence of workloads —
+e.g. steady reads, then a heavy write burst, then recovery. It is NOT a job
+scheduler: steps are expected to share a subject (see issue #11). Unrelated
+co-scheduled work doesn't belong here.
+
+Composition is by subprocess over each unit's CLI contract — the runner shells
+`nova <run> <config>`, forwarding ``NOVA_EXPERIMENT_ID`` so every child run is
+tagged with this experiment, and emits phase events that become Grafana
+annotations. It never imports a unit; the unit boundary is a process boundary.
+
+Each step has one of three dispositions:
+  * foreground (default) — run to completion; the runner brackets it with
+    ``<id>:start`` / ``<id>:end``. Optional ``timeout_s`` caps it into a bounded
+    burst (SIGINT then kill), reported as a clean end, not an error. (e.g. local
+    ``load`` capped to a write burst.)
+  * launcher (``launcher: true``) — the subprocess returns once the work is
+    *dispatched* and keeps running elsewhere (e.g. ``storm-dist`` launches a fleet
+    that runs on its own ``duration_s``). The runner waits for that fast exit and
+    emits ``<id>:launched``; it has no handle on the remote work's lifetime.
+  * background (``background: true``) — launched concurrently (``Popen``, not
+    waited on) and torn down (SIGINT) at experiment end, emitting ``<id>:end``
+    then. This is how a *local* long-running reader overlaps a foreground writer.
+
+storm-dist gets concurrency for free as a launcher (it backgrounds its own
+fleet); a local ``storm`` reader needs ``background: true`` to overlap writes.
+"""
+
+import logging
+import signal
+import subprocess
+import sys
+import time
+
+from supernova import metrics
+
+logger = logging.getLogger(__name__)
+
+_STOP_GRACE_S = 30  # SIGINT then wait this long before SIGKILL
+
+
+def _sleep(seconds: float, label: str) -> None:
+    if seconds and seconds > 0:
+        logger.info("experiment: %s — sleeping %.0fs", label, seconds)
+        time.sleep(seconds)
+
+
+def _stop(proc: subprocess.Popen) -> None:
+    """Stop a running child gracefully: SIGINT (so the unit can flush metrics /
+    mark its run finished), then SIGKILL if it doesn't exit in time."""
+    if proc.poll() is not None:
+        return
+    proc.send_signal(signal.SIGINT)
+    try:
+        proc.wait(timeout=_STOP_GRACE_S)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def run_experiment(experiment_id: str, steps: list[dict], cooldown: float = 0.0, env: dict | None = None) -> str:
+    """Execute ``steps`` in order, emitting phase events tagged with the experiment.
+
+    Returns the final status ("ok" / "error" / "interrupted"). Assumes the caller
+    has built + started a metrics backend with ``run_id == experiment_id`` and
+    forwarded ``NOVA_EXPERIMENT_ID`` via ``env``.
+    """
+    status = "ok"
+    background: list[tuple[str, subprocess.Popen]] = []
+
+    def _teardown_background() -> None:
+        for step_id, proc in background:
+            if proc.poll() is not None:
+                metrics.event(f"{step_id}:end", step=step_id, note="self-exited")
+                continue
+            logger.info("experiment: stopping background step %r", step_id)
+            _stop(proc)
+            metrics.event(f"{step_id}:end", step=step_id)
+
+    try:
+        for step in steps:
+            step_id = step["id"]
+            _sleep(step.get("delay", 0), f"before {step_id}")
+
+            cmd = [sys.executable, "-m", "supernova.cli.cli", step["run"], step["config"]]
+            cmd += [str(a) for a in (step.get("args") or [])]  # extra unit flags, e.g. --no-manage-indexing
+            disposition = (
+                "background" if step.get("background")
+                else "launcher" if step.get("launcher")
+                else "foreground"
+            )
+            metrics.event(f"{step_id}:start", step=step_id, run=step["run"], disposition=disposition)
+            logger.info("experiment: step %r [%s] -> %s", step_id, disposition, " ".join(cmd[2:]))
+
+            # stdio inherited so SkyPilot/tqdm output streams live; SIGINT reaches
+            # children via the shared process group.
+            proc = subprocess.Popen(cmd, env=env)
+
+            if disposition == "background":
+                background.append((step_id, proc))
+                continue  # concurrent — torn down after the foreground timeline
+
+            timeout = step.get("timeout_s") if disposition == "foreground" else None
+            try:
+                rc = proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                # deliberate cap on the burst — a clean stop, not an error.
+                _stop(proc)
+                metrics.event(f"{step_id}:end", step=step_id, note=f"timeout_s={timeout}")
+                logger.info("experiment: step %r hit timeout_s=%s — stopped", step_id, timeout)
+                continue
+
+            if rc != 0:
+                metrics.event(f"{step_id}:error", step=step_id, returncode=rc)
+                logger.error("experiment: step %r exited %d — aborting", step_id, rc)
+                status = "error"
+                break
+
+            metrics.event(
+                f"{step_id}:{'launched' if disposition == 'launcher' else 'end'}", step=step_id
+            )
+
+        if status == "ok":
+            _sleep(cooldown, "cooldown")
+    except KeyboardInterrupt:
+        status = "interrupted"
+        metrics.event("experiment:interrupted")
+        logger.warning("experiment: interrupted")
+    finally:
+        _teardown_background()
+    return status

--- a/supernova/metrics/naming.py
+++ b/supernova/metrics/naming.py
@@ -8,7 +8,7 @@ a run.
 """
 
 import random
-from datetime import datetime
+from datetime import datetime, timezone
 
 _ADJECTIVES = (
     "frosty", "amber", "brisk", "cobalt", "dapper", "eager", "fuzzy", "gilded",
@@ -31,5 +31,8 @@ def make_run_id(name: str) -> str:
     """Unique id for ONE execution: base name + timestamp. The runs table keys on
     this, so rerunning with the same dispatch.run_name no longer collides.
     Distributed workers must share one id — the controller mints it and forwards
-    NOVA_RUN_ID rather than each worker calling this."""
-    return f"{name}-{datetime.now():%Y%m%d-%H%M%S}"
+    NOVA_RUN_ID rather than each worker calling this.
+
+    Timestamp is UTC to match every stored metric ts (samples/events/started_at
+    are all UTC); a local-time suffix here would read hours off from the data."""
+    return f"{name}-{datetime.now(timezone.utc):%Y%m%d-%H%M%S}"

--- a/supernova/metrics/postgres.py
+++ b/supernova/metrics/postgres.py
@@ -26,14 +26,15 @@ logger = logging.getLogger("supernova.metrics")
 
 _SCHEMA = """
 create table if not exists runs (
-    run_id      text primary key,
-    command     text,
-    node_id     text,
-    started_at  timestamptz not null default now(),
-    finished_at timestamptz,
-    status      text,
-    config      jsonb,
-    summary     jsonb
+    run_id        text primary key,
+    command       text,
+    node_id       text,
+    experiment_id text,
+    started_at    timestamptz not null default now(),
+    finished_at   timestamptz,
+    status        text,
+    config        jsonb,
+    summary       jsonb
 );
 create table if not exists samples (
     ts      timestamptz not null,
@@ -89,6 +90,8 @@ class PostgresBackend(MetricsBackend):
         with self._conn.cursor() as cur:
             for stmt in filter(str.strip, _SCHEMA.split(";")):
                 cur.execute(stmt)
+            # Backfill the column on tables created before experiments existed.
+            cur.execute("alter table runs add column if not exists experiment_id text")
             try:
                 cur.execute("create extension if not exists timescaledb")
                 cur.execute("select create_hypertable('samples', 'ts', if_not_exists => true)")
@@ -105,9 +108,15 @@ class PostgresBackend(MetricsBackend):
         # ON CONFLICT DO NOTHING so replicated fleet workers (sharing one run_id
         # via NOVA_RUN_ID) don't fight over the row; the first one writes it.
         self._conn.execute(
-            "insert into runs (run_id, command, node_id, status, config) "
-            "values (%s, %s, %s, 'running', %s) on conflict (run_id) do nothing",
-            (run_id, context.get("command"), self._node_id, Jsonb(_redact(context.get("config", {})))),
+            "insert into runs (run_id, command, node_id, experiment_id, status, config) "
+            "values (%s, %s, %s, %s, 'running', %s) on conflict (run_id) do nothing",
+            (
+                run_id,
+                context.get("command"),
+                self._node_id,
+                context.get("experiment_id"),
+                Jsonb(_redact(context.get("config", {}))),
+            ),
         )
 
     def log(self, name, value, **tags):

--- a/uv.lock
+++ b/uv.lock
@@ -4388,7 +4388,7 @@ wheels = [
 
 [[package]]
 name = "supernova"
-version = "0.1.3"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -4424,12 +4424,6 @@ load = [
     { name = "duckdb" },
     { name = "qdrant-client" },
 ]
-partition = [
-    { name = "aiobotocore" },
-    { name = "aiohttp" },
-    { name = "hf-transfer" },
-    { name = "tiktoken" },
-]
 pg = [
     { name = "psycopg", extra = ["binary"] },
 ]
@@ -4450,9 +4444,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiobotocore", marker = "extra == 'embed'", specifier = "<3.5" },
-    { name = "aiobotocore", marker = "extra == 'partition'", specifier = "<3.5" },
     { name = "aiohttp", marker = "extra == 'embed'", specifier = "<3.13.5" },
-    { name = "aiohttp", marker = "extra == 'partition'", specifier = "<3.13.5" },
     { name = "boto3" },
     { name = "click", specifier = ">=8.1" },
     { name = "duckdb", marker = "extra == 'load'", specifier = ">=1.5.1" },
@@ -4461,7 +4453,6 @@ requires-dist = [
     { name = "fastembed", marker = "extra == 'embed'" },
     { name = "flagembedding", marker = "extra == 'embed'" },
     { name = "hf-transfer", marker = "extra == 'embed'" },
-    { name = "hf-transfer", marker = "extra == 'partition'" },
     { name = "huggingface-hub", specifier = ">=1.5" },
     { name = "numpy" },
     { name = "openai", marker = "extra == 'embed'" },
@@ -4473,13 +4464,12 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'embed'" },
     { name = "skypilot", extras = ["aws"], marker = "extra == 'dist'" },
     { name = "tiktoken", marker = "extra == 'embed'", specifier = ">=0.12.0" },
-    { name = "tiktoken", marker = "extra == 'partition'", specifier = ">=0.12.0" },
     { name = "torch", marker = "extra == 'embed'" },
     { name = "torch", marker = "extra == 'eval'" },
     { name = "tqdm" },
     { name = "transformers", marker = "extra == 'embed'" },
 ]
-provides-extras = ["embed", "partition", "load", "eval", "storm", "dist", "pg"]
+provides-extras = ["embed", "load", "eval", "storm", "dist", "pg"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Lands the `nova experiment` framework on `master` as a clean, releasable unit — it was previously only on the `rewrites` mega-branch (commit 107bfd5), tangled with the unrelated Rust migration work. This branch is `master` + that one commit + two fixes + the version bump, nothing else.

## What's here

- **`nova experiment`** — composes existing units (storm-dist / load / …) over a shared timeline against one subject (steady reads + write bursts + recovery), forwarding `NOVA_EXPERIMENT_ID` so child runs group under the experiment. Phase events become Grafana annotations. (commit 107bfd5, unchanged)
- **fix: UTC run-id timestamps** — `make_run_id` stamped the suffix in naive *local* time while every metric `ts` (samples/events/`started_at`) is UTC, so run ids read hours off from the data they label.
- **fix: self-tag experiment runs** — the orchestrator inserted its own run row without an `experiment_id`, so the dashboard annotation query (which keys phase events off the selected run's `experiment_id`) returned NULL when the experiment run itself was selected. Now `experiment_id == run_id` for the orchestrator.

## Why release it

Distributed workers `pip install` the pinned PyPI version (`worker_version()`), so the experiment-aware `storm` code only reaches the fleet once it's published. Tagging `v0.1.5` after merge ships it.

## Notes
- Lockfile reconciled (drops the stale `partition` extra already removed from pyproject on `master`).
- Verified `make_run_id` now emits UTC; package imports + builds clean under the project interpreter (≥3.11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)