### PR TITLE
Recall calc

### DIFF
--- a/configs/brute_force/example.yaml
+++ b/configs/brute_force/example.yaml
@@ -41,3 +41,14 @@ params:
   # until a file is big enough (or the query set large enough) to OOM the GPU.
   # Values below k are raised to k (a smaller batch can't fill the top-K).
   # corpus_batch_size: 4096
+
+# Restrict eligible neighbors to corpus rows matching this predicate — shaped
+# like a Qdrant filter (must = AND, should = OR-at-least-one, must_not = AND-NOT).
+# A condition's `field` is the only place you name a corpus column to filter on
+# — `compute` reads exactly (and only) the columns referenced here.
+# filter:
+#   must:
+#     - field: language
+#       match: eng            # scalar = equality; a list matches any of them
+#     - field: cost
+#       range: {lt: 10}       # gt/gte/lt/lte, combinable in one condition

--- a/crates/nova-storm/src/config.rs
+++ b/crates/nova-storm/src/config.rs
@@ -27,7 +27,14 @@ impl StormConfig {
     /// Parse from YAML text, expanding `${VAR}` references first.
     pub fn from_yaml(yaml: &str) -> Result<Self, ConfigError> {
         let expanded = expand_env(yaml)?;
-        Ok(serde_yaml::from_str(&expanded)?)
+        let cfg: Self = serde_yaml::from_str(&expanded)?;
+        // A `.limit(0)` query returns nothing and, if `ground_truth_column` is
+        // set, divides recall by 0 (NaN) — reject at config time rather than
+        // silently corrupting the summary.
+        if cfg.query.top_k == 0 {
+            return Err(ConfigError::ZeroTopK);
+        }
+        Ok(cfg)
     }
 
     /// Read and parse a config file, expanding `${VAR}` references.
@@ -62,6 +69,14 @@ pub struct QuerySource {
     /// How many query vectors to load and cycle through.
     #[serde(default = "default_limit")]
     pub limit: usize,
+    /// A `list<string>` column in the same file holding each query's known-correct
+    /// top-k point ids (e.g. `nova bf`'s own `hit_ids` output, reused directly —
+    /// no separate ground-truth file or id-matching needed since it's read
+    /// alongside the vector in the same row). `None` (default) → no recall
+    /// tracking; a null value for a given row → that row just has no ground
+    /// truth (not an error), so it still contributes latency but no recall.
+    #[serde(default)]
+    pub ground_truth_column: Option<String>,
 }
 
 /// Per-worker load shape, replicated (NOT sharded) across the fleet.
@@ -114,6 +129,8 @@ pub enum ConfigError {
     MissingEnvVar(String),
     #[error("unterminated `${{` placeholder in config (missing closing `}}`)")]
     UnterminatedPlaceholder,
+    #[error("query.top_k must be greater than 0")]
+    ZeroTopK,
 }
 
 /// Expand `${VAR}` references in `input` from the process environment.
@@ -211,6 +228,40 @@ query:
         assert_eq!(cfg.load.concurrency, 32);
         assert_eq!(cfg.load.target_qps, 0.0);
         assert_eq!(cfg.query.top_k, 10);
+        assert_eq!(cfg.query.source.ground_truth_column, None);
+    }
+
+    #[test]
+    fn rejects_zero_top_k() {
+        let yaml = r#"
+target:
+  type: qdrant
+  url: http://localhost:6334
+  collection_name: c
+query:
+  top_k: 0
+  source:
+    uri: /tmp/q.parquet
+    column: embedding
+"#;
+        assert!(matches!(StormConfig::from_yaml(yaml).unwrap_err(), ConfigError::ZeroTopK));
+    }
+
+    #[test]
+    fn parses_ground_truth_column() {
+        let yaml = r#"
+target:
+  type: qdrant
+  url: http://localhost:6334
+  collection_name: c
+query:
+  source:
+    uri: /tmp/q.parquet
+    column: embedding
+    ground_truth_column: hit_ids
+"#;
+        let cfg = StormConfig::from_yaml(yaml).expect("parses");
+        assert_eq!(cfg.query.source.ground_truth_column.as_deref(), Some("hit_ids"));
     }
 
     fn expand(input: &str, vars: &[(&str, &str)]) -> Result<String, ConfigError> {

--- a/crates/nova-storm/src/lib.rs
+++ b/crates/nova-storm/src/lib.rs
@@ -38,6 +38,7 @@ pub async fn run(config: StormConfig) -> Result<Summary, StormError> {
             query.source.uri, query.source.column
         )));
     }
+    let with_ground_truth = vectors.iter().filter(|v| v.ground_truth.is_some()).count();
 
     let target = target.into_target(&query)?;
 
@@ -52,6 +53,32 @@ pub async fn run(config: StormConfig) -> Result<Summary, StormError> {
         duration_s = load.duration_s,
         "storm: {mode}"
     );
+    if query.source.ground_truth_column.is_some() {
+        // Surfaces a wrong column name / all-null column immediately, rather
+        // than silently as a missing `mean_recall` at the end of the run.
+        tracing::info!(
+            "recall tracking: {with_ground_truth}/{} queries have ground truth (column {:?})",
+            vectors.len(),
+            query.source.ground_truth_column,
+        );
+        // recall_at_k divides by top_k, so a ground-truth list shorter than
+        // top_k silently caps recall (e.g. bf's k=10 vs storm's top_k=100 caps
+        // every recall sample at 0.10) with no other signal — warn up front
+        // rather than let it read as a real search-quality regression.
+        let short = vectors
+            .iter()
+            .filter_map(|v| v.ground_truth.as_ref())
+            .filter(|gt| (gt.len() as u64) < query.top_k)
+            .count();
+        if short > 0 {
+            tracing::warn!(
+                "{short}/{with_ground_truth} ground-truth lists hold fewer than top_k={} ids — \
+                 recall will read artificially low for those queries (the ground truth's own k \
+                 must be at least storm's top_k)",
+                query.top_k,
+            );
+        }
+    }
 
     // A spinner so a long run doesn't look frozen; hidden when not a TTY.
     let spinner = if std::io::stderr().is_terminal() {
@@ -63,7 +90,7 @@ pub async fn run(config: StormConfig) -> Result<Summary, StormError> {
         ProgressBar::hidden()
     };
 
-    let results = runner::run_storm(target, vectors, &load).await;
+    let results = runner::run_storm(target, vectors, &load, query.top_k).await;
     spinner.finish_and_clear();
 
     Ok(results.summary())

--- a/crates/nova-storm/src/queries.rs
+++ b/crates/nova-storm/src/queries.rs
@@ -6,6 +6,16 @@
 //! one-shot synchronous read — there's nothing to stream or overlap. (Contrast
 //! `nova-load`, which downloads huge corpus files; a small query set reads fine
 //! straight from `s3://` via httpfs.)
+//!
+//! If `source.ground_truth_column` is set, each row's known-correct top-k point
+//! ids are read alongside its vector in the *same* query — e.g. pointing
+//! straight at `nova bf`'s own output parquet (`hit_ids`), which already carries
+//! the query vector forward if `nova bf`'s `queries.payload_fields` included it.
+//! Reading both columns from the same row sidesteps ever needing to join two
+//! files by an independently-derived query id: the vector and its ground truth
+//! arrive already paired, by construction.
+
+use std::collections::HashSet;
 
 use duckdb::Connection;
 use duckdb::types::Value;
@@ -13,31 +23,64 @@ use duckdb::types::Value;
 use crate::config::QuerySource;
 use crate::errors::QueryLoadError;
 
-/// Read up to `source.limit` query vectors from `source.column` of the parquet
-/// at `source.uri`. Rows whose vector column is NULL are skipped.
-pub fn load_query_vectors(source: &QuerySource) -> Result<Vec<Vec<f32>>, QueryLoadError> {
+/// One query vector plus its ground truth, if configured. Bundled into one
+/// struct (rather than two parallel `Vec`s) so the two can never drift out of
+/// index alignment. `ground_truth` is a `HashSet`, not the raw `Vec` the
+/// column decodes to, so `recall_at_k` (called once per query *firing*, and
+/// queries cycle round-robin through a fixed, reused set of these) doesn't
+/// rebuild a set from the same ids over and over — it's built once, here, at
+/// load time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueryVector {
+    pub vector: Vec<f32>,
+    /// `None` when `ground_truth_column` isn't configured, or when this row's
+    /// value is SQL NULL — either way, just "no known-correct answer for this
+    /// query," not an error: the query still runs and contributes latency.
+    pub ground_truth: Option<HashSet<String>>,
+}
+
+/// Read up to `source.limit` query vectors (and, if configured, each one's
+/// ground truth) from `source.uri`. Rows whose vector column is NULL are
+/// skipped entirely (there's nothing to query with); a NULL ground-truth value
+/// on an otherwise-valid row just means that query has no known-correct answer.
+pub fn load_query_vectors(source: &QuerySource) -> Result<Vec<QueryVector>, QueryLoadError> {
     let conn = Connection::open_in_memory()?;
     // httpfs lets DuckDB read `s3://` (and `http(s)://`); harmless for local paths.
     conn.execute_batch("INSTALL httpfs; LOAD httpfs;")?;
     configure_s3(&conn)?;
 
-    // Config is operator-authored (trusted). The column is quoted so names with
-    // odd characters survive.
+    // Config is operator-authored (trusted). Columns are quoted so names with
+    // odd characters survive. `cols` is the single source of truth for both the
+    // SQL projection and "how many columns to read per row" below — there's
+    // exactly one place that decides whether a ground-truth column is in play.
+    let cols: Vec<&str> =
+        std::iter::once(source.column.as_str()).chain(source.ground_truth_column.as_deref()).collect();
+    let projection = cols.iter().map(|c| format!("\"{c}\"")).collect::<Vec<_>>().join(", ");
     let sql = format!(
-        "SELECT \"{col}\" FROM read_parquet('{uri}') WHERE \"{col}\" IS NOT NULL LIMIT {limit}",
-        col = source.column,
+        "SELECT {projection} FROM read_parquet('{uri}') WHERE \"{col}\" IS NOT NULL LIMIT {limit}",
         uri = source.uri,
+        col = source.column,
         limit = source.limit,
     );
 
+    let has_gt = cols.len() > 1;
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map([], |row| row.get::<_, Value>(0))?;
+    let rows = stmt.query_map([], move |row| {
+        let vector = row.get::<_, Value>(0)?;
+        let ground_truth = if has_gt { Some(row.get::<_, Value>(1)?) } else { None };
+        Ok((vector, ground_truth))
+    })?;
 
-    let mut vectors = Vec::new();
+    let mut out = Vec::new();
     for row in rows {
-        vectors.push(float_list(row?)?);
+        let (vector, ground_truth) = row?;
+        let ground_truth = match ground_truth {
+            None | Some(Value::Null) => None,
+            Some(v) => Some(string_list(v)?.into_iter().collect::<HashSet<_>>()),
+        };
+        out.push(QueryVector { vector: float_list(vector)?, ground_truth });
     }
-    Ok(vectors)
+    Ok(out)
 }
 
 /// Point DuckDB's httpfs at S3 using the standard AWS environment variables.
@@ -83,6 +126,23 @@ fn float(v: &Value) -> Option<f32> {
     }
 }
 
