### PR TITLE
enabled batched queries and adapt existing pacing logic to support it

### DIFF
--- a/configs/skypilot/storm.yaml
+++ b/configs/skypilot/storm.yaml
@@ -5,7 +5,7 @@
 #   nova dist storm configs/storm/test.yaml --resources configs/skypilot/storm.yaml --num-jobs 10
 #
 # storm is REPLICATED, not partitioned: every worker runs the same profile, so
-# total offered load ≈ num_jobs × (concurrency or qps). Workers run
+# total offered load ≈ num_jobs × (concurrency or rps) × batch_size. Workers run
 # `nova-storm <cfg>`.
 
 resources:

--- a/configs/storm/example.yaml
+++ b/configs/storm/example.yaml
@@ -4,7 +4,7 @@
 #   nova storm configs/storm/example.yaml
 #
 # Distributed: work is REPLICATED, not sharded — every worker runs this same
-# profile, so total offered load ≈ num_jobs × (concurrency or qps).
+# profile, so total offered load ≈ num_jobs × (concurrency or rps) × batch_size.
 #   nova dist storm configs/storm/example.yaml --num-jobs 10
 #
 # Prints a latency summary (requests, errors, throughput, p50/p95/p99, max).
@@ -30,12 +30,21 @@ query:
 
 # Per-worker load shape (replicated across the fleet).
 load:
-  # Closed-loop (default, `qps` unset): hold `concurrency` requests in flight for
+  # Closed-loop (default, `rps` unset): hold `concurrency` requests in flight for
   # `duration_s` and measure the max throughput sustainable at that depth.
   concurrency: 32
   duration_s: 60
 
-  # Open-loop paced: uncomment `qps` to launch on a fixed 1/qps schedule instead,
-  # with `concurrency` as the in-flight ceiling. Use this to measure latency at a
-  # KNOWN offered rate (avoids coordinated omission); raise qps to find the knee.
-  # qps: 500
+  # How many query vectors go in each dispatch (one query_batch RPC per
+  # dispatch). 1 (default) is not a special case — every dispatch is a batch,
+  # just of size 1 by default. Raise this to measure Qdrant's native batched
+  # query throughput instead of one-vector-per-round-trip.
+  # batch_size: 8
+
+  # Open-loop paced: uncomment `rps` to launch a batch dispatch on a fixed
+  # 1/rps schedule instead, with `concurrency` as the in-flight ceiling. Use
+  # this to measure latency at a KNOWN offered rate (avoids coordinated
+  # omission); raise rps to find the knee. Note `rps` paces *dispatches*, not
+  # individual queries — actual query throughput is `rps * batch_size` (see
+  # the `qps` field in the printed summary).
+  # rps: 500

--- a/crates/nova-storm/src/config.rs
+++ b/crates/nova-storm/src/config.rs
@@ -34,6 +34,9 @@ impl StormConfig {
         if cfg.query.top_k == 0 {
             return Err(ConfigError::ZeroTopK);
         }
+        if cfg.load.batch_size == 0 {
+            return Err(ConfigError::ZeroBatchSize);
+        }
         Ok(cfg)
     }
 
@@ -90,10 +93,15 @@ pub struct LoadProfile {
     #[serde(default = "default_duration")]
     pub duration_s: f64,
     /// `0` (default) = closed-loop, measuring max throughput at `concurrency`.
-    /// `>0` = open-loop paced at this many queries/sec per worker, with
-    /// `concurrency` as the in-flight cap. The YAML key is `qps`.
-    #[serde(rename = "qps", default)]
-    pub target_qps: f64,
+    /// `>0` = open-loop paced at this many *batch dispatches*/sec per worker,
+    /// with `concurrency` as the in-flight cap. The YAML key is `rps`.
+    #[serde(rename = "rps", default)]
+    pub target_rps: f64,
+    /// How many query vectors go in a single dispatch (`query_batch` RPC).
+    /// `1` (default) is not a special case — every dispatch is a batch, just
+    /// of size 1 by default, so existing configs behave identically.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
 }
 
 impl Default for LoadProfile {
@@ -101,7 +109,8 @@ impl Default for LoadProfile {
         Self {
             concurrency: default_concurrency(),
             duration_s: default_duration(),
-            target_qps: 0.0,
+            target_rps: 0.0,
+            batch_size: default_batch_size(),
         }
     }
 }
@@ -118,6 +127,9 @@ fn default_concurrency() -> usize {
 fn default_duration() -> f64 {
     60.0
 }
+fn default_batch_size() -> usize {
+    1
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
@@ -131,6 +143,8 @@ pub enum ConfigError {
     UnterminatedPlaceholder,
     #[error("query.top_k must be greater than 0")]
     ZeroTopK,
+    #[error("load.batch_size must be greater than 0")]
+    ZeroBatchSize,
 }
 
 /// Expand `${VAR}` references in `input` from the process environment.
@@ -187,7 +201,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_storm_config_and_qps_alias() {
+    fn parses_storm_config_and_rps() {
         let yaml = r#"
 target:
   type: qdrant
@@ -203,13 +217,15 @@ query:
 load:
   concurrency: 8
   duration_s: 300
-  qps: 75
+  rps: 75
+  batch_size: 16
 "#;
         let cfg = StormConfig::from_yaml(yaml).expect("should parse");
         assert_eq!(cfg.query.top_k, 10);
         assert_eq!(cfg.query.source.limit, 1000);
         assert_eq!(cfg.load.concurrency, 8);
-        assert_eq!(cfg.load.target_qps, 75.0); // `qps` -> target_qps
+        assert_eq!(cfg.load.target_rps, 75.0); // `rps` -> target_rps
+        assert_eq!(cfg.load.batch_size, 16);
     }
 
     #[test]
@@ -226,7 +242,8 @@ query:
 "#;
         let cfg = StormConfig::from_yaml(yaml).expect("parses");
         assert_eq!(cfg.load.concurrency, 32);
-        assert_eq!(cfg.load.target_qps, 0.0);
+        assert_eq!(cfg.load.target_rps, 0.0);
+        assert_eq!(cfg.load.batch_size, 1);
         assert_eq!(cfg.query.top_k, 10);
         assert_eq!(cfg.query.source.ground_truth_column, None);
     }
@@ -245,6 +262,42 @@ query:
     column: embedding
 "#;
         assert!(matches!(StormConfig::from_yaml(yaml).unwrap_err(), ConfigError::ZeroTopK));
+    }
+
+    #[test]
+    fn rejects_zero_batch_size() {
+        let yaml = r#"
+target:
+  type: qdrant
+  url: http://localhost:6334
+  collection_name: c
+query:
+  source:
+    uri: /tmp/q.parquet
+    column: embedding
+load:
+  batch_size: 0
+"#;
+        assert!(matches!(StormConfig::from_yaml(yaml).unwrap_err(), ConfigError::ZeroBatchSize));
+    }
+
+    #[test]
+    fn qps_key_is_no_longer_accepted() {
+        let yaml = r#"
+target:
+  type: qdrant
+  url: http://localhost:6334
+  collection_name: c
+query:
+  source:
+    uri: /tmp/q.parquet
+    column: embedding
+load:
+  qps: 75
+"#;
+        // `qps` was replaced by `rps` with no back-compat alias -- an old config
+        // using it now hits `deny_unknown_fields` like any other typo'd key.
+        assert!(matches!(StormConfig::from_yaml(yaml).unwrap_err(), ConfigError::Yaml(_)));
     }
 
     #[test]

--- a/crates/nova-storm/src/errors.rs
+++ b/crates/nova-storm/src/errors.rs
@@ -8,7 +8,7 @@
 /// Backend client errors are boxed: `QdrantError` is large and an unboxed
 /// variant would bloat every `Result`. Note this covers setup/teardown only —
 /// a *query* failure during the load run is recorded as a non-fatal error
-/// sample (see [`QueryOutcome`](crate::targets::QueryOutcome)), not surfaced here.
+/// sample (see [`BatchOutcome`](crate::targets::BatchOutcome)), not surfaced here.
 #[derive(Debug, thiserror::Error)]
 pub enum TargetError {
     #[error(transparent)]

--- a/crates/nova-storm/src/lib.rs
+++ b/crates/nova-storm/src/lib.rs
@@ -3,12 +3,13 @@
 //! A *storm* fires nearest-neighbour queries at a target cluster and records
 //! the latency distribution. Work is **replicated, not partitioned**: every
 //! worker runs the same [`LoadProfile`](config::LoadProfile), so total offered
-//! load is roughly `num_workers × {concurrency or qps}`.
+//! load is roughly `num_workers × {concurrency or rps} × batch_size`.
 //!
 //! The split mirrors `nova-load`: a backend ([`QueryTarget`](targets::QueryTarget))
-//! is a thin "fire one query, report its latency" adapter, and the runner owns
-//! the load *shape* (how many in flight, for how long, at what rate). The same
-//! [`run_storm`](runner::run_storm) drives any backend.
+//! is a thin "fire one batch dispatch, report its latency" adapter, and the
+//! runner owns the load *shape* (how many in flight, for how long, at what
+//! rate, how many queries per dispatch). The same [`run_storm`](runner::run_storm)
+//! drives any backend.
 
 pub mod config;
 pub mod errors;
@@ -40,17 +41,38 @@ pub async fn run(config: StormConfig) -> Result<Summary, StormError> {
     }
     let with_ground_truth = vectors.iter().filter(|v| v.ground_truth.is_some()).count();
 
+    // `batch_size` is only checked for `> 0` at config-load time (it has no
+    // visibility into how many rows `query.source` will actually yield) — a
+    // `batch_size` bigger than the loaded set is harmless (each repeated
+    // position still scores independently and correctly, see `batch_indices`)
+    // but silently sends duplicate vectors within a single dispatch and does
+    // more work than the operator likely intended. Warn up front, the same
+    // way a too-short ground-truth list is warned about below.
+    if load.batch_size > vectors.len() {
+        tracing::warn!(
+            "load.batch_size={} exceeds the {} loaded query vectors — each batch dispatch will \
+             contain duplicate vectors (harmless, but likely not intended; raise query.source.limit \
+             or lower batch_size)",
+            load.batch_size,
+            vectors.len(),
+        );
+    }
+
     let target = target.into_target(&query)?;
 
-    let mode = if load.target_qps > 0.0 {
-        format!("paced {:.0} qps/worker (cap {} in-flight)", load.target_qps, load.concurrency)
+    let mode = if load.target_rps > 0.0 {
+        format!(
+            "paced {:.0} rps/worker (batch_size={}, cap {} in-flight)",
+            load.target_rps, load.batch_size, load.concurrency
+        )
     } else {
-        format!("closed-loop concurrency={}", load.concurrency)
+        format!("closed-loop concurrency={} batch_size={}", load.concurrency, load.batch_size)
     };
     tracing::info!(
         target = %target,
         query_vectors = vectors.len(),
         duration_s = load.duration_s,
+        batch_size = load.batch_size,
         "storm: {mode}"
     );
     if query.source.ground_truth_column.is_some() {

--- a/crates/nova-storm/src/runner.rs
+++ b/crates/nova-storm/src/runner.rs
@@ -1,15 +1,21 @@
 //! The load generator + single-worker result summary.
 //!
-//! Two modes, chosen by [`LoadProfile::target_qps`](crate::config::LoadProfile):
+//! Two modes, chosen by [`LoadProfile::target_rps`](crate::config::LoadProfile):
 //!
 //! * `0` — **closed-loop**: hold `concurrency` requests in flight for the whole
-//!   window, each task firing the next query the instant its previous one
-//!   returns. Measures the max throughput the cluster gives at that depth.
-//! * `>0` — **open-loop paced**: launch one query every `1/target_qps` seconds
-//!   on a fixed virtual schedule, with `concurrency` as an in-flight ceiling.
-//!   The fixed schedule is what avoids coordinated omission — a slow response
-//!   can't delay the next launch and hide latency — and keeps the offered rate
-//!   tracking the target without overshooting it.
+//!   window, each task firing the next batch dispatch the instant its previous
+//!   one returns. Measures the max throughput the cluster gives at that depth.
+//! * `>0` — **open-loop paced**: launch one batch dispatch every `1/target_rps`
+//!   seconds on a fixed virtual schedule, with `concurrency` as an in-flight
+//!   ceiling. The fixed schedule is what avoids coordinated omission — a slow
+//!   response can't delay the next launch and hide latency — and keeps the
+//!   offered rate tracking the target without overshooting it.
+//!
+//! A batch dispatch (one `query_batch` round-trip) is the atomic unit of load
+//! regardless of [`LoadProfile::batch_size`](crate::config::LoadProfile) — a
+//! batch of 1 is not a special case, it's just the default. Latency is one
+//! sample per dispatch; recall stays per-query within it (see [`BatchOutcome`](
+//! crate::targets::BatchOutcome)).
 //!
 //! Aggregating ACROSS workers is a separate step and must merge latency
 //! *distributions*, never average per-worker percentiles.
@@ -31,23 +37,37 @@ use crate::targets::QueryTarget;
 /// can recompute true percentiles/means instead of averaging per-worker stats.
 #[derive(Debug, Clone)]
 pub struct StormResults {
+    /// One entry per batch dispatch (one `query_batch` round-trip), not per
+    /// query — a single gRPC round-trip's timing can't be honestly
+    /// disaggregated into per-query numbers.
     pub latencies_ms: Vec<f64>,
     /// One entry per query that had ground truth (see [`QueryVector::ground_truth`]).
-    /// Shorter than `latencies_ms` whenever some/all queries have none — that's
-    /// expected, not an error.
+    /// Recall stays per-query even though latency doesn't: `QueryBatchResponse`
+    /// gives one distinct result per submitted query, so each query's recall is
+    /// still individually real, not approximated from the batch.
     pub recalls: Vec<f64>,
+    /// Count of batch dispatches, not individual queries.
     pub n_ok: u64,
     pub n_err: u64,
     pub wall_s: f64,
+    /// How many query vectors went in each dispatch — carried alongside the
+    /// raw samples so `summary()` can self-describe regardless of what
+    /// `LoadProfile` is in scope.
+    pub batch_size: usize,
 }
 
 /// Aggregated stats for THIS worker. Fleet-wide stats must merge raw samples
 /// from every worker, not average these.
 #[derive(Debug, Clone)]
 pub struct Summary {
+    /// Batch dispatches (round-trips), not individual queries.
     pub requests: u64,
     pub errors: u64,
-    pub throughput_qps: f64,
+    pub batch_size: usize,
+    /// Batch dispatch rate — round-trips/sec, not query throughput.
+    pub requests_per_sec: f64,
+    /// Actual query throughput: `requests_per_sec * batch_size`.
+    pub qps: f64,
     pub p50_ms: f64,
     pub p95_ms: f64,
     pub p99_ms: f64,
@@ -72,10 +92,13 @@ impl StormResults {
         let mut rc = self.recalls.clone();
         rc.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         let total = self.n_ok + self.n_err;
+        let requests_per_sec = if self.wall_s > 0.0 { total as f64 / self.wall_s } else { 0.0 };
         Summary {
             requests: total,
             errors: self.n_err,
-            throughput_qps: if self.wall_s > 0.0 { total as f64 / self.wall_s } else { 0.0 },
+            batch_size: self.batch_size,
+            requests_per_sec,
+            qps: requests_per_sec * self.batch_size as f64,
             p50_ms: percentile(&ms, 50.0),
             p95_ms: percentile(&ms, 95.0),
             p99_ms: percentile(&ms, 99.0),
@@ -92,7 +115,9 @@ impl std::fmt::Display for Summary {
         let mut lines = vec![
             format!("{:>16}: {}", "requests", self.requests),
             format!("{:>16}: {}", "errors", self.errors),
-            format!("{:>16}: {:.1}", "throughput_qps", self.throughput_qps),
+            format!("{:>16}: {}", "batch_size", self.batch_size),
+            format!("{:>16}: {:.1}", "requests_per_sec", self.requests_per_sec),
+            format!("{:>16}: {:.1}", "qps", self.qps),
             format!("{:>16}: {:.2}", "p50_ms", self.p50_ms),
             format!("{:>16}: {:.2}", "p95_ms", self.p95_ms),
             format!("{:>16}: {:.2}", "p99_ms", self.p99_ms),
@@ -135,35 +160,65 @@ fn recall_at_k(returned: &[String], ground_truth: &HashSet<String>, k: u64) -> f
     hits as f64 / k as f64
 }
 
-/// One query observation forwarded from a worker to the collector.
-struct Sample {
+/// One batch dispatch's observation forwarded from a worker to the collector.
+/// `latency_ms`/`ok` describe the one round-trip; `recalls` holds 0..N values,
+/// one per query in the batch that had both ground truth and returned ids.
+struct DispatchSample {
     latency_ms: f64,
     ok: bool,
-    /// `None` when this query had no ground truth to compare against, OR the
-    /// query itself failed (`!ok`) — a failed request has no "returned ids" to
-    /// score, so it must not count as recall=0. Conflating the two would make
-    /// `mean_recall` crash under load-induced errors even when every
-    /// *successful* query has perfect recall — a different, already-visible
-    /// finding via `errors`/`throughput_qps`, not one recall should also report.
-    recall: Option<f64>,
+    /// A query contributes no entry here (not a `0.0` entry) when it had no
+    /// ground truth to compare against, OR the whole dispatch failed (`!ok`)
+    /// — a failed request has no "returned ids" to score, so it must not
+    /// count as recall=0. Conflating the two would make `mean_recall` crash
+    /// under load-induced errors even when every *successful* query has
+    /// perfect recall — a different, already-visible finding via
+    /// `errors`/`requests_per_sec`, not one recall should also report.
+    recalls: Vec<f64>,
 }
 
-/// Build a [`Sample`] from a completed query, applying the "only score recall
-/// on success" rule above in one place (both load-shape functions call this).
-/// `out.ids` being `None` already covers both "no ground truth was tracked"
-/// and "the query failed" — see `QueryOutcome::ids` — so `zip` alone is the
-/// whole rule; no separate `out.ok` check is needed here anymore.
-fn sample_from(out: &crate::targets::QueryOutcome, ground_truth: Option<&HashSet<String>>, top_k: u64) -> Sample {
-    let recall = out.ids.as_ref().zip(ground_truth).map(|(ids, gt)| recall_at_k(ids, gt, top_k));
-    Sample { latency_ms: out.latency.as_secs_f64() * 1000.0, ok: out.ok, recall }
+/// Build a [`DispatchSample`] from a completed batch dispatch, applying the
+/// "only score recall on success" rule above per-query within the batch.
+/// `idxs[i]` is the vectors-index the i-th slot in `out.ids` corresponds to.
+/// `out.ids[i]` being `None` already covers both "no ground truth was
+/// tracked" and "the dispatch failed" — see `BatchOutcome::ids` — so `zip`
+/// alone is the whole rule; no separate `out.ok` check is needed here.
+fn dispatch_sample(
+    out: &crate::targets::BatchOutcome,
+    idxs: &[usize],
+    vectors: &[QueryVector],
+    top_k: u64,
+) -> DispatchSample {
+    let recalls = idxs
+        .iter()
+        .zip(out.ids.iter())
+        .filter_map(|(&i, ids)| {
+            ids.as_ref().zip(vectors[i].ground_truth.as_ref()).map(|(ids, gt)| recall_at_k(ids, gt, top_k))
+        })
+        .collect();
+    DispatchSample { latency_ms: out.latency.as_secs_f64() * 1000.0, ok: out.ok, recalls }
+}
+
+/// The batch-of-`batch_size` indices into a round-robin `vectors` set of
+/// length `n`, starting at `start` and wrapping around. Pulled out on its own
+/// so the wraparound math is unit-testable without a mock run.
+///
+/// Precondition: `n > 0` — callers must not invoke this against an empty
+/// vector set (`% 0` panics). Every current caller is already guarded by
+/// `lib.rs::run()` rejecting an empty query-vector set before `run_storm` is
+/// reachable; the assertion exists so a future caller added inside this
+/// module fails loudly instead of hitting a raw divide-by-zero.
+fn batch_indices(start: usize, batch_size: usize, n: usize) -> Vec<usize> {
+    debug_assert!(n > 0, "batch_indices requires a non-empty vector set");
+    (0..batch_size).map(|offset| (start + offset) % n).collect()
 }
 
 /// Drive one worker's load profile against `target` and collect latencies
 /// (and recall, for queries carrying ground truth).
 ///
-/// `vectors` is the query set to cycle through (round-robin). A query failure is
-/// recorded as an error sample, not a hard error — see [`QueryOutcome`]. `top_k`
-/// is the denominator for recall — see [`recall_at_k`].
+/// `vectors` is the query set to cycle through (round-robin). A dispatch failure
+/// is recorded as an error sample, not a hard error — see [`BatchOutcome`](
+/// crate::targets::BatchOutcome). `top_k` is the denominator for recall — see
+/// [`recall_at_k`].
 pub async fn run_storm(
     target: Arc<dyn QueryTarget>,
     vectors: Vec<QueryVector>,
@@ -171,7 +226,7 @@ pub async fn run_storm(
     top_k: u64,
 ) -> StormResults {
     let vectors = Arc::new(vectors);
-    let (tx, mut rx) = mpsc::unbounded_channel::<Sample>();
+    let (tx, mut rx) = mpsc::unbounded_channel::<DispatchSample>();
 
     // Collector: drain samples into the raw distributions + counts. Owning the
     // accumulation in one task keeps the workers lock-free on the hot path.
@@ -182,9 +237,7 @@ pub async fn run_storm(
         let mut n_err = 0u64;
         while let Some(s) = rx.recv().await {
             latencies.push(s.latency_ms);
-            if let Some(r) = s.recall {
-                recalls.push(r);
-            }
+            recalls.extend(s.recalls);
             if s.ok {
                 n_ok += 1;
             } else {
@@ -196,8 +249,9 @@ pub async fn run_storm(
 
     let started = Instant::now();
     let stop_at = started + Duration::from_secs_f64(profile.duration_s);
+    let batch_size = profile.batch_size.max(1);
 
-    if profile.target_qps > 0.0 {
+    if profile.target_rps > 0.0 {
         run_paced(&target, &vectors, profile, stop_at, top_k, &tx).await;
     } else {
         run_closed_loop(&target, &vectors, profile, stop_at, top_k, &tx).await;
@@ -210,7 +264,7 @@ pub async fn run_storm(
     let (latencies_ms, recalls, n_ok, n_err) = collector.await.unwrap_or_default();
     let _ = target.close().await;
 
-    StormResults { latencies_ms, recalls, n_ok, n_err, wall_s }
+    StormResults { latencies_ms, recalls, n_ok, n_err, wall_s, batch_size }
 }
 
 /// Hold `concurrency` requests in flight until the window closes; each task
@@ -221,9 +275,10 @@ async fn run_closed_loop(
     profile: &LoadProfile,
     stop_at: Instant,
     top_k: u64,
-    tx: &mpsc::UnboundedSender<Sample>,
+    tx: &mpsc::UnboundedSender<DispatchSample>,
 ) {
     let n = vectors.len();
+    let batch_size = profile.batch_size.max(1);
     let cursor = Arc::new(AtomicUsize::new(0));
     let mut workers = JoinSet::new();
 
@@ -235,10 +290,11 @@ async fn run_closed_loop(
         workers.spawn(async move {
             while Instant::now() < stop_at {
                 // fetch_add wraps far below usize::MAX over any real run.
-                let i = cursor.fetch_add(1, Ordering::Relaxed) % n;
-                let qv = &vectors[i];
-                let out = target.query(&qv.vector).await;
-                let _ = tx.send(sample_from(&out, qv.ground_truth.as_ref(), top_k));
+                let start = cursor.fetch_add(batch_size, Ordering::Relaxed) % n;
+                let idxs = batch_indices(start, batch_size, n);
+                let vecs: Vec<&[f32]> = idxs.iter().map(|&i| vectors[i].vector.as_slice()).collect();
+                let out = target.query_batch(&vecs).await;
+                let _ = tx.send(dispatch_sample(&out, &idxs, &vectors, top_k));
             }
         });
     }
@@ -246,21 +302,22 @@ async fn run_closed_loop(
     while workers.join_next().await.is_some() {}
 }
 
-/// Open-loop: launch a query on a fixed `1/target_qps` schedule regardless of
-/// whether prior ones have returned. `concurrency` caps in-flight requests as a
-/// safety valve — when the cluster can't keep up the cap fills, `acquire` stalls
-/// the dispatcher, and the achieved QPS sags below target (which is the finding,
-/// not an error).
+/// Open-loop: launch a batch dispatch on a fixed `1/target_rps` schedule
+/// regardless of whether prior ones have returned. `concurrency` caps in-flight
+/// requests as a safety valve — when the cluster can't keep up the cap fills,
+/// `acquire` stalls the dispatcher, and the achieved rate sags below target
+/// (which is the finding, not an error).
 async fn run_paced(
     target: &Arc<dyn QueryTarget>,
     vectors: &Arc<Vec<QueryVector>>,
     profile: &LoadProfile,
     stop_at: Instant,
     top_k: u64,
-    tx: &mpsc::UnboundedSender<Sample>,
+    tx: &mpsc::UnboundedSender<DispatchSample>,
 ) {
     let n = vectors.len();
-    let interval = Duration::from_secs_f64(1.0 / profile.target_qps);
+    let batch_size = profile.batch_size.max(1);
+    let interval = Duration::from_secs_f64(1.0 / profile.target_rps);
     let sem = Arc::new(Semaphore::new(profile.concurrency.max(1)));
     let mut inflight = JoinSet::new();
     let mut idx = 0usize;
@@ -275,15 +332,16 @@ async fn run_paced(
         if Instant::now() >= stop_at {
             break;
         }
-        let i = idx % n;
-        idx += 1;
+        let start = idx % n;
+        idx += batch_size;
+        let idxs = batch_indices(start, batch_size, n);
         let target = target.clone();
         let vectors = vectors.clone();
         let tx = tx.clone();
         inflight.spawn(async move {
-            let qv = &vectors[i];
-            let out = target.query(&qv.vector).await;
-            let _ = tx.send(sample_from(&out, qv.ground_truth.as_ref(), top_k));
+            let vecs: Vec<&[f32]> = idxs.iter().map(|&i| vectors[i].vector.as_slice()).collect();
+            let out = target.query_batch(&vecs).await;
+            let _ = tx.send(dispatch_sample(&out, &idxs, &vectors, top_k));
             drop(permit); // release the in-flight slot
         });
 
@@ -297,7 +355,7 @@ async fn run_paced(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::targets::QueryOutcome;
+    use crate::targets::BatchOutcome;
     use async_trait::async_trait;
 
     /// A target that "answers" instantly with a fixed set of ids (or a hard
@@ -322,19 +380,19 @@ mod tests {
 
     #[async_trait]
     impl QueryTarget for MockTarget {
-        async fn query(&self, _vector: &[f32]) -> QueryOutcome {
+        async fn query_batch(&self, vectors: &[&[f32]]) -> BatchOutcome {
             if self.fail {
-                return QueryOutcome {
+                return BatchOutcome {
                     latency: Duration::from_micros(100),
                     ok: false,
-                    ids: None,
+                    ids: vec![None; vectors.len()],
                     error: Some("mock failure".into()),
                 };
             }
-            QueryOutcome {
+            BatchOutcome {
                 latency: Duration::from_micros(100),
                 ok: true,
-                ids: Some(self.ids.clone()),
+                ids: vec![Some(self.ids.clone()); vectors.len()],
                 error: None,
             }
         }
@@ -346,7 +404,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn closed_loop_fires_many_and_records_each() {
-        let profile = LoadProfile { concurrency: 4, duration_s: 0.2, target_qps: 0.0 };
+        let profile = LoadProfile { concurrency: 4, duration_s: 0.2, target_rps: 0.0, batch_size: 1 };
         let target = Arc::new(MockTarget::ok(vec![]));
         let results = run_storm(target, vectors(), &profile, 10).await;
         let summary = results.summary();
@@ -355,24 +413,26 @@ mod tests {
         assert_eq!(summary.errors, 0);
         // every request contributes exactly one latency sample
         assert_eq!(results.latencies_ms.len() as u64, summary.requests);
-        assert!(summary.throughput_qps > 0.0);
+        assert!(summary.requests_per_sec > 0.0);
+        // batch_size 1 -> requests_per_sec and qps (actual query throughput) coincide
+        assert!((summary.qps - summary.requests_per_sec).abs() < 1e-9);
         // no query in `vectors()` carries ground truth -> recall untouched, not zero
         assert!(results.recalls.is_empty());
         assert_eq!(summary.mean_recall, None);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn paced_does_not_overshoot_target_qps() {
-        let target_qps = 200.0;
+    async fn paced_does_not_overshoot_target_rps() {
+        let target_rps = 200.0;
         let duration_s = 0.5;
-        let profile = LoadProfile { concurrency: 16, duration_s, target_qps };
+        let profile = LoadProfile { concurrency: 16, duration_s, target_rps, batch_size: 1 };
         let target = Arc::new(MockTarget::ok(vec![]));
         let results = run_storm(target, vectors(), &profile, 10).await;
         let summary = results.summary();
 
         // The whole point: pacing holds the offered rate at/under target. Allow a
         // small ceiling slack for scheduling, but it must not run open-throttle.
-        let ceiling = (target_qps * duration_s) as u64 + profile.concurrency as u64;
+        let ceiling = (target_rps * duration_s) as u64 + profile.concurrency as u64;
         assert!(summary.requests > 0);
         assert!(
             summary.requests <= ceiling,
@@ -399,7 +459,7 @@ mod tests {
             })
             .collect();
 
-        let profile = LoadProfile { concurrency: 2, duration_s: 0.15, target_qps: 0.0 };
+        let profile = LoadProfile { concurrency: 2, duration_s: 0.15, target_rps: 0.0, batch_size: 1 };
         let results = run_storm(target, vectors, &profile, 4).await;
         let summary = results.summary();
 
@@ -417,7 +477,7 @@ mod tests {
         // A live-Qdrant smoke test caught this: a target that fails every query
         // (e.g. wrong vector_name, transient overload) must not report
         // mean_recall=0.0 -- that would read as "search is bad" when the real
-        // finding is "every request errored," which `errors`/`throughput_qps`
+        // finding is "every request errored," which `errors`/`requests_per_sec`
         // already surface distinctly.
         let target = Arc::new(MockTarget { ids: vec![], fail: true });
         let vectors: Vec<QueryVector> = (0..8)
@@ -427,7 +487,7 @@ mod tests {
             })
             .collect();
 
-        let profile = LoadProfile { concurrency: 2, duration_s: 0.15, target_qps: 0.0 };
+        let profile = LoadProfile { concurrency: 2, duration_s: 0.15, target_rps: 0.0, batch_size: 1 };
         let results = run_storm(target, vectors, &profile, 1).await;
         let summary = results.summary();
 
@@ -461,7 +521,9 @@ mod tests {
         let base = Summary {
             requests: 10,
             errors: 0,
-            throughput_qps: 5.0,
+            batch_size: 1,
+            requests_per_sec: 5.0,
+            qps: 5.0,
             p50_ms: 1.0,
             p95_ms: 2.0,
             p99_ms: 3.0,
@@ -492,14 +554,19 @@ mod tests {
         }
         #[async_trait]
         impl QueryTarget for PerQueryTarget {
-            async fn query(&self, vector: &[f32]) -> QueryOutcome {
+            async fn query_batch(&self, vectors: &[&[f32]]) -> BatchOutcome {
                 // vector[0] selects which of the 3 fixed ids come back.
-                let ids = match vector[0] as i64 {
-                    0 => vec![], // 0/2 in ground truth -> recall 0.0
-                    1 => vec!["a".to_string()], // 1/2 -> recall 0.5
-                    _ => vec!["a".to_string(), "b".to_string()], // 2/2 -> recall 1.0
-                };
-                QueryOutcome { latency: Duration::from_micros(100), ok: true, ids: Some(ids), error: None }
+                let ids = vectors
+                    .iter()
+                    .map(|v| {
+                        Some(match v[0] as i64 {
+                            0 => vec![], // 0/2 in ground truth -> recall 0.0
+                            1 => vec!["a".to_string()], // 1/2 -> recall 0.5
+                            _ => vec!["a".to_string(), "b".to_string()], // 2/2 -> recall 1.0
+                        })
+                    })
+                    .collect();
+                BatchOutcome { latency: Duration::from_micros(100), ok: true, ids, error: None }
             }
         }
         let gt = Some(HashSet::from(["a".to_string(), "b".to_string()]));
@@ -509,7 +576,7 @@ mod tests {
             QueryVector { vector: vec![2.0], ground_truth: gt },
         ];
         // duration long enough to cycle through all 3 at concurrency=1 several times
-        let profile = LoadProfile { concurrency: 1, duration_s: 0.1, target_qps: 0.0 };
+        let profile = LoadProfile { concurrency: 1, duration_s: 0.1, target_rps: 0.0, batch_size: 1 };
         let results = run_storm(Arc::new(PerQueryTarget), vectors, &profile, 2).await;
 
         // Only asserts the pipeline actually produced all 3 distinct values --
@@ -534,6 +601,7 @@ mod tests {
             n_ok: 3,
             n_err: 0,
             wall_s: 1.0,
+            batch_size: 1,
         };
         let summary = results.summary();
 
@@ -543,5 +611,65 @@ mod tests {
         // mean and median coincide here (symmetric distribution) -- min is the
         // one that actually differs from both, proving it's not just an alias.
         assert_ne!(summary.min_recall, summary.mean_recall);
+    }
+
+    #[test]
+    fn batch_indices_wrap_around() {
+        assert_eq!(batch_indices(6, 5, 8), vec![6, 7, 0, 1, 2]);
+        assert_eq!(batch_indices(0, 3, 8), vec![0, 1, 2]);
+        assert_eq!(batch_indices(0, 1, 8), vec![0]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn batches_group_multiple_queries_per_dispatch_and_score_each() {
+        // Records the length of every query_batch call, and returns ids chosen
+        // by position-within-the-batch so each slot scores a distinct, known
+        // recall -- proving query_batch is actually called with `batch_size`
+        // vectors together (not looped internally), and each query in the
+        // batch gets its own correct recall score.
+        struct BatchCapturingTarget {
+            call_lens: std::sync::Mutex<Vec<usize>>,
+        }
+        impl std::fmt::Display for BatchCapturingTarget {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "batch-capturing-mock")
+            }
+        }
+        #[async_trait]
+        impl QueryTarget for BatchCapturingTarget {
+            async fn query_batch(&self, vectors: &[&[f32]]) -> BatchOutcome {
+                self.call_lens.lock().unwrap().push(vectors.len());
+                // position 0 -> 0/2 in ground truth -> recall 0.0
+                // position 1 -> 1/2 -> recall 0.5
+                // position 2 -> 2/2 -> recall 1.0
+                let ids = (0..vectors.len())
+                    .map(|pos| {
+                        Some(match pos % 3 {
+                            0 => vec![],
+                            1 => vec!["a".to_string()],
+                            _ => vec!["a".to_string(), "b".to_string()],
+                        })
+                    })
+                    .collect();
+                BatchOutcome { latency: Duration::from_micros(100), ok: true, ids, error: None }
+            }
+        }
+
+        let gt = Some(HashSet::from(["a".to_string(), "b".to_string()]));
+        let vectors: Vec<QueryVector> =
+            (0..9).map(|i| QueryVector { vector: vec![i as f32], ground_truth: gt.clone() }).collect();
+        let batch_size = 3;
+        let profile = LoadProfile { concurrency: 1, duration_s: 0.15, target_rps: 0.0, batch_size };
+        let target = Arc::new(BatchCapturingTarget { call_lens: std::sync::Mutex::new(Vec::new()) });
+        let results = run_storm(target.clone(), vectors, &profile, 2).await;
+
+        let call_lens = target.call_lens.lock().unwrap();
+        assert!(!call_lens.is_empty());
+        assert!(call_lens.iter().all(|&len| len == batch_size), "{call_lens:?}");
+
+        assert!(results.recalls.iter().any(|&r| (r - 0.0).abs() < 1e-9));
+        assert!(results.recalls.iter().any(|&r| (r - 0.5).abs() < 1e-9));
+        assert!(results.recalls.iter().any(|&r| (r - 1.0).abs() < 1e-9));
+        assert_eq!(results.summary().batch_size, batch_size);
     }
 }

--- a/crates/nova-storm/src/targets/mod.rs
+++ b/crates/nova-storm/src/targets/mod.rs
@@ -1,11 +1,13 @@
 //! Query targets — the backends a storm fires at.
 //!
-//! A [`QueryTarget`] is a thin adapter: "fire one nearest-neighbour query and
-//! report its latency." The load *shape* (concurrency, duration, rate) lives in
-//! the [runner](crate::runner), so a backend stays minimal and the same runner
-//! drives any store. Targets are built once and shared across every concurrent
-//! request via `Arc`, so the trait is `Send + Sync` (the gRPC client multiplexes
-//! concurrent calls over one connection).
+//! A [`QueryTarget`] is a thin adapter: "fire one batch dispatch of nearest-
+//! neighbour queries and report its latency." A batch of 1 is not a special
+//! case — it's just the default. The load *shape* (concurrency, duration,
+//! rate, batch size) lives in the [runner](crate::runner), so a backend stays
+//! minimal and the same runner drives any store. Targets are built once and
+//! shared across every concurrent request via `Arc`, so the trait is
+//! `Send + Sync` (the gRPC client multiplexes concurrent calls over one
+//! connection).
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,19 +20,24 @@ use crate::errors::TargetError;
 
 pub mod qdrant;
 
-/// Outcome of a single query. A failure is recorded here (`ok = false`) rather
+/// Outcome of a single batch dispatch (one `query_batch` round-trip, covering
+/// `vectors.len()` queries). A failure is recorded here (`ok = false`) rather
 /// than aborting the run — a storm measures how a cluster behaves under load,
-/// and errors at the limit are a finding, not a crash.
+/// and errors at the limit are a finding, not a crash. `latency`/`ok`/`error`
+/// describe the one round-trip, not any individual query inside it — a single
+/// gRPC call's timing can't be honestly disaggregated into per-query numbers.
 #[derive(Debug, Clone)]
-pub struct QueryOutcome {
+pub struct BatchOutcome {
     pub latency: Duration,
     pub ok: bool,
-    /// The point ids actually returned, best-first — `None` when there's
-    /// nothing meaningful to report: recall tracking wasn't on for this run
-    /// (`QdrantTarget::collect_ids` is `false`) or the query failed (`!ok`).
-    /// `Some(vec![])` is a real, different thing — recall tracking was on,
-    /// the query succeeded, and it just matched nothing.
-    pub ids: Option<Vec<String>>,
+    /// One entry per submitted query, in the same order as the input
+    /// `vectors` — the point ids that query actually returned, best-first.
+    /// `None` at a position means there's nothing meaningful to report for
+    /// that query: recall tracking wasn't on for this run
+    /// (`QdrantTarget::collect_ids` is `false`) or the whole dispatch failed
+    /// (`!ok`). `Some(vec![])` is a real, different thing — recall tracking
+    /// was on, the dispatch succeeded, and that query just matched nothing.
+    pub ids: Vec<Option<Vec<String>>>,
     pub error: Option<String>,
 }
 
@@ -38,10 +45,12 @@ pub struct QueryOutcome {
 /// (e.g. `qdrant(products)`).
 #[async_trait]
 pub trait QueryTarget: Send + Sync + std::fmt::Display {
-    /// Fire a single nearest-neighbour query for `vector` and return its latency
-    /// + outcome. The top-k / vector-name knobs are baked into the target at
-    /// construction, so the hot path is just the vector.
-    async fn query(&self, vector: &[f32]) -> QueryOutcome;
+    /// Fire one batch dispatch covering all of `vectors` in a single
+    /// round-trip and return its latency + outcome. The top-k / vector-name
+    /// knobs are baked into the target at construction, so the hot path is
+    /// just the vectors. A single-element slice is not a special case — it's
+    /// the default (`LoadProfile::batch_size == 1`).
+    async fn query_batch(&self, vectors: &[&[f32]]) -> BatchOutcome;
 
     /// Tear down connections. Default: nothing (clients close on drop).
     async fn close(&self) -> Result<(), TargetError> {

--- a/crates/nova-storm/src/targets/qdrant.rs
+++ b/crates/nova-storm/src/targets/qdrant.rs
@@ -6,10 +6,10 @@ use std::time::Instant;
 use async_trait::async_trait;
 use qdrant_client::Qdrant;
 use qdrant_client::qdrant::point_id::PointIdOptions;
-use qdrant_client::qdrant::{QueryPointsBuilder, ScoredPoint};
+use qdrant_client::qdrant::{QueryBatchPointsBuilder, QueryPointsBuilder, ScoredPoint};
 use serde::Deserialize;
 
-use super::{QueryOutcome, QueryTarget};
+use super::{BatchOutcome, QueryTarget};
 use crate::config::QueryConfig;
 use crate::errors::TargetError;
 
@@ -19,10 +19,11 @@ pub struct QdrantTarget {
     collection_name: String,
     vector_name: Option<String>,
     top_k: u64,
-    /// Whether to materialize `QueryOutcome.ids`. Skipped (leaving `ids` empty)
-    /// when the run has no `ground_truth_column` configured — recall is the
-    /// only consumer of `ids`, so collecting it otherwise is a wasted
-    /// allocation (a `String` clone per returned point) on every query.
+    /// Whether to materialize `BatchOutcome.ids`. Skipped (leaving each
+    /// position `None`) when the run has no `ground_truth_column` configured
+    /// — recall is the only consumer of `ids`, so collecting it otherwise is
+    /// a wasted allocation (a `String` clone per returned point) on every
+    /// query.
     collect_ids: bool,
 }
 
@@ -67,27 +68,48 @@ impl fmt::Display for QdrantTarget {
 
 #[async_trait]
 impl QueryTarget for QdrantTarget {
-    async fn query(&self, vector: &[f32]) -> QueryOutcome {
-        let mut builder = QueryPointsBuilder::new(&self.collection_name)
-            .query(vector.to_vec())
-            .limit(self.top_k)
-            .with_payload(false);
-        if let Some(name) = &self.vector_name {
-            builder = builder.using(name.clone());
-        }
+    async fn query_batch(&self, vectors: &[&[f32]]) -> BatchOutcome {
+        let query_points: Vec<_> = vectors
+            .iter()
+            .map(|vector| {
+                let mut builder = QueryPointsBuilder::new(&self.collection_name)
+                    .query(vector.to_vec())
+                    .limit(self.top_k)
+                    .with_payload(false);
+                if let Some(name) = &self.vector_name {
+                    builder = builder.using(name.clone());
+                }
+                builder.build()
+            })
+            .collect();
+        let request = QueryBatchPointsBuilder::new(&self.collection_name, query_points);
 
         let started = Instant::now();
-        match self.client.query(builder).await {
-            Ok(resp) => QueryOutcome {
-                latency: started.elapsed(),
-                ok: true,
-                ids: self.collect_ids.then(|| resp.result.iter().filter_map(point_id_string).collect()),
-                error: None,
-            },
-            Err(e) => QueryOutcome {
+        match self.client.query_batch(request).await {
+            Ok(resp) => {
+                debug_assert_eq!(
+                    resp.result.len(),
+                    vectors.len(),
+                    "query_batch response length must match the submitted batch size"
+                );
+                BatchOutcome {
+                    latency: started.elapsed(),
+                    ok: true,
+                    ids: resp
+                        .result
+                        .into_iter()
+                        .map(|batch_result| {
+                            self.collect_ids
+                                .then(|| batch_result.result.iter().filter_map(point_id_string).collect())
+                        })
+                        .collect(),
+                    error: None,
+                }
+            }
+            Err(e) => BatchOutcome {
                 latency: started.elapsed(),
                 ok: false,
-                ids: None,
+                ids: vec![None; vectors.len()],
                 error: Some(e.to_string()),
             },
         }

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -123,7 +123,7 @@ for config and tuning.
 ### storm
 
 Replicated, **not** partitioned — every worker runs the same profile, so total
-offered load ≈ `num_jobs × (concurrency or qps)`.
+offered load ≈ `num_jobs × (concurrency or rps) × batch_size`.
 
 ```bash
 nova dist storm configs/storm/test.yaml --num-jobs 10

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -105,7 +105,8 @@ query:
 load:
   concurrency: 32
   duration_s: 60
-  # qps: 500     # omit for closed-loop (max throughput); set for paced open-loop
+  # batch_size: 8   # queries per query_batch dispatch (1 = one query per round-trip)
+  # rps: 500        # omit for closed-loop (max throughput); set for paced open-loop
 ```
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -84,7 +84,7 @@ See [Brute-Force overview](../brute-force/overview.md) for the config, output sc
 
 Load-test a vector store (Rust). Work is **replicated**, not partitioned — every
 worker runs the same profile, so total offered load ≈ `num_workers × {concurrency
-or qps}`.
+or rps} × batch_size`.
 
 ```bash
 nova storm <config>
@@ -92,13 +92,19 @@ nova storm <config>
 
 The config's `load` block picks the mode:
 
-- **closed-loop** (default, `qps` unset) — hold `concurrency` requests in flight
+- **closed-loop** (default, `rps` unset) — hold `concurrency` requests in flight
   for `duration_s`; measures max throughput at that depth.
-- **open-loop paced** (`qps > 0`) — launch on a fixed `1/qps` schedule with
-  `concurrency` as an in-flight cap; avoids coordinated omission.
+- **open-loop paced** (`rps > 0`) — launch a batch dispatch on a fixed `1/rps`
+  schedule with `concurrency` as an in-flight cap; avoids coordinated omission.
 
-Prints a latency summary (requests, errors, throughput, p50/p95/p99, max) at the
-end.
+`batch_size` (default `1`) is how many query vectors go in each dispatch (one
+Qdrant `query_batch` RPC per dispatch) — not a special case at `1`, just the
+default. `rps` paces *dispatches*, not individual queries.
+
+Prints a latency summary at the end: requests/errors (dispatch counts),
+`batch_size`, `requests_per_sec` (dispatch rate) and `qps` (actual query
+throughput, `= requests_per_sec × batch_size`), p50/p95/p99/max latency (per
+dispatch), and recall stats (per query) if `ground_truth_column` is configured.
 
 ## Local dev: overriding a tool's location
 


### PR DESCRIPTION
## Summary

Adds native Qdrant `query_batch` support to `nova-storm`, allowing a load test to dispatch `N` query vectors per round-trip instead of always sending one vector per request.

Existing behavior is unchanged by default: `batch_size` defaults to `1`.

This is a from-scratch reimplementation of an earlier prototype from the `recall_calc` branch, rather than a stash replay, because `master` had since gained unrelated fixes.

## Breaking change

Renames the YAML key:

```yaml
load.qps
```

to:

```yaml
load.rps
```

There is no backward-compatible alias. Old configs using `qps:` now fail clearly at config-load time via `deny_unknown_fields`.

This is intentional: once batching exists, “requests/sec” and “queries/sec” are different. `rps` more accurately describes what the field paces: batch dispatches, not individual queries.

## What changed

### `config.rs`

* Adds `LoadProfile.batch_size`, defaulting to `1`.
* Renames `qps` to `rps`.
* Adds `ConfigError::ZeroBatchSize` to reject `batch_size: 0` before any network work begins.

### `targets/mod.rs` / `targets/qdrant.rs`

* Replaces single-vector `QueryTarget::query()` with:

```rust
query_batch(&self, vectors: &[&[f32]])
```

* Qdrant now builds one `QueryPoints` per vector, wraps them in `QueryBatchPointsBuilder`, and sends one RPC for the whole batch.
* Renames `QueryOutcome` to `BatchOutcome`, since the result now describes one round-trip with shared latency/status plus per-query ids.
* Adds a `debug_assert_eq!` to guard the assumption that Qdrant batch responses are positionally aligned with requests.

### `runner.rs`

* Adds `batch_indices()` for round-robin batch construction, tested independently.
* Updates closed-loop and paced runners to advance by a whole batch per dispatch.
* Replaces repeated single-query calls with one `query_batch` call.
* Renames `Sample` to `DispatchSample`.
* Preserves per-query recall scoring inside each batch via `recalls: Vec<f64>`.
* Summary now reports both:

  * `requests_per_sec`: batch dispatch rate
  * `qps`: actual query throughput, computed as `requests_per_sec × batch_size`

### `lib.rs`

* Logs `batch_size` at startup.
* Warns when `batch_size` exceeds the loaded query-vector count. This is harmless, but it causes vectors to be reused within a dispatch, so it is worth making visible.

### Docs / configs

* Updates docs and example configs from `qps` to `rps`.
* Updates load-formula comments to include `× batch_size`.
* Documents the new `batch_size` knob and the two throughput numbers in the summary output.

## Testing

* `cargo test -p nova-storm`: 24/24 passing.

  * Adds `batch_indices_wrap_around`.
  * Adds `batches_group_multiple_queries_per_dispatch_and_score_each`, confirming that `query_batch` is called with multiple vectors together and recall is scored per query.
* `cargo clippy -p nova-storm --all-targets -- -D warnings`: clean.
* Full workspace `cargo test`: green; `nova-load` unaffected.
* Ran adversarial review passes across correctness, cross-file behavior, Rust correctness, reuse, simplification, efficiency, and abstraction level.

  * Fixed the two real findings:

    * potential silent truncation if Qdrant batch responses were ever misaligned
    * missing warning when `batch_size` exceeds the query set size
* Live-tested against a real Qdrant instance across:

  * batch sizes from `1` through `100000`, including non-divisor sizes
  * paced/open-loop behavior
  * corrupted and short ground-truth recall cases
  * whole-batch failure paths
  * config validation
  * 50k-vector / 128-dim indexed dataset with non-self-inclusive queries
  * all three distance metrics
  * 3-process concurrent fleet simulation
  * 30s soak test

## Reviewer notes

* No dependency changes.
* Final dead-code/staleness audit found no unused-code warnings and no leftover tracked references to the old `qps`, `QueryOutcome`, `Sample`, or single-query API.