+/// Coerce a DuckDB `LIST`/`ARRAY` of strings into a `Vec<String>` — the same
+/// shape as [`float_list`], for a ground-truth `hit_ids` column instead of a
+/// vector column.
+fn string_list(value: Value) -> Result<Vec<String>, QueryLoadError> {
+    match value {
+        Value::List(xs) | Value::Array(xs) => xs
+            .iter()
+            .map(|v| match v {
+                Value::Text(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect::<Option<_>>()
+            .ok_or_else(|| QueryLoadError::Other("ground_truth column is not a list of strings".into())),
+        _ => Err(QueryLoadError::Other("ground_truth column is not a list of strings".into())),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -98,6 +158,29 @@ mod tests {
         .unwrap();
     }
 
+    /// Like [`write_parquet`], plus a `hit_ids` column: row `i` gets
+    /// `["gt-{i}-a", "gt-{i}-b"]`, except row 0 which gets a NULL ground truth
+    /// (to exercise the "no known-correct answer for this one" path).
+    fn write_parquet_with_ground_truth(path: &std::path::Path, rows: usize) {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(&format!(
+            "COPY (SELECT [i::FLOAT, (i + 1)::FLOAT, (i + 2)::FLOAT] AS embedding, \
+             CASE WHEN i = 0 THEN NULL ELSE ['gt-' || i || '-a', 'gt-' || i || '-b'] END AS hit_ids \
+             FROM range({rows}) r(i)) TO '{}' (FORMAT PARQUET)",
+            path.display()
+        ))
+        .unwrap();
+    }
+
+    fn source(uri: String, ground_truth_column: Option<&str>) -> QuerySource {
+        QuerySource {
+            uri,
+            column: "embedding".into(),
+            limit: 10,
+            ground_truth_column: ground_truth_column.map(str::to_string),
+        }
+    }
+
     #[test]
     fn loads_and_limits_query_vectors() {
         let dir = std::env::temp_dir().join(format!("nova_storm_q_{}", std::process::id()));
@@ -105,16 +188,57 @@ mod tests {
         let file = dir.join("queries.parquet");
         write_parquet(&file, 100);
 
-        let source = QuerySource {
-            uri: file.display().to_string(),
-            column: "embedding".into(),
-            limit: 10,
-        };
-        let vectors = load_query_vectors(&source).unwrap();
+        let vectors = load_query_vectors(&source(file.display().to_string(), None)).unwrap();
 
         std::fs::remove_dir_all(&dir).ok();
 
         assert_eq!(vectors.len(), 10); // LIMIT honoured
-        assert!(vectors.iter().all(|v| v.len() == 3)); // full dim per row
+        assert!(vectors.iter().all(|v| v.vector.len() == 3)); // full dim per row
+        assert!(vectors.iter().all(|v| v.ground_truth.is_none())); // no column configured
+    }
+
+    #[test]
+    fn loads_ground_truth_column_when_configured() {
+        let dir = std::env::temp_dir().join(format!("nova_storm_qgt_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("queries.parquet");
+        write_parquet_with_ground_truth(&file, 5);
+
+        let vectors =
+            load_query_vectors(&source(file.display().to_string(), Some("hit_ids"))).unwrap();
+
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(vectors.len(), 5);
+        // row 0's ground truth was NULL -> None, not an error, not skipped.
+        assert_eq!(vectors[0].ground_truth, None);
+        assert_eq!(
+            vectors[1].ground_truth,
+            Some(HashSet::from(["gt-1-a".to_string(), "gt-1-b".to_string()]))
+        );
+        assert_eq!(
+            vectors[4].ground_truth,
+            Some(HashSet::from(["gt-4-a".to_string(), "gt-4-b".to_string()]))
+        );
+    }
+
+    #[test]
+    fn ground_truth_column_wrong_type_errors() {
+        let dir = std::env::temp_dir().join(format!("nova_storm_qgtbad_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("queries.parquet");
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(&format!(
+            "COPY (SELECT [i::FLOAT, (i + 1)::FLOAT, (i + 2)::FLOAT] AS embedding, \
+             i AS hit_ids FROM range(3) r(i)) TO '{}' (FORMAT PARQUET)",
+            file.display()
+        ))
+        .unwrap();
+
+        let result = load_query_vectors(&source(file.display().to_string(), Some("hit_ids")));
+
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert!(result.is_err());
     }
 }

--- a/crates/nova-storm/src/runner.rs
+++ b/crates/nova-storm/src/runner.rs
@@ -327,7 +327,6 @@ mod tests {
                 return QueryOutcome {
                     latency: Duration::from_micros(100),
                     ok: false,
-                    matched: 0,
                     ids: None,
                     error: Some("mock failure".into()),
                 };
@@ -335,7 +334,6 @@ mod tests {
             QueryOutcome {
                 latency: Duration::from_micros(100),
                 ok: true,
-                matched: self.ids.len(),
                 ids: Some(self.ids.clone()),
                 error: None,
             }
@@ -501,7 +499,7 @@ mod tests {
                     1 => vec!["a".to_string()], // 1/2 -> recall 0.5
                     _ => vec!["a".to_string(), "b".to_string()], // 2/2 -> recall 1.0
                 };
-                QueryOutcome { latency: Duration::from_micros(100), ok: true, matched: ids.len(), ids: Some(ids), error: None }
+                QueryOutcome { latency: Duration::from_micros(100), ok: true, ids: Some(ids), error: None }
             }
         }
         let gt = Some(HashSet::from(["a".to_string(), "b".to_string()]));

--- a/crates/nova-storm/src/runner.rs
+++ b/crates/nova-storm/src/runner.rs
@@ -150,8 +150,11 @@ struct Sample {
 
 /// Build a [`Sample`] from a completed query, applying the "only score recall
 /// on success" rule above in one place (both load-shape functions call this).
+/// `out.ids` being `None` already covers both "no ground truth was tracked"
+/// and "the query failed" — see `QueryOutcome::ids` — so `zip` alone is the
+/// whole rule; no separate `out.ok` check is needed here anymore.
 fn sample_from(out: &crate::targets::QueryOutcome, ground_truth: Option<&HashSet<String>>, top_k: u64) -> Sample {
-    let recall = out.ok.then(|| ground_truth.map(|gt| recall_at_k(&out.ids, gt, top_k))).flatten();
+    let recall = out.ids.as_ref().zip(ground_truth).map(|(ids, gt)| recall_at_k(ids, gt, top_k));
     Sample { latency_ms: out.latency.as_secs_f64() * 1000.0, ok: out.ok, recall }
 }
 
@@ -325,7 +328,7 @@ mod tests {
                     latency: Duration::from_micros(100),
                     ok: false,
                     matched: 0,
-                    ids: vec![],
+                    ids: None,
                     error: Some("mock failure".into()),
                 };
             }
@@ -333,7 +336,7 @@ mod tests {
                 latency: Duration::from_micros(100),
                 ok: true,
                 matched: self.ids.len(),
-                ids: self.ids.clone(),
+                ids: Some(self.ids.clone()),
                 error: None,
             }
         }
@@ -498,7 +501,7 @@ mod tests {
                     1 => vec!["a".to_string()], // 1/2 -> recall 0.5
                     _ => vec!["a".to_string(), "b".to_string()], // 2/2 -> recall 1.0
                 };
-                QueryOutcome { latency: Duration::from_micros(100), ok: true, matched: ids.len(), ids, error: None }
+                QueryOutcome { latency: Duration::from_micros(100), ok: true, matched: ids.len(), ids: Some(ids), error: None }
             }
         }
         let gt = Some(HashSet::from(["a".to_string(), "b".to_string()]));
@@ -510,11 +513,32 @@ mod tests {
         // duration long enough to cycle through all 3 at concurrency=1 several times
         let profile = LoadProfile { concurrency: 1, duration_s: 0.1, target_qps: 0.0 };
         let results = run_storm(Arc::new(PerQueryTarget), vectors, &profile, 2).await;
-        let summary = results.summary();
 
+        // Only asserts the pipeline actually produced all 3 distinct values --
+        // NOT their exact proportions, which depend on how many times each of
+        // the 3 round-robin slots happened to be hit inside a fixed wall-clock
+        // window (not guaranteed 1:1:1). The exact mean/median/min math itself
+        // is covered deterministically, with no timing dependency, by
+        // `summary_aggregates_recall_distribution_correctly` below.
         assert!(results.recalls.iter().any(|&r| (r - 0.0).abs() < 1e-9));
         assert!(results.recalls.iter().any(|&r| (r - 0.5).abs() < 1e-9));
         assert!(results.recalls.iter().any(|&r| (r - 1.0).abs() < 1e-9));
+    }
+
+    #[test]
+    fn summary_aggregates_recall_distribution_correctly() {
+        // Deterministic, no async/timing involved -- exercises StormResults::summary()
+        // directly, so it can assert exact mean/median/min without depending on
+        // how many times a round-robin cycle happened to repeat within a window.
+        let results = StormResults {
+            latencies_ms: vec![1.0, 2.0, 3.0],
+            recalls: vec![0.0, 0.5, 1.0],
+            n_ok: 3,
+            n_err: 0,
+            wall_s: 1.0,
+        };
+        let summary = results.summary();
+
         assert_eq!(summary.min_recall, Some(0.0)); // the worst query, not hidden by the mean
         assert!((summary.mean_recall.unwrap() - 0.5).abs() < 1e-9); // (0+0.5+1)/3 = 0.5
         assert!((summary.median_recall.unwrap() - 0.5).abs() < 1e-9);

--- a/crates/nova-storm/src/runner.rs
+++ b/crates/nova-storm/src/runner.rs
@@ -14,6 +14,7 @@
 //! Aggregating ACROSS workers is a separate step and must merge latency
 //! *distributions*, never average per-worker percentiles.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -22,13 +23,19 @@ use tokio::task::JoinSet;
 use tokio::time::{Duration, Instant, sleep_until};
 
 use crate::config::LoadProfile;
+use crate::queries::QueryVector;
 use crate::targets::QueryTarget;
 
-/// One worker's raw measurements. Latencies are kept as a full sample (not
-/// pre-aggregated) so a fleet merge can recompute true percentiles.
+/// One worker's raw measurements. Latencies (and recalls, if ground truth is
+/// configured) are kept as full samples — not pre-aggregated — so a fleet merge
+/// can recompute true percentiles/means instead of averaging per-worker stats.
 #[derive(Debug, Clone)]
 pub struct StormResults {
     pub latencies_ms: Vec<f64>,
+    /// One entry per query that had ground truth (see [`QueryVector::ground_truth`]).
+    /// Shorter than `latencies_ms` whenever some/all queries have none — that's
+    /// expected, not an error.
+    pub recalls: Vec<f64>,
     pub n_ok: u64,
     pub n_err: u64,
     pub wall_s: f64,
@@ -45,12 +52,25 @@ pub struct Summary {
     pub p95_ms: f64,
     pub p99_ms: f64,
     pub max_ms: f64,
+    /// `None` when no query in this run had ground truth (feature unused, or
+    /// misconfigured — e.g. wrong column name — which looks the same from here).
+    /// `mean_recall` alone can hide a bimodal distribution (some queries near-
+    /// perfect, some near-zero) the same way it would for latency — hence
+    /// `median_recall`/`min_recall` alongside it, from the same raw samples.
+    pub mean_recall: Option<f64>,
+    pub median_recall: Option<f64>,
+    /// The single worst query's recall — the "tail" that matters for recall,
+    /// which is the LOW end (unlike latency's p95/p99, which watch the high
+    /// end) — so this is a min, not a high percentile.
+    pub min_recall: Option<f64>,
 }
 
 impl StormResults {
     pub fn summary(&self) -> Summary {
         let mut ms = self.latencies_ms.clone();
         ms.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let mut rc = self.recalls.clone();
+        rc.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         let total = self.n_ok + self.n_err;
         Summary {
             requests: total,
@@ -60,19 +80,34 @@ impl StormResults {
             p95_ms: percentile(&ms, 95.0),
             p99_ms: percentile(&ms, 99.0),
             max_ms: ms.last().copied().unwrap_or(0.0),
+            mean_recall: (!rc.is_empty()).then(|| rc.iter().sum::<f64>() / rc.len() as f64),
+            median_recall: (!rc.is_empty()).then(|| percentile(&rc, 50.0)),
+            min_recall: rc.first().copied(),
         }
     }
 }
 
 impl std::fmt::Display for Summary {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{:>16}: {}", "requests", self.requests)?;
-        writeln!(f, "{:>16}: {}", "errors", self.errors)?;
-        writeln!(f, "{:>16}: {:.1}", "throughput_qps", self.throughput_qps)?;
-        writeln!(f, "{:>16}: {:.2}", "p50_ms", self.p50_ms)?;
-        writeln!(f, "{:>16}: {:.2}", "p95_ms", self.p95_ms)?;
-        writeln!(f, "{:>16}: {:.2}", "p99_ms", self.p99_ms)?;
-        write!(f, "{:>16}: {:.2}", "max_ms", self.max_ms)
+        let mut lines = vec![
+            format!("{:>16}: {}", "requests", self.requests),
+            format!("{:>16}: {}", "errors", self.errors),
+            format!("{:>16}: {:.1}", "throughput_qps", self.throughput_qps),
+            format!("{:>16}: {:.2}", "p50_ms", self.p50_ms),
+            format!("{:>16}: {:.2}", "p95_ms", self.p95_ms),
+            format!("{:>16}: {:.2}", "p99_ms", self.p99_ms),
+            format!("{:>16}: {:.2}", "max_ms", self.max_ms),
+        ];
+        if let Some(r) = self.mean_recall {
+            lines.push(format!("{:>16}: {:.4}", "mean_recall", r));
+        }
+        if let Some(r) = self.median_recall {
+            lines.push(format!("{:>16}: {:.4}", "median_recall", r));
+        }
+        if let Some(r) = self.min_recall {
+            lines.push(format!("{:>16}: {:.4}", "min_recall", r));
+        }
+        write!(f, "{}", lines.join("\n"))
     }
 }
 
@@ -87,67 +122,102 @@ fn percentile(sorted_ms: &[f64], p: f64) -> f64 {
     sorted_ms[rank.min(n) - 1]
 }
 
-/// One latency observation forwarded from a worker to the collector.
+/// Recall@k for one query: the fraction of the known-correct top-k ids
+/// (`ground_truth`) that appear among the ids the target actually `returned`.
+/// Divides by `k` (not `ground_truth.len()` or `returned.len()`) — the
+/// conventional recall@k definition — so `ground_truth` should hold at least
+/// `k` ids (nova-bf's own `k` at or above storm's `top_k`) or recall reads
+/// artificially low; `lib.rs` warns at startup if any loaded row is short.
+/// `ground_truth` is already a `HashSet` (built once at load time in
+/// `queries.rs`, not per call) since this runs on every query firing.
+fn recall_at_k(returned: &[String], ground_truth: &HashSet<String>, k: u64) -> f64 {
+    let hits = returned.iter().filter(|id| ground_truth.contains(id.as_str())).count();
+    hits as f64 / k as f64
+}
+
+/// One query observation forwarded from a worker to the collector.
 struct Sample {
     latency_ms: f64,
     ok: bool,
+    /// `None` when this query had no ground truth to compare against, OR the
+    /// query itself failed (`!ok`) — a failed request has no "returned ids" to
+    /// score, so it must not count as recall=0. Conflating the two would make
+    /// `mean_recall` crash under load-induced errors even when every
+    /// *successful* query has perfect recall — a different, already-visible
+    /// finding via `errors`/`throughput_qps`, not one recall should also report.
+    recall: Option<f64>,
 }
 
-/// Drive one worker's load profile against `target` and collect latencies.
+/// Build a [`Sample`] from a completed query, applying the "only score recall
+/// on success" rule above in one place (both load-shape functions call this).
+fn sample_from(out: &crate::targets::QueryOutcome, ground_truth: Option<&HashSet<String>>, top_k: u64) -> Sample {
+    let recall = out.ok.then(|| ground_truth.map(|gt| recall_at_k(&out.ids, gt, top_k))).flatten();
+    Sample { latency_ms: out.latency.as_secs_f64() * 1000.0, ok: out.ok, recall }
+}
+
+/// Drive one worker's load profile against `target` and collect latencies
+/// (and recall, for queries carrying ground truth).
 ///
 /// `vectors` is the query set to cycle through (round-robin). A query failure is
-/// recorded as an error sample, not a hard error — see [`QueryOutcome`].
+/// recorded as an error sample, not a hard error — see [`QueryOutcome`]. `top_k`
+/// is the denominator for recall — see [`recall_at_k`].
 pub async fn run_storm(
     target: Arc<dyn QueryTarget>,
-    vectors: Vec<Vec<f32>>,
+    vectors: Vec<QueryVector>,
     profile: &LoadProfile,
+    top_k: u64,
 ) -> StormResults {
     let vectors = Arc::new(vectors);
     let (tx, mut rx) = mpsc::unbounded_channel::<Sample>();
 
-    // Collector: drain samples into the raw distribution + counts. Owning the
+    // Collector: drain samples into the raw distributions + counts. Owning the
     // accumulation in one task keeps the workers lock-free on the hot path.
     let collector = tokio::spawn(async move {
         let mut latencies = Vec::new();
+        let mut recalls = Vec::new();
         let mut n_ok = 0u64;
         let mut n_err = 0u64;
         while let Some(s) = rx.recv().await {
             latencies.push(s.latency_ms);
+            if let Some(r) = s.recall {
+                recalls.push(r);
+            }
             if s.ok {
                 n_ok += 1;
             } else {
                 n_err += 1;
             }
         }
-        (latencies, n_ok, n_err)
+        (latencies, recalls, n_ok, n_err)
     });
 
     let started = Instant::now();
     let stop_at = started + Duration::from_secs_f64(profile.duration_s);
 
     if profile.target_qps > 0.0 {
-        run_paced(&target, &vectors, profile, stop_at, &tx).await;
+        run_paced(&target, &vectors, profile, stop_at, top_k, &tx).await;
     } else {
-        run_closed_loop(&target, &vectors, profile, stop_at, &tx).await;
+        run_closed_loop(&target, &vectors, profile, stop_at, top_k, &tx).await;
     }
 
     // Drop the last sender so the collector's `recv` loop ends.
     drop(tx);
     let wall_s = started.elapsed().as_secs_f64();
 
-    let (latencies_ms, n_ok, n_err) = collector.await.unwrap_or_default();
+    let (latencies_ms, recalls, n_ok, n_err) = collector.await.unwrap_or_default();
     let _ = target.close().await;
 
-    StormResults { latencies_ms, n_ok, n_err, wall_s }
+    StormResults { latencies_ms, recalls, n_ok, n_err, wall_s }
 }
 
 /// Hold `concurrency` requests in flight until the window closes; each task
 /// fires the next query the instant its previous one returns.
 async fn run_closed_loop(
     target: &Arc<dyn QueryTarget>,
-    vectors: &Arc<Vec<Vec<f32>>>,
+    vectors: &Arc<Vec<QueryVector>>,
     profile: &LoadProfile,
     stop_at: Instant,
+    top_k: u64,
     tx: &mpsc::UnboundedSender<Sample>,
 ) {
     let n = vectors.len();
@@ -163,11 +233,9 @@ async fn run_closed_loop(
             while Instant::now() < stop_at {
                 // fetch_add wraps far below usize::MAX over any real run.
                 let i = cursor.fetch_add(1, Ordering::Relaxed) % n;
-                let out = target.query(&vectors[i]).await;
-                let _ = tx.send(Sample {
-                    latency_ms: out.latency.as_secs_f64() * 1000.0,
-                    ok: out.ok,
-                });
+                let qv = &vectors[i];
+                let out = target.query(&qv.vector).await;
+                let _ = tx.send(sample_from(&out, qv.ground_truth.as_ref(), top_k));
             }
         });
     }
@@ -182,9 +250,10 @@ async fn run_closed_loop(
 /// not an error).
 async fn run_paced(
     target: &Arc<dyn QueryTarget>,
-    vectors: &Arc<Vec<Vec<f32>>>,
+    vectors: &Arc<Vec<QueryVector>>,
     profile: &LoadProfile,
     stop_at: Instant,
+    top_k: u64,
     tx: &mpsc::UnboundedSender<Sample>,
 ) {
     let n = vectors.len();
@@ -209,11 +278,9 @@ async fn run_paced(
         let vectors = vectors.clone();
         let tx = tx.clone();
         inflight.spawn(async move {
-            let out = target.query(&vectors[i]).await;
-            let _ = tx.send(Sample {
-                latency_ms: out.latency.as_secs_f64() * 1000.0,
-                ok: out.ok,
-            });
+            let qv = &vectors[i];
+            let out = target.query(&qv.vector).await;
+            let _ = tx.send(sample_from(&out, qv.ground_truth.as_ref(), top_k));
             drop(permit); // release the in-flight slot
         });
 
@@ -230,9 +297,19 @@ mod tests {
     use crate::targets::QueryOutcome;
     use async_trait::async_trait;
 
-    /// A target that "answers" instantly, for exercising the generator without a
-    /// real cluster.
-    struct MockTarget;
+    /// A target that "answers" instantly with a fixed set of ids (or a hard
+    /// error, if `fail` is set), for exercising the generator (and recall)
+    /// without a real cluster.
+    struct MockTarget {
+        ids: Vec<String>,
+        fail: bool,
+    }
+
+    impl MockTarget {
+        fn ok(ids: Vec<String>) -> Self {
+            Self { ids, fail: false }
+        }
+    }
 
     impl std::fmt::Display for MockTarget {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -243,18 +320,34 @@ mod tests {
     #[async_trait]
     impl QueryTarget for MockTarget {
         async fn query(&self, _vector: &[f32]) -> QueryOutcome {
-            QueryOutcome { latency: Duration::from_micros(100), ok: true, matched: 1, error: None }
+            if self.fail {
+                return QueryOutcome {
+                    latency: Duration::from_micros(100),
+                    ok: false,
+                    matched: 0,
+                    ids: vec![],
+                    error: Some("mock failure".into()),
+                };
+            }
+            QueryOutcome {
+                latency: Duration::from_micros(100),
+                ok: true,
+                matched: self.ids.len(),
+                ids: self.ids.clone(),
+                error: None,
+            }
         }
     }
 
-    fn vectors() -> Vec<Vec<f32>> {
-        (0..16).map(|i| vec![i as f32; 4]).collect()
+    fn vectors() -> Vec<QueryVector> {
+        (0..16).map(|i| QueryVector { vector: vec![i as f32; 4], ground_truth: None }).collect()
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn closed_loop_fires_many_and_records_each() {
         let profile = LoadProfile { concurrency: 4, duration_s: 0.2, target_qps: 0.0 };
-        let results = run_storm(Arc::new(MockTarget), vectors(), &profile).await;
+        let target = Arc::new(MockTarget::ok(vec![]));
+        let results = run_storm(target, vectors(), &profile, 10).await;
         let summary = results.summary();
 
         assert!(summary.requests > 0);
@@ -262,6 +355,9 @@ mod tests {
         // every request contributes exactly one latency sample
         assert_eq!(results.latencies_ms.len() as u64, summary.requests);
         assert!(summary.throughput_qps > 0.0);
+        // no query in `vectors()` carries ground truth -> recall untouched, not zero
+        assert!(results.recalls.is_empty());
+        assert_eq!(summary.mean_recall, None);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -269,7 +365,8 @@ mod tests {
         let target_qps = 200.0;
         let duration_s = 0.5;
         let profile = LoadProfile { concurrency: 16, duration_s, target_qps };
-        let results = run_storm(Arc::new(MockTarget), vectors(), &profile).await;
+        let target = Arc::new(MockTarget::ok(vec![]));
+        let results = run_storm(target, vectors(), &profile, 10).await;
         let summary = results.summary();
 
         // The whole point: pacing holds the offered rate at/under target. Allow a
@@ -284,11 +381,145 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn recall_is_computed_only_for_queries_with_ground_truth() {
+        // MockTarget always "returns" exactly these 2 ids, regardless of query.
+        let target = Arc::new(MockTarget::ok(vec!["a".into(), "b".into()]));
+        // Half the queries have ground truth overlapping 1-of-2 returned ids
+        // (recall@4 = 1/4 = 0.25 each); the other half have none.
+        let vectors: Vec<QueryVector> = (0..10)
+            .map(|i| QueryVector {
+                vector: vec![i as f32; 4],
+                ground_truth: if i % 2 == 0 {
+                    Some(HashSet::from(["a".to_string(), "z".into(), "y".into(), "x".into()]))
+                } else {
+                    None
+                },
+            })
+            .collect();
+
+        let profile = LoadProfile { concurrency: 2, duration_s: 0.15, target_qps: 0.0 };
+        let results = run_storm(target, vectors, &profile, 4).await;
+        let summary = results.summary();
+
+        // every recorded recall sample must be exactly 0.25 -- never 0, never
+        // computed against a query that had no ground truth.
+        assert!(!results.recalls.is_empty());
+        assert!(results.recalls.iter().all(|&r| (r - 0.25).abs() < 1e-9));
+        assert_eq!(summary.mean_recall, Some(0.25));
+        // fewer recall samples than total requests -- only the ground-truthed half
+        assert!((results.recalls.len() as u64) < summary.requests);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn failed_queries_never_contribute_a_recall_sample() {
+        // A live-Qdrant smoke test caught this: a target that fails every query
+        // (e.g. wrong vector_name, transient overload) must not report
+        // mean_recall=0.0 -- that would read as "search is bad" when the real
+        // finding is "every request errored," which `errors`/`throughput_qps`
+        // already surface distinctly.
+        let target = Arc::new(MockTarget { ids: vec![], fail: true });
+        let vectors: Vec<QueryVector> = (0..8)
+            .map(|i| QueryVector {
+                vector: vec![i as f32; 4],
+                ground_truth: Some(HashSet::from(["a".to_string()])),
+            })
+            .collect();
+
+        let profile = LoadProfile { concurrency: 2, duration_s: 0.15, target_qps: 0.0 };
+        let results = run_storm(target, vectors, &profile, 1).await;
+        let summary = results.summary();
+
+        assert_eq!(summary.errors, summary.requests); // every query failed
+        assert!(results.recalls.is_empty()); // -> zero recall SAMPLES, not samples of 0.0
+        assert_eq!(summary.mean_recall, None); // -> "unknown", not "search returned nothing"
+    }
+
+    #[test]
+    fn recall_at_k_divides_by_k_not_returned_or_ground_truth_len() {
+        let returned = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let ground_truth =
+            HashSet::from(["a".to_string(), "b".to_string(), "z".to_string(), "y".to_string()]);
+        // 2 of the 3 returned ids are in ground_truth, k=4 -> 2/4, not 2/3 or 2/4-of-gt-len coincidence
+        assert_eq!(recall_at_k(&returned, &ground_truth, 4), 0.5);
+        assert_eq!(recall_at_k(&returned, &ground_truth, 2), 1.0); // capped by k, not clamped to <=1 elsewhere
+        assert_eq!(recall_at_k(&[], &ground_truth, 4), 0.0);
+        assert_eq!(recall_at_k(&returned, &HashSet::new(), 4), 0.0);
+    }
+
     #[test]
     fn percentiles_are_nearest_rank() {
         let sorted: Vec<f64> = (1..=100).map(|i| i as f64).collect();
         assert_eq!(percentile(&sorted, 50.0), 50.0);
         assert_eq!(percentile(&sorted, 99.0), 99.0);
         assert_eq!(percentile(&[], 99.0), 0.0);
+    }
+
+    #[test]
+    fn summary_display_appends_recall_lines_only_when_present() {
+        let base = Summary {
+            requests: 10,
+            errors: 0,
+            throughput_qps: 5.0,
+            p50_ms: 1.0,
+            p95_ms: 2.0,
+            p99_ms: 3.0,
+            max_ms: 4.0,
+            mean_recall: None,
+            median_recall: None,
+            min_recall: None,
+        };
+        assert!(!base.to_string().contains("recall"));
+
+        let with_recall = Summary { mean_recall: Some(0.87), ..base };
+        assert!(with_recall.to_string().contains("mean_recall"));
+        assert!(!with_recall.to_string().contains("median_recall")); // still None -> still absent
+        assert!(with_recall.to_string().ends_with("0.8700"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn median_and_min_recall_reflect_the_distribution_not_just_the_mean() {
+        // 3 distinct queries, each with a different, deterministic recall by
+        // construction: 0.0 (no overlap), 0.5 (half), 1.0 (full) -- proves
+        // median_recall/min_recall are computed independently from the raw
+        // `recalls` samples, not just re-derived from mean_recall.
+        struct PerQueryTarget;
+        impl std::fmt::Display for PerQueryTarget {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "per-query-mock")
+            }
+        }
+        #[async_trait]
+        impl QueryTarget for PerQueryTarget {
+            async fn query(&self, vector: &[f32]) -> QueryOutcome {
+                // vector[0] selects which of the 3 fixed ids come back.
+                let ids = match vector[0] as i64 {
+                    0 => vec![], // 0/2 in ground truth -> recall 0.0
+                    1 => vec!["a".to_string()], // 1/2 -> recall 0.5
+                    _ => vec!["a".to_string(), "b".to_string()], // 2/2 -> recall 1.0
+                };
+                QueryOutcome { latency: Duration::from_micros(100), ok: true, matched: ids.len(), ids, error: None }
+            }
+        }
+        let gt = Some(HashSet::from(["a".to_string(), "b".to_string()]));
+        let vectors = vec![
+            QueryVector { vector: vec![0.0], ground_truth: gt.clone() },
+            QueryVector { vector: vec![1.0], ground_truth: gt.clone() },
+            QueryVector { vector: vec![2.0], ground_truth: gt },
+        ];
+        // duration long enough to cycle through all 3 at concurrency=1 several times
+        let profile = LoadProfile { concurrency: 1, duration_s: 0.1, target_qps: 0.0 };
+        let results = run_storm(Arc::new(PerQueryTarget), vectors, &profile, 2).await;
+        let summary = results.summary();
+
+        assert!(results.recalls.iter().any(|&r| (r - 0.0).abs() < 1e-9));
+        assert!(results.recalls.iter().any(|&r| (r - 0.5).abs() < 1e-9));
+        assert!(results.recalls.iter().any(|&r| (r - 1.0).abs() < 1e-9));
+        assert_eq!(summary.min_recall, Some(0.0)); // the worst query, not hidden by the mean
+        assert!((summary.mean_recall.unwrap() - 0.5).abs() < 1e-9); // (0+0.5+1)/3 = 0.5
+        assert!((summary.median_recall.unwrap() - 0.5).abs() < 1e-9);
+        // mean and median coincide here (symmetric distribution) -- min is the
+        // one that actually differs from both, proving it's not just an alias.
+        assert_ne!(summary.min_recall, summary.mean_recall);
     }
 }

--- a/crates/nova-storm/src/targets/mod.rs
+++ b/crates/nova-storm/src/targets/mod.rs
@@ -25,8 +25,18 @@ pub mod qdrant;
 pub struct QueryOutcome {
     pub latency: Duration,
     pub ok: bool,
-    /// Number of points the query returned (sanity / future recall checks).
+    /// Number of points the query returned (sanity check). NOT guaranteed to
+    /// equal `ids.len()`: `ids` is left empty whenever the target has no
+    /// reason to populate it (no query in the run has `ground_truth_column`
+    /// configured — the common case, since recall tracking is opt-in — see
+    /// `QdrantTarget::collect_ids`), and even when populated, a point lacking
+    /// a resolvable id is dropped from `ids` but still counted here. Use
+    /// `matched` for a raw result-count sanity check; use `ids` for recall.
     pub matched: usize,
+    /// The point ids actually returned, best-first. Populated only when this
+    /// run tracks recall — see `matched`'s doc for why it can be empty (or
+    /// shorter than `matched`) even on a successful query. Empty on error.
+    pub ids: Vec<String>,
     pub error: Option<String>,
 }
 

--- a/crates/nova-storm/src/targets/mod.rs
+++ b/crates/nova-storm/src/targets/mod.rs
@@ -25,10 +25,6 @@ pub mod qdrant;
 pub struct QueryOutcome {
     pub latency: Duration,
     pub ok: bool,
-    /// Number of points the query returned (sanity check). Independent of
-    /// `ids` — a point lacking a resolvable id is dropped from `ids` but still
-    /// counted here, so don't assume `matched == ids.len()`.
-    pub matched: usize,
     /// The point ids actually returned, best-first — `None` when there's
     /// nothing meaningful to report: recall tracking wasn't on for this run
     /// (`QdrantTarget::collect_ids` is `false`) or the query failed (`!ok`).

--- a/crates/nova-storm/src/targets/mod.rs
+++ b/crates/nova-storm/src/targets/mod.rs
@@ -25,18 +25,16 @@ pub mod qdrant;
 pub struct QueryOutcome {
     pub latency: Duration,
     pub ok: bool,
-    /// Number of points the query returned (sanity check). NOT guaranteed to
-    /// equal `ids.len()`: `ids` is left empty whenever the target has no
-    /// reason to populate it (no query in the run has `ground_truth_column`
-    /// configured — the common case, since recall tracking is opt-in — see
-    /// `QdrantTarget::collect_ids`), and even when populated, a point lacking
-    /// a resolvable id is dropped from `ids` but still counted here. Use
-    /// `matched` for a raw result-count sanity check; use `ids` for recall.
+    /// Number of points the query returned (sanity check). Independent of
+    /// `ids` — a point lacking a resolvable id is dropped from `ids` but still
+    /// counted here, so don't assume `matched == ids.len()`.
     pub matched: usize,
-    /// The point ids actually returned, best-first. Populated only when this
-    /// run tracks recall — see `matched`'s doc for why it can be empty (or
-    /// shorter than `matched`) even on a successful query. Empty on error.
-    pub ids: Vec<String>,
+    /// The point ids actually returned, best-first — `None` when there's
+    /// nothing meaningful to report: recall tracking wasn't on for this run
+    /// (`QdrantTarget::collect_ids` is `false`) or the query failed (`!ok`).
+    /// `Some(vec![])` is a real, different thing — recall tracking was on,
+    /// the query succeeded, and it just matched nothing.
+    pub ids: Option<Vec<String>>,
     pub error: Option<String>,
 }
 

--- a/crates/nova-storm/src/targets/qdrant.rs
+++ b/crates/nova-storm/src/targets/qdrant.rs
@@ -82,18 +82,14 @@ impl QueryTarget for QdrantTarget {
                 latency: started.elapsed(),
                 ok: true,
                 matched: resp.result.len(),
-                ids: if self.collect_ids {
-                    resp.result.iter().filter_map(point_id_string).collect()
-                } else {
-                    Vec::new()
-                },
+                ids: self.collect_ids.then(|| resp.result.iter().filter_map(point_id_string).collect()),
                 error: None,
             },
             Err(e) => QueryOutcome {
                 latency: started.elapsed(),
                 ok: false,
                 matched: 0,
-                ids: vec![],
+                ids: None,
                 error: Some(e.to_string()),
             },
         }

--- a/crates/nova-storm/src/targets/qdrant.rs
+++ b/crates/nova-storm/src/targets/qdrant.rs
@@ -81,14 +81,12 @@ impl QueryTarget for QdrantTarget {
             Ok(resp) => QueryOutcome {
                 latency: started.elapsed(),
                 ok: true,
-                matched: resp.result.len(),
                 ids: self.collect_ids.then(|| resp.result.iter().filter_map(point_id_string).collect()),
                 error: None,
             },
             Err(e) => QueryOutcome {
                 latency: started.elapsed(),
                 ok: false,
-                matched: 0,
                 ids: None,
                 error: Some(e.to_string()),
             },

--- a/crates/nova-storm/src/targets/qdrant.rs
+++ b/crates/nova-storm/src/targets/qdrant.rs
@@ -5,7 +5,8 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use qdrant_client::Qdrant;
-use qdrant_client::qdrant::QueryPointsBuilder;
+use qdrant_client::qdrant::point_id::PointIdOptions;
+use qdrant_client::qdrant::{QueryPointsBuilder, ScoredPoint};
 use serde::Deserialize;
 
 use super::{QueryOutcome, QueryTarget};
@@ -18,6 +19,11 @@ pub struct QdrantTarget {
     collection_name: String,
     vector_name: Option<String>,
     top_k: u64,
+    /// Whether to materialize `QueryOutcome.ids`. Skipped (leaving `ids` empty)
+    /// when the run has no `ground_truth_column` configured — recall is the
+    /// only consumer of `ids`, so collecting it otherwise is a wasted
+    /// allocation (a `String` clone per returned point) on every query.
+    collect_ids: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -48,6 +54,7 @@ impl QdrantConfig {
             collection_name: self.collection_name,
             vector_name: query.vector_name.clone(),
             top_k: query.top_k,
+            collect_ids: query.source.ground_truth_column.is_some(),
         })
     }
 }
@@ -75,26 +82,71 @@ impl QueryTarget for QdrantTarget {
                 latency: started.elapsed(),
                 ok: true,
                 matched: resp.result.len(),
+                ids: if self.collect_ids {
+                    resp.result.iter().filter_map(point_id_string).collect()
+                } else {
+                    Vec::new()
+                },
                 error: None,
             },
             Err(e) => QueryOutcome {
                 latency: started.elapsed(),
                 ok: false,
                 matched: 0,
+                ids: vec![],
                 error: Some(e.to_string()),
             },
         }
     }
 }
 
+/// A scored point's id as a plain string — `Uuid` verbatim (what a
+/// `nova-load`-populated collection always uses), `Num` decimal-formatted.
+/// Canonicalizing both to strings here is what lets recall be computed as a
+/// plain string-set intersection against `hit_ids`, which `nova bf` also
+/// always stores as strings (see its own `str(...)` coercion) regardless of
+/// whether the underlying collection uses UUID or integer ids.
+fn point_id_string(point: &ScoredPoint) -> Option<String> {
+    match point.id.as_ref()?.point_id_options.as_ref()? {
+        PointIdOptions::Uuid(s) => Some(s.clone()),
+        PointIdOptions::Num(n) => Some(n.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use qdrant_client::qdrant::PointId;
+
+    use super::*;
     use crate::config::StormConfig;
 
     fn cfg() -> StormConfig {
         let yaml = "target:\n  type: qdrant\n  url: http://localhost:6334\n  collection_name: c\n\
                     query:\n  vector_name: dense\n  top_k: 5\n  source:\n    uri: /tmp/q.parquet\n    column: e\n";
         StormConfig::from_yaml(yaml).expect("parses")
+    }
+
+    fn scored(id: Option<PointId>) -> ScoredPoint {
+        ScoredPoint {
+            id,
+            payload: Default::default(),
+            score: 0.0,
+            version: 0,
+            vectors: None,
+            shard_key: None,
+            order_value: None,
+        }
+    }
+
+    #[test]
+    fn point_id_string_formats_uuid_and_num() {
+        let uuid = PointId { point_id_options: Some(PointIdOptions::Uuid("abc-123".into())) };
+        assert_eq!(point_id_string(&scored(Some(uuid))), Some("abc-123".to_string()));
+
+        let num = PointId { point_id_options: Some(PointIdOptions::Num(42)) };
+        assert_eq!(point_id_string(&scored(Some(num))), Some("42".to_string()));
+
+        assert_eq!(point_id_string(&scored(None)), None);
     }
 
     #[test]
@@ -104,5 +156,24 @@ mod tests {
         let cfg = cfg();
         let target = cfg.target.into_target(&cfg.query).expect("builds");
         assert_eq!(target.to_string(), "qdrant(c)");
+    }
+
+    fn qdrant_config(target: crate::targets::TargetConfig) -> QdrantConfig {
+        match target {
+            crate::targets::TargetConfig::Qdrant(c) => c,
+        }
+    }
+
+    #[test]
+    fn collect_ids_follows_ground_truth_column_config() {
+        let cfg = cfg(); // no ground_truth_column
+        let target = qdrant_config(cfg.target).into_target(&cfg.query).expect("builds");
+        assert!(!target.collect_ids);
+
+        let yaml = "target:\n  type: qdrant\n  url: http://localhost:6334\n  collection_name: c\n\
+                    query:\n  top_k: 5\n  source:\n    uri: /tmp/q.parquet\n    column: e\n    ground_truth_column: hit_ids\n";
+        let cfg = StormConfig::from_yaml(yaml).expect("parses");
+        let target = qdrant_config(cfg.target).into_target(&cfg.query).expect("builds");
+        assert!(target.collect_ids);
     }
 }

--- a/docs/brute-force/overview.md
+++ b/docs/brute-force/overview.md
@@ -42,6 +42,23 @@ params:
 
 `${VAR}` / `${VAR:-default}` references are expanded from the environment, same as every other tool.
 
+### Filtering the corpus
+
+To evaluate recall for a *filtered* search, restrict which corpus rows are eligible neighbors with a top-level `filter`, shaped like a Qdrant filter:
+
+```yaml
+filter:
+  must:
+    - field: language
+      match: eng          # scalar → equality; a list matches any of them (MatchAny)
+    - field: cost
+      range: {lt: 10}     # gt / gte / lt / lte — combinable in one condition
+  should: []               # OR-at-least-one
+  must_not: []              # AND-NOT
+```
+
+A condition's `field` is the only place you name a corpus column — there's no separate list to keep in sync, so `compute` reads exactly (and only) the columns the filter references. The filter applies uniformly to every query in the run: it restricts which corpus points are searchable, the same way a Qdrant search filter does — it never touches the queries themselves.
+
 ## Running
 
 ```bash
@@ -110,4 +127,4 @@ The work splits into three layers: **reading** corpus parquet from S3, **decodin
 
 A good starting point for a large corpus on AWS: a high-vCPU single-GPU instance, `io_thread_count: 128`, `io_workers: 32–64`. Raising query count shifts the balance toward the GPU — at that point batch the matmul (`corpus_batch_size`) and add GPUs/workers.
 
-> **Reading fewer bytes** helps every layer: `compute` already projects only the dense (and optional id) column, so the heavy work is unavoidable corpus data. Storing the dense column as fp16 (half the bytes to transfer *and* decode) is the next lever if the read path is still the bottleneck.
+> **Reading fewer bytes** helps every layer: `compute` already projects only the dense column (plus `id_column`/`filter` fields when configured), so the heavy work is unavoidable corpus data. Storing the dense column as fp16 (half the bytes to transfer *and* decode) is the next lever if the read path is still the bottleneck.

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -45,7 +45,7 @@ from nova_bf.config import BruteForceConfig
 from nova_bf.filters import evaluate
 from nova_bf.ids import make_point_id
 from nova_bf.io import Store, dense_to_2d
-from nova_bf.results import build_result_table, partial_dir, result_name
+from nova_bf.results import build_result_table, partial_dir, result_name, warn_if_short
 
 logger = logging.getLogger(__name__)
 
@@ -351,8 +351,14 @@ def run_compute(
     if num_jobs is not None:
         width = max(3, len(str(num_jobs - 1)))
         name = f"{partial_dir(cfg)}/rank{job_rank:0{width}d}.parquet"
+        # This worker's slice of the corpus naturally has fewer than k
+        # candidates per query most of the time (stride partitioning spreads
+        # the corpus thin) -- that's expected here, not a signal of anything.
+        # Only `merge` (or this function's own single-node path below) sees
+        # the true final count, so that's the only place worth warning.
     else:
         name = result_name(cfg)
+        warn_if_short(hit_ids, k, logger)
     path = out.write(name, table)
     logger.info("wrote %s (%d queries)", path, n_q)
     return path

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -17,6 +17,15 @@ of `make_point_id`. Such an id isn't recomputable from (file, row), so it's read
 alongside the dense column and kept in RAM per file (the worker's slice) to resolve
 the final top-K. Large files can be scored in row-batches (`params.corpus_batch_size`)
 to bound the per-file score matrix `(n_queries × rows)` on the GPU.
+
+If `filter` is set (see `nova_bf.filters`), each file's payload columns are
+read alongside the dense column and evaluated into a keep-mask *before*
+scoring, so filtered-out rows never reach the GPU. The mask compacts `arr` but
+never renumbers rows — `orig_rows` tracks each surviving row's true file-row
+number, since both `make_point_id` and the `id_column` lookup are keyed on it.
+Mask evaluation is timed separately from the read (`filter_secs`, reported
+alongside `read_secs`/`io_wait`/`gpu_secs`) so a slow filter is distinguishable
+from slow IO in the end-of-run timing log.
 """
 
 from __future__ import annotations
@@ -33,6 +42,7 @@ import numpy as np
 from tqdm import tqdm
 
 from nova_bf.config import BruteForceConfig
+from nova_bf.filters import evaluate
 from nova_bf.ids import make_point_id
 from nova_bf.io import Store, dense_to_2d
 from nova_bf.results import build_result_table, partial_dir, result_name
@@ -126,6 +136,8 @@ def run_compute(
         n_q, dim, metric, k, device,
         f" rank={job_rank}/{num_jobs}" if num_jobs else "",
     )
+    if cfg.filter is not None:
+        logger.info("filter: %s", cfg.filter.model_dump(exclude_defaults=True))
 
     # 2. corpus files (global, deterministic order); this worker takes a stride
     #    slice so its global indices stay stable for id decoding.
@@ -156,7 +168,9 @@ def run_compute(
     # commutative). pyarrow releases the GIL during IO, so threads parallelize.
     dense_col = cfg.corpus.dense_column
     id_col = cfg.corpus.id_column  # None → derive make_point_id(file_key, row) at decode
-    read_cols = [dense_col] + ([id_col] if id_col else [])
+    filt = cfg.filter  # None → no filtering; else a corpus-side payload predicate
+    filter_cols = sorted(filt.fields()) if filt else []
+    read_cols = list(dict.fromkeys([dense_col] + ([id_col] if id_col else []) + filter_cols))
     # Corpus id strings carried through to decode, kept in RAM per file (only when
     # id_column is set). gidx → pyarrow string array aligned with that file's rows.
     corpus_ids: dict[int, object] = {}
@@ -193,7 +207,15 @@ def run_compute(
             # carry the id column (combined to one contiguous array) to decode;
             # None when id_column isn't configured. Same row order as `arr`.
             ids = table[id_col].combine_chunks() if id_col else None
-            fq.put((gidx, arr, ids, time.perf_counter() - t0))
+            t1 = time.perf_counter()
+            # None when unfiltered; else a boolean mask over this file's rows,
+            # ORIGINAL row order preserved (no compaction here — see consumer).
+            # Timed separately from the read above: it's CPU-vectorized work over
+            # the whole file, not IO wait, and lumping it into `read_secs` would
+            # make an expensive filter look like slow S3, not slow filtering.
+            keep = evaluate(filt, table) if filt else None
+            t2 = time.perf_counter()
+            fq.put((gidx, arr, ids, keep, t1 - t0, t2 - t1))
 
     for _ in range(io_workers):
         Thread(target=reader, daemon=True).start()
@@ -203,7 +225,10 @@ def run_compute(
     # here. `gpu_secs` is just CPU-side enqueue time (CUDA is async and overlaps
     # the next read), so it being tiny is itself evidence we're not compute-bound.
     # `read_secs` is summed per-file read latency across the reader threads.
-    io_wait = gpu_secs = read_secs = 0.0
+    # `filter_secs` is summed per-file mask-evaluation time (0 when unfiltered),
+    # also across the reader threads — kept apart from `read_secs` so a slow
+    # filter doesn't masquerade as slow IO.
+    io_wait = gpu_secs = read_secs = filter_secs = 0.0
     rows_seen = 0
     bytes_seen = 0  # decoded float32 bytes consumed (~= wire bytes for snappy-float32)
     wall0 = time.perf_counter()
@@ -211,16 +236,30 @@ def run_compute(
     with tqdm(total=len(mine), unit="file", dynamic_ncols=True, desc="bf") as bar:
         for _ in range(len(mine)):
             w0 = time.perf_counter()
-            gidx, arr, ids, rsec = fq.get()
+            gidx, arr, ids, keep, rsec, fsec = fq.get()
             io_wait += time.perf_counter() - w0
             read_secs += rsec
+            filter_secs += fsec
             bar.update(1)
+            # `orig_rows[i]` is the TRUE file row that arr[i] came from — identity
+            # when unfiltered, else the surviving indices of `keep`. Filtering
+            # compacts `arr` (fewer/smaller matmuls) but must never renumber rows:
+            # both make_point_id(file, row) and corpus_ids[gidx][row] need the row
+            # the vector actually occupies in the parquet file, not its position
+            # in the filtered-down array.
+            if keep is not None:
+                orig_rows = np.nonzero(keep)[0]
+                arr = arr[orig_rows]
+            else:
+                orig_rows = None
             if len(arr) == 0:
                 continue
             rows_seen += len(arr)
             bytes_seen += int(arr.nbytes)
             if id_col:
                 corpus_ids[gidx] = ids  # kept in RAM; indexed by row at decode
+                # unfiltered — always the full per-file array, so `corpus_ids[gidx][row]`
+                # resolves correctly regardless of `keep`.
 
             g0 = time.perf_counter()
             # zero-copy view of the (contiguous float32) array + one H2D copy;
@@ -233,9 +272,13 @@ def run_compute(
                 scores = _scores(Q, Cb, metric)  # (n_q, ≤step)
                 bk = min(k, Cb.shape[0])
                 f_scores, f_local = torch.topk(scores, k=bk, dim=1)
-                # rows are FILE-LOCAL indices (offset by r0) so the encoding stays
-                # global_file_idx * MAX_ROWS_PER_FILE + row regardless of batching.
-                rows = torch.arange(r0, r0 + Cb.shape[0], dtype=torch.int64, device=device)
+                # rows are the TRUE file row for each entry of Cb (see orig_rows
+                # above), so the encoding stays global_file_idx * MAX_ROWS_PER_FILE
+                # + row regardless of batching or filtering.
+                if orig_rows is not None:
+                    rows = torch.from_numpy(orig_rows[r0 : r0 + Cb.shape[0]]).to(device)
+                else:
+                    rows = torch.arange(r0, r0 + Cb.shape[0], dtype=torch.int64, device=device)
                 f_enc = (gidx * MAX_ROWS_PER_FILE + rows)[f_local]
                 merged_s = torch.cat([top_scores, f_scores], dim=1)
                 merged_e = torch.cat([top_enc, f_enc], dim=1)
@@ -244,7 +287,10 @@ def run_compute(
             gpu_secs += time.perf_counter() - g0
 
             if bar.n % 200 == 0:
-                bar.set_postfix_str(f"io_wait={io_wait:.0f}s gpu={gpu_secs:.0f}s", refresh=False)
+                postfix = f"io_wait={io_wait:.0f}s gpu={gpu_secs:.0f}s"
+                if filt:
+                    postfix += f" filter={filter_secs:.0f}s"
+                bar.set_postfix_str(postfix, refresh=False)
 
     wall = time.perf_counter() - wall0
     gb = bytes_seen / 1e9
@@ -252,19 +298,23 @@ def run_compute(
     stream_mbps = bytes_seen / 1e6 / max(read_secs, 1e-9)  # avg single-connection throughput
     logger.info(
         "timing: %d files / %d rows / %.2f GB in %.1fs | consumer io_wait=%.1fs gpu=%.1fs | "
-        "read latency avg=%.3fs/file (summed %.0fs over %d threads)",
+        "read latency avg=%.3fs/file (summed %.0fs over %d threads)%s",
         len(mine), rows_seen, gb, wall, io_wait, gpu_secs,
         read_secs / max(1, len(mine)), read_secs, io_workers,
+        f" | filter eval avg={filter_secs / max(1, len(mine)):.3f}s/file "
+        f"(summed {filter_secs:.0f}s over {io_workers} threads)" if filt else "",
     )
     # One machine-parseable line per run — for sweeping io_workers and plotting.
     # `wall_mbps` is the effective aggregate download rate; compare it to the
     # instance's *sustained* NIC baseline (g5.xlarge ≈ 310 MB/s) to tell whether
     # you're NIC-bound (plateaus there) or still latency-bound (keeps rising).
+    # `filter_s` is 0.0 when unfiltered — always present so the line's schema
+    # stays stable for scripts parsing it across both filtered and plain runs.
     logger.info(
         "bf-bench io_workers=%d files=%d rows=%d gb=%.3f wall_s=%.1f "
-        "wall_mbps=%.1f stream_mbps=%.1f io_wait_s=%.1f gpu_s=%.1f",
+        "wall_mbps=%.1f stream_mbps=%.1f io_wait_s=%.1f gpu_s=%.1f filter_s=%.1f",
         io_workers, len(mine), rows_seen, gb, wall,
-        wall_mbps, stream_mbps, io_wait, gpu_secs,
+        wall_mbps, stream_mbps, io_wait, gpu_secs, filter_secs,
     )
     if io_wait > 3 * max(gpu_secs, 1e-6):
         logger.info(

--- a/python/nova-bf/src/nova_bf/config.py
+++ b/python/nova-bf/src/nova_bf/config.py
@@ -4,6 +4,9 @@
     queries:  the query embeddings (a parquet file or dir)
     output:   where results land (local dir / s3:// prefix)
     params:   k, distance metric
+    filter:   optional corpus-side payload predicate restricting eligible
+              neighbors (see Filter) — each condition's `field` is itself the
+              declaration of which corpus column to read for it.
 """
 
 from __future__ import annotations
@@ -14,7 +17,7 @@ from typing import Literal
 
 import yaml
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 import os
 
@@ -119,6 +122,70 @@ class ParamsConfig(BaseModel):
     merge_prefetch: bool = False
 
 
+# A single scalar payload value, as it would appear in a corpus column.
+MatchValue = str | int | float | bool
+
+
+class RangeCondition(BaseModel):
+    """Numeric bounds, combinable like Qdrant's Range (e.g. `gte` + `lt` together)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    gt: float | None = None
+    gte: float | None = None
+    lt: float | None = None
+    lte: float | None = None
+
+    @model_validator(mode="after")
+    def _at_least_one_bound(self) -> "RangeCondition":
+        if all(v is None for v in (self.gt, self.gte, self.lt, self.lte)):
+            raise ValueError("range condition needs at least one of gt/gte/lt/lte")
+        return self
+
+
+class FilterCondition(BaseModel):
+    """One field predicate: keyword-style equality (`match`) or numeric bounds (`range`).
+
+    `match` takes a scalar (equality) or a list (matches any of them — Qdrant's
+    MatchAny). Exactly one of `match`/`range` must be set.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # The corpus column this condition reads and matches against — this is the
+    # only place a filtered field is named; nothing else needs to declare it,
+    # so `compute` reads exactly (and only) the columns the filter references.
+    field: str
+    match: MatchValue | list[MatchValue] | None = None
+    range: RangeCondition | None = None
+
+    @model_validator(mode="after")
+    def _exactly_one(self) -> "FilterCondition":
+        if (self.match is None) == (self.range is None):
+            raise ValueError(
+                f"filter condition on `{self.field}` must set exactly one of `match` or `range`"
+            )
+        return self
+
+
+class Filter(BaseModel):
+    """A corpus-side payload filter, shaped like Qdrant's own filter (must/should/must_not).
+
+    Restricts which corpus points are eligible neighbors for every query in the
+    run — it does not touch queries themselves, same as a Qdrant search filter.
+    `must` = AND, `should` = OR-at-least-one, `must_not` = AND-NOT.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    must: list[FilterCondition] = []
+    should: list[FilterCondition] = []
+    must_not: list[FilterCondition] = []
+
+    def fields(self) -> set[str]:
+        return {c.field for group in (self.must, self.should, self.must_not) for c in group}
+
+
 class BruteForceConfig(BaseModel):
     # allow extra top-level keys (e.g. a `resources:` block for `nova dist`).
     model_config = ConfigDict(extra="allow")
@@ -127,6 +194,7 @@ class BruteForceConfig(BaseModel):
     queries: QueriesConfig
     output: OutputConfig
     params: ParamsConfig = ParamsConfig()
+    filter: Filter | None = None
 
 
 def load_config(path: str) -> BruteForceConfig:

--- a/python/nova-bf/src/nova_bf/config.py
+++ b/python/nova-bf/src/nova_bf/config.py
@@ -4,6 +4,9 @@
     queries:  the query embeddings (a parquet file or dir)
     output:   where results land (local dir / s3:// prefix)
     params:   k, distance metric
+    filter:   optional corpus-side payload predicate restricting eligible
+              neighbors (see Filter) — each condition's `field` is itself the
+              declaration of which corpus column to read for it.
 """
 
 from __future__ import annotations
@@ -14,7 +17,7 @@ from typing import Literal
 
 import yaml
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 import os
 
@@ -105,6 +108,70 @@ class ParamsConfig(BaseModel):
     corpus_batch_size: int | None = None
 
 
+# A single scalar payload value, as it would appear in a corpus column.
+MatchValue = str | int | float | bool
+
+
+class RangeCondition(BaseModel):
+    """Numeric bounds, combinable like Qdrant's Range (e.g. `gte` + `lt` together)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    gt: float | None = None
+    gte: float | None = None
+    lt: float | None = None
+    lte: float | None = None
+
+    @model_validator(mode="after")
+    def _at_least_one_bound(self) -> "RangeCondition":
+        if all(v is None for v in (self.gt, self.gte, self.lt, self.lte)):
+            raise ValueError("range condition needs at least one of gt/gte/lt/lte")
+        return self
+
+
+class FilterCondition(BaseModel):
+    """One field predicate: keyword-style equality (`match`) or numeric bounds (`range`).
+
+    `match` takes a scalar (equality) or a list (matches any of them — Qdrant's
+    MatchAny). Exactly one of `match`/`range` must be set.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # The corpus column this condition reads and matches against — this is the
+    # only place a filtered field is named; nothing else needs to declare it,
+    # so `compute` reads exactly (and only) the columns the filter references.
+    field: str
+    match: MatchValue | list[MatchValue] | None = None
+    range: RangeCondition | None = None
+
+    @model_validator(mode="after")
+    def _exactly_one(self) -> "FilterCondition":
+        if (self.match is None) == (self.range is None):
+            raise ValueError(
+                f"filter condition on `{self.field}` must set exactly one of `match` or `range`"
+            )
+        return self
+
+
+class Filter(BaseModel):
+    """A corpus-side payload filter, shaped like Qdrant's own filter (must/should/must_not).
+
+    Restricts which corpus points are eligible neighbors for every query in the
+    run — it does not touch queries themselves, same as a Qdrant search filter.
+    `must` = AND, `should` = OR-at-least-one, `must_not` = AND-NOT.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    must: list[FilterCondition] = []
+    should: list[FilterCondition] = []
+    must_not: list[FilterCondition] = []
+
+    def fields(self) -> set[str]:
+        return {c.field for group in (self.must, self.should, self.must_not) for c in group}
+
+
 class BruteForceConfig(BaseModel):
     # allow extra top-level keys (e.g. a `resources:` block for `nova dist`).
     model_config = ConfigDict(extra="allow")
@@ -113,6 +180,7 @@ class BruteForceConfig(BaseModel):
     queries: QueriesConfig
     output: OutputConfig
     params: ParamsConfig = ParamsConfig()
+    filter: Filter | None = None
 
 
 def load_config(path: str) -> BruteForceConfig:

--- a/python/nova-bf/src/nova_bf/filters.py
+++ b/python/nova-bf/src/nova_bf/filters.py
@@ -1,0 +1,59 @@
+"""Evaluating a corpus-side `Filter` (see config.py) against one corpus file.
+
+Runs once per file, over the whole file at once, via `pyarrow.compute` — O(rows),
+independent of query count. The filter restricts which corpus points are
+eligible neighbors for every query in the run; it is evaluated before scoring,
+not per (query, row), same as a Qdrant search filter only ever touches the
+points being searched.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.compute as pc
+
+from nova_bf.config import Filter, FilterCondition
+
+
+def _condition_mask(cond: FilterCondition, table: pa.Table) -> np.ndarray:
+    col = table[cond.field]
+    if cond.match is not None:
+        values = cond.match if isinstance(cond.match, list) else [cond.match]
+        mask = pc.is_in(col, value_set=pa.array(values))
+    else:
+        r = cond.range
+        mask = None
+        for op, bound in (
+            (pc.greater, r.gt),
+            (pc.greater_equal, r.gte),
+            (pc.less, r.lt),
+            (pc.less_equal, r.lte),
+        ):
+            if bound is None:
+                continue
+            part = op(col, bound)
+            mask = part if mask is None else pc.and_(mask, part)
+    # A null payload value (field absent/None on that row) never matches —
+    # same as Qdrant treating a missing field as non-matching.
+    return pc.fill_null(mask, False).to_numpy(zero_copy_only=False)
+
+
+def evaluate(filt: Filter, table: pa.Table) -> np.ndarray:
+    """A `(len(table),)` boolean mask: which rows satisfy `filt`."""
+    n = len(table)
+    keep = np.ones(n, dtype=bool)
+
+    for cond in filt.must:
+        keep &= _condition_mask(cond, table)
+
+    if filt.should:
+        any_match = np.zeros(n, dtype=bool)
+        for cond in filt.should:
+            any_match |= _condition_mask(cond, table)
+        keep &= any_match
+
+    for cond in filt.must_not:
+        keep &= ~_condition_mask(cond, table)
+
+    return keep

--- a/python/nova-bf/src/nova_bf/merge.py
+++ b/python/nova-bf/src/nova_bf/merge.py
@@ -16,7 +16,7 @@ from tqdm import tqdm
 
 from nova_bf.config import BruteForceConfig
 from nova_bf.io import Store
-from nova_bf.results import RESERVED, build_result_table, partial_dir, result_name
+from nova_bf.results import RESERVED, build_result_table, partial_dir, result_name, warn_if_short
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +56,7 @@ def run_merge(cfg: BruteForceConfig) -> str:
         for c in payload_cols:
             payload[c].append(payloads[qid][c])
 
+    warn_if_short(hit_ids, k, logger)
     table = build_result_table(query_ids, payload, hit_ids, hit_scores)
     path = out.write(result_name(cfg), table)
     logger.info("wrote %s (%d queries)", path, len(query_ids))

--- a/python/nova-bf/src/nova_bf/results.py
+++ b/python/nova-bf/src/nova_bf/results.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 
+import logging
+
 import pyarrow as pa
 
 from nova_bf.config import BruteForceConfig
@@ -39,33 +41,17 @@ def build_result_table(
     return pa.table(data)
 
 
-<<<<<<< HEAD
 def warn_if_short(hit_ids: list[list[str]], k: int, logger: logging.Logger) -> None:
-=======
-def warn_if_short(short: int, total: int, k: int, logger: logging.Logger) -> None:
->>>>>>> refs/remotes/origin/recall_calc
     """Log if any query's FINAL top-K came out shorter than k. Not an error —
     hit_ids/hit_scores are already correctly truncated (see the `-inf` sentinel
     handling in compute.py) — just a signal that the corpus, or `filter` if one
     is configured, didn't have k matches for some queries, so this ground truth
     is smaller than requested rather than wrong.
-<<<<<<< HEAD
     """
     short = sum(1 for h in hit_ids if len(h) < k)
-=======
-
-    Takes pre-computed counts, not the hit_ids themselves, so a caller that
-    never materializes a full Python list of hits — like merge's streaming,
-    batched reduce — doesn't have to build one just to log this.
-    """
->>>>>>> refs/remotes/origin/recall_calc
     if short:
         logger.warning(
             "%d/%d quer%s returned fewer than k=%d hits — the corpus (after "
             "any `filter`) didn't have enough matches for them",
-<<<<<<< HEAD
             short, len(hit_ids), "y" if short == 1 else "ies", k,
-=======
-            short, total, "y" if short == 1 else "ies", k,
->>>>>>> refs/remotes/origin/recall_calc
         )

--- a/python/nova-bf/src/nova_bf/results.py
+++ b/python/nova-bf/src/nova_bf/results.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import pyarrow as pa
 
 from nova_bf.config import BruteForceConfig
@@ -35,3 +37,19 @@ def build_result_table(
     data["hit_ids"] = pa.array(hit_ids, pa.list_(pa.string()))
     data["hit_scores"] = pa.array(hit_scores, pa.list_(pa.float32()))
     return pa.table(data)
+
+
+def warn_if_short(hit_ids: list[list[str]], k: int, logger: logging.Logger) -> None:
+    """Log if any query's FINAL top-K came out shorter than k. Not an error —
+    hit_ids/hit_scores are already correctly truncated (see the `-inf` sentinel
+    handling in compute.py) — just a signal that the corpus, or `filter` if one
+    is configured, didn't have k matches for some queries, so this ground truth
+    is smaller than requested rather than wrong.
+    """
+    short = sum(1 for h in hit_ids if len(h) < k)
+    if short:
+        logger.warning(
+            "%d/%d quer%s returned fewer than k=%d hits — the corpus (after "
+            "any `filter`) didn't have enough matches for them",
+            short, len(hit_ids), "y" if short == 1 else "ies", k,
+        )

--- a/python/nova-bf/tests/test_compute.py
+++ b/python/nova-bf/tests/test_compute.py
@@ -24,9 +24,12 @@ from nova_bf.compute import run_compute
 from nova_bf.config import (
     BruteForceConfig,
     CorpusConfig,
+    Filter,
+    FilterCondition,
     OutputConfig,
     ParamsConfig,
     QueriesConfig,
+    RangeCondition,
 )
 from nova_bf.ids import make_point_id
 from nova_bf.io import Store
@@ -49,13 +52,21 @@ def ds(tmp_path_factory):
     cdir = tmp / "corpus"
     cdir.mkdir()
 
-    corpus, ids_by_g, loc_by_g, g = [], [], [], 0
+    corpus, ids_by_g, loc_by_g, lang_by_g, cost_by_g, g = [], [], [], [], [], 0
     for fi, n in enumerate(SIZES):
         rows = rng.standard_normal((n, DIM)).astype(np.float32)
-        _write_vectors(cdir / f"f{fi}.parquet", rows, id=[f"c{g + r}" for r in range(n)])
+        # deterministic payload for filter tests: alternating language, cost = global idx
+        lang = [("eng" if (g + r) % 2 == 0 else "fra") for r in range(n)]
+        cost = [float(g + r) for r in range(n)]
+        _write_vectors(
+            cdir / f"f{fi}.parquet", rows,
+            id=[f"c{g + r}" for r in range(n)], language=lang, cost=cost,
+        )
         corpus.append(rows)
         ids_by_g += [f"c{g + r}" for r in range(n)]
         loc_by_g += [(fi, r) for r in range(n)]  # global idx → (file, file-local row)
+        lang_by_g += lang
+        cost_by_g += cost
         g += n
     corpus = np.concatenate(corpus)
 
@@ -78,12 +89,16 @@ def ds(tmp_path_factory):
         "qids": qids,
         "ids_by_g": ids_by_g,
         "loc_by_g": loc_by_g,
+        "lang_by_g": lang_by_g,
+        "cost_by_g": cost_by_g,
         "expected": expected,
+        "corpus": corpus,
+        "queries": queries,
         "files": Store(str(cdir)).list_parquets(),  # same sorted order as run_compute's gidx
     }
 
 
-def _run(ds, *, batch, id_column, out_name):
+def _run(ds, *, batch, id_column, out_name, filt=None):
     out = ds["tmp"] / out_name
     out.mkdir(exist_ok=True)
     cfg = BruteForceConfig(
@@ -91,6 +106,7 @@ def _run(ds, *, batch, id_column, out_name):
         queries=QueriesConfig(path=ds["qpath"], dense_column="dense_embedding", id_column="qid"),
         output=OutputConfig(path=str(out)),
         params=ParamsConfig(k=K, metric="dot", corpus_batch_size=batch, io_workers=2),
+        filter=filt,
     )
     t = pq.read_table(run_compute(cfg)).to_pydict()
     return {q: list(zip(hi, hs)) for q, hi, hs in zip(t["query_id"], t["hit_ids"], t["hit_scores"])}
@@ -147,3 +163,59 @@ def test_corpus_batch_below_k_warns_and_clamps(ds, caplog):
     whole = _run(ds, batch=None, id_column="id", out_name="belowk_ref")
     for q in ds["qids"]:
         assert [i for i, _ in below[q]] == [i for i, _ in whole[q]]
+
+
+def _filtered_ground_truth(ds, qid, allowed_globals):
+    i = ds["qids"].index(qid)
+    s = ds["corpus"][allowed_globals] @ ds["queries"][i]
+    return [allowed_globals[j] for j in np.argsort(-s)[:K]]
+
+
+def test_filter_match_restricts_candidates(ds):
+    filt = Filter(must=[FilterCondition(field="language", match="eng")])
+    res = _run(ds, batch=None, id_column="id", out_name="filter_lang", filt=filt)
+    eng_globals = [g for g, lang in enumerate(ds["lang_by_g"]) if lang == "eng"]
+    for q in ds["qids"]:
+        got = [i for i, _ in res[q]]
+        assert got  # sanity: something survived the filter
+        assert got == [ds["ids_by_g"][g] for g in _filtered_ground_truth(ds, q, eng_globals)]
+
+
+def test_filter_range_condition(ds):
+    filt = Filter(must=[FilterCondition(field="cost", range=RangeCondition(gte=5))])
+    res = _run(ds, batch=None, id_column="id", out_name="filter_cost", filt=filt)
+    allowed = [g for g, c in enumerate(ds["cost_by_g"]) if c >= 5]
+    for q in ds["qids"]:
+        got = [i for i, _ in res[q]]
+        assert got == [ds["ids_by_g"][g] for g in _filtered_ground_truth(ds, q, allowed)]
+
+
+@pytest.mark.parametrize("batch", [None, K])
+def test_filter_preserves_row_numbers_under_batching(ds, batch):
+    """A filter must resolve the same (correct) point ids whether or not
+    corpus_batch_size tiles the file — the bug this guards against is filtering
+    renumbering rows instead of keeping their true file-row number."""
+    filt = Filter(must=[FilterCondition(field="language", match="eng")])
+    res = _run(ds, batch=batch, id_column=None, out_name=f"filter_defid_{batch}", filt=filt)
+    eng_globals = [g for g, lang in enumerate(ds["lang_by_g"]) if lang == "eng"]
+    files = ds["files"]
+    for q in ds["qids"]:
+        want = []
+        for g in _filtered_ground_truth(ds, q, eng_globals):
+            fi, row = ds["loc_by_g"][g]
+            want.append(make_point_id(files[fi].key, row))
+        assert [i for i, _ in res[q]] == want
+
+
+def test_filter_timing_is_reported_only_when_filtering(ds, caplog):
+    with caplog.at_level(logging.INFO, logger="nova_bf.compute"):
+        _run(ds, batch=None, id_column="id", out_name="filter_timing_on",
+             filt=Filter(must=[FilterCondition(field="language", match="eng")]))
+    assert any("filter eval" in r.message for r in caplog.records)
+    assert any("filter_s=" in r.message for r in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="nova_bf.compute"):
+        _run(ds, batch=None, id_column="id", out_name="filter_timing_off")
+    assert not any("filter eval" in r.message for r in caplog.records)
+    assert any("filter_s=0.0" in r.message for r in caplog.records)  # stable bf-bench schema

--- a/python/nova-bf/tests/test_filters.py
+++ b/python/nova-bf/tests/test_filters.py
@@ -1,0 +1,100 @@
+"""Unit tests for `nova_bf.filters.evaluate` — no torch required."""
+
+from __future__ import annotations
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from nova_bf.config import (
+    BruteForceConfig,
+    CorpusConfig,
+    Filter,
+    FilterCondition,
+    OutputConfig,
+    QueriesConfig,
+    RangeCondition,
+)
+from nova_bf.filters import evaluate
+
+
+def _table(**cols):
+    return pa.table(cols)
+
+
+def test_match_scalar_equality():
+    t = _table(language=["eng", "fra", "eng", "deu"])
+    f = Filter(must=[FilterCondition(field="language", match="eng")])
+    assert evaluate(f, t).tolist() == [True, False, True, False]
+
+
+def test_match_any_of_list():
+    t = _table(language=["eng", "fra", "spa", "deu"])
+    f = Filter(must=[FilterCondition(field="language", match=["eng", "spa"])])
+    assert evaluate(f, t).tolist() == [True, False, True, False]
+
+
+def test_range_single_bound():
+    t = _table(cost=[1, 5, 10, 20])
+    f = Filter(must=[FilterCondition(field="cost", range=RangeCondition(lt=10))])
+    assert evaluate(f, t).tolist() == [True, True, False, False]
+
+
+def test_range_combined_bounds_within_one_condition():
+    t = _table(cost=[1, 5, 10, 20])
+    f = Filter(must=[FilterCondition(field="cost", range=RangeCondition(gte=5, lt=20))])
+    assert evaluate(f, t).tolist() == [False, True, True, False]
+
+
+def test_must_is_and():
+    t = _table(language=["eng", "eng", "fra", "fra"], cost=[1, 20, 1, 20])
+    f = Filter(must=[
+        FilterCondition(field="language", match="eng"),
+        FilterCondition(field="cost", range=RangeCondition(lt=10)),
+    ])
+    assert evaluate(f, t).tolist() == [True, False, False, False]
+
+
+def test_should_is_any_of():
+    t = _table(language=["eng", "fra", "deu"])
+    f = Filter(should=[
+        FilterCondition(field="language", match="eng"),
+        FilterCondition(field="language", match="fra"),
+    ])
+    assert evaluate(f, t).tolist() == [True, True, False]
+
+
+def test_must_not_excludes():
+    t = _table(language=["eng", "fra", "deu"])
+    f = Filter(must_not=[FilterCondition(field="language", match="fra")])
+    assert evaluate(f, t).tolist() == [True, False, True]
+
+
+def test_null_payload_value_never_matches():
+    t = _table(cost=[1, None, 10])
+    f = Filter(must=[FilterCondition(field="cost", range=RangeCondition(lt=100))])
+    assert evaluate(f, t).tolist() == [True, False, True]
+
+
+def test_condition_requires_exactly_one_of_match_or_range():
+    with pytest.raises(ValueError):
+        FilterCondition(field="cost")
+    with pytest.raises(ValueError):
+        FilterCondition(field="cost", match=5, range=RangeCondition(lt=10))
+
+
+def test_range_condition_requires_a_bound():
+    with pytest.raises(ValueError):
+        RangeCondition()
+
+
+def test_config_filter_field_is_the_only_declaration_needed():
+    # No separate "which columns to read" list — a condition's `field` is itself
+    # the declaration, and `.fields()` (what compute.py reads) reflects it directly.
+    cfg = BruteForceConfig(
+        corpus=CorpusConfig(path="/tmp/corpus"),
+        queries=QueriesConfig(path="/tmp/q.parquet"),
+        output=OutputConfig(path="/tmp/out"),
+        filter=Filter(must=[FilterCondition(field="language", match="eng")]),
+    )
+    assert cfg.filter.fields() == {"language"}


### PR DESCRIPTION
## Summary

`nova-storm` previously load-tested Qdrant collections for latency/throughput, but did not verify whether returned results were correct. This MR adds opt-in `recall@k` tracking.

A query source can now specify a `list<string>` ground-truth column containing each query’s known-correct top-k ids, typically the existing `nova-bf` `hit_ids` output. No separate ground-truth file or id join is required.

When configured, storm now reports:

* `mean_recall`
* `median_recall`
* `min_recall`

alongside the existing latency percentiles.

This is fully backward compatible: the new config field defaults to `None`, and existing storm configs/outputs are unchanged when it is unset.

## What changed

### `config.rs`

* Added `QuerySource.ground_truth_column: Option<String>`.
* Rejects `top_k: 0` at config-load time to avoid recall division-by-zero / `NaN`.

### `queries.rs`

* Added `QueryVector { vector, ground_truth }`.
* Loads the query vector and ground truth from the same row in one query, so pairing is correct by construction.
* Stores ground truth as a `HashSet<String>` built once at load time for repeated membership checks.

### `targets/mod.rs` / `targets/qdrant.rs`

* Added returned point ids to `QueryOutcome`.
* Qdrant ids are collected only when recall is enabled via `collect_ids`, avoiding hot-path allocation when unused.

### `runner.rs`

* Added `recall_at_k()` using:

  ```text
  |returned ∩ ground_truth| / top_k
  ```

* Scores recall only for successful queries. Failed requests do not count as recall `0.0`, since that would confuse request errors with poor search quality.

* Stores raw per-query recall samples in `StormResults.recalls`, mirroring `latencies_ms`, so merged fleet-wide results compute one true distribution instead of averaging worker means.

### `lib.rs`

* Passes `query.top_k` into the runner.
* Logs how many queries loaded ground truth at startup.
* Warns if any ground-truth list is shorter than `top_k`, since a `nova-bf` / storm `k` mismatch would otherwise silently deflate recall.

## Design notes

* Ground truth lives in the same file as the query vectors. This reuses `nova-bf`’s existing `queries.payload_fields` mechanism, which can carry arbitrary columns, including the query vector, through to its output.
* This avoids porting `nova-bf`’s point-id derivation logic into Rust.
* Recall is reported as `None`, not `0.0`, when a query has no ground truth or when the request fails.
* `min_recall` is reported instead of a latency-style tail percentile because recall regressions matter at the low end, while latency regressions matter at the high end.

## Testing

* Added/updated Rust unit tests covering:

  * `top_k: 0` config rejection
  * DuckDB `list<string>` decoding
  * null ground-truth rows
  * wrong-column-type errors
  * recall arithmetic and `k` semantics
  * `collect_ids` behavior
  * end-to-end runner behavior
  * recall-on-failure regression coverage
  * display formatting

* Verified:

  ```bash
  cargo clippy --workspace --all-targets
  cargo test --workspace
  ```

* Ran live end-to-end smoke tests against a real Qdrant Docker instance:

  * loaded a fake corpus with the real `nova-load` binary
  * generated ground truth with the real `nova-bf compute`
  * ran the real `nova-storm` binary
  * confirmed recall `1.0000` with unmodified ground truth
  * confirmed recall `0.5000` with deliberately half-corrupted ground truth
  * confirmed the opt-out path remains identical to pre-change behavior

An adversarial review pass found several correctness and efficiency issues, including `top_k = 0`, missing `k`-mismatch validation, unnecessary id collection, and avoidable `HashSet` allocation. These were fixed and covered by tests.
