### PR TITLE
Merge bf-simplify-sharing: multi-search sharing + filter-index simplification

### DIFF
--- a/configs/brute_force/example.yaml
+++ b/configs/brute_force/example.yaml
@@ -37,6 +37,16 @@ output:
 params:
   io_workers: 16
   io_thread_count: 0
+  # Score each corpus file against the queries in row-batches of this many rows
+  # instead of all at once, bounding the (n_queries × rows) score matrix on the
+  # GPU. Omit (default) to score the whole file in one matmul — fastest, and fine
+  # until a file is big enough (or the query set large enough) to OOM the GPU.
+  # Values below the largest k among that vector_type's searches are raised to it
+  # (a smaller batch can't fill any search's top-K). One value per vector_type,
+  # run-wide — every search of a vector_type ends up sharing one GPU pass over
+  # the corpus, so this isn't a per-search setting.
+  # dense_batch_size: 4096
+  # sparse_batch_size: 4096
   # merge_batch_size: null
   # merge_prefetch: false
 
@@ -48,12 +58,6 @@ searches:
     vector_type: dense          # dense | sparse
     metric: cosine               # cosine | dot | euclidean (euclidean unsupported with vector_type: sparse)
     k: 1000
-    # Score each corpus file against the queries in row-batches of this many rows
-    # instead of all at once, bounding the (n_queries × rows) score matrix on the
-    # GPU. Omit (default) to score the whole file in one matmul — fastest, and fine
-    # until a file is big enough (or the query set large enough) to OOM the GPU.
-    # Values below k are raised to k (a smaller batch can't fill the top-K).
-    # corpus_batch_size: 4096
     # Restrict eligible neighbors to corpus rows matching this predicate — shaped
     # like a Qdrant filter (must = AND, should = OR-at-least-one, must_not = AND-NOT).
     # A condition's `field` is the only place you name a corpus column to filter on

--- a/docs/brute-force/overview.md
+++ b/docs/brute-force/overview.md
@@ -39,6 +39,8 @@ output:
 params:
   io_workers: 16             # concurrent corpus-file reader threads
   io_thread_count: 0         # pyarrow IO-pool size (0 = pyarrow's default ~8)
+  # dense_batch_size: 4096   # bound GPU memory on huge files; omit = whole file at once
+  # sparse_batch_size: 4096  # same, for vector_type: sparse searches
   # merge_batch_size: null   # merge tuning, see Performance & tuning
   # merge_prefetch: false
 
@@ -47,19 +49,21 @@ searches:
     vector_type: dense       # dense | sparse
     metric: cosine           # cosine | dot | euclidean (euclidean unsupported with vector_type: sparse)
     k: 1000
-    # corpus_batch_size: 4096  # bound GPU memory on huge files; omit = whole file at once
     # filter: {...}            # see "Filtering the corpus" below
 ```
 
-`${VAR}` / `${VAR:-default}` references are expanded from the environment, same as every other tool. `params` holds only run-level IO/merge tuning — every search-specific setting (`k`, `metric`, `vector_type`, `corpus_batch_size`, `filter`) lives on its `searches[]` entry.
+`${VAR}` / `${VAR:-default}` references are expanded from the environment, same as every other tool. `params` holds run-level IO/merge/GPU-batching tuning; every search-specific setting (`k`, `metric`, `vector_type`, `filter`) lives on its `searches[]` entry. GPU batch size (`dense_batch_size`/`sparse_batch_size`) lives on `params`, not per search — see [One search, or several in one pass](#one-search-or-several-in-one-pass) for why.
 
 ### One search, or several in one pass
 
 A single `compute` run computes every entry in `searches:` — one is the common case, but you can list several **independent** top-K results (e.g. dense-unfiltered, sparse-unfiltered, and a filtered variant of either) and they'll share corpus file IO/decode: each corpus file is read and decoded only **once per vector_type any search needs**, not once per search. This is not a fused hybrid score — each search gets its own ranked list, own `k`/`metric`/`filter`, and own output file; they just cost roughly the price of one corpus scan instead of one scan per search (the read+decode path is what dominates, see [Performance & tuning](#performance--tuning)).
 
-Searches sharing the exact same `vector_type` **and** the exact same `filter` (including two unfiltered searches) share more than just decode: their filter evaluation, row compaction, and GPU transfer / sparse-CSR construction all happen once per shared batch too — only each search's own scoring (by its own `metric`) and top-K accumulation stay independent. So `dense_all` and `dense_eng` above are in different groups (different `filter`), but two searches differing only by `k` or `metric` over the same unfiltered corpus (or the same filter) land in one group and pay for the transfer exactly once between them.
+Per `vector_type`, searches share GPU work one of two ways:
 
-When grouped searches request different `corpus_batch_size` values, the group runs at the **smallest** of the explicit requests (a smaller batch is always safe, just less efficient — never larger than any one member asked for), floored so it never drops below the largest `k` among the group's members (the same "a batch below k gives no memory benefit" rule already applied per search). A group whose resolved batch size differs from what one of its members configured logs an INFO line naming that search and the resolved value, so this is never silent.
+- **If any search of that vector_type is unfiltered**, every search of that vector_type — filtered or not — shares one full-file GPU pass: the transfer/CSR build and each distinct `metric`'s score matrix are computed once per batch, and every search (including filtered ones) reads its top-K straight from those shared columns, masking down to its own filter's surviving rows first if it has one. This is exact, not an approximation — masking a raw score matrix commutes with computing it — so a filtered search's `metric` never needs to match anything else in the run; scoring one more metric on a batch that's already on the GPU is cheap, unlike a second transfer. In the example above, `dense_eng` and `sparse_eng` both ride `dense_all`/`sparse_all`'s pass this way.
+- **Otherwise** (no search of that vector_type is unfiltered), there's no full-file pass to ride, so searches are grouped by exact filter equality instead and each such group compacts its own rows before transfer — same behavior as a single filtered search run alone.
+
+Either way, GPU batch size for a vector_type is one run-level setting (`params.dense_batch_size`/`sparse_batch_size`) — it's not something you tune per search, since every search of a vector_type ends up sharing one GPU pass over the corpus regardless of grouping. What happens when it's set below some search's `k` differs by which of the two cases above applies: in the **shared-pass** case, your configured value is kept as-is (an under-filled batch just costs the larger-`k` search a few extra merge rounds — never a wrong answer, and never a memory bound you didn't ask for, since one unrelated search's large `k` would otherwise silently widen every OTHER search's GPU footprint too); in the **grouped-by-filter** case, each group's own batch size floors at the largest `k` among that GROUP's own (related, identically-filtered) members, same as before — there's no unrelated search sharing the grid to protect against there.
 
 ```yaml
 searches:
@@ -97,7 +101,7 @@ Every entry needs a unique `name` — it's spliced into the output filename (`bf
 
 Set a search's `vector_type: sparse` to score a `struct<indices: list<uint32>, values: list<float32>>` column instead of the dense one — the same schema `nova embed`'s sparse embedders write and `nova load` reads (default column name `sparse_column`, override via `corpus.sparse_column` / `queries.sparse_column`). Only `metric: dot` and `metric: cosine` are supported (`euclidean` has no real use case for sparse retrieval and is rejected at config load).
 
-Scoring densifies the query set once over its own token vocabulary (a corpus-only token id can never match any query, so dropping it is exact, not approximate) and keeps each corpus batch genuinely sparse (`torch.sparse_csr_tensor`) on the GPU, scored via `sparse @ dense` matmul — `corpus_batch_size` bounds GPU residency the same way it does for dense.
+Scoring densifies the query set once over its own token vocabulary (a corpus-only token id can never match any query, so dropping it is exact, not approximate) and keeps each corpus batch genuinely sparse (`torch.sparse_csr_tensor`) on the GPU, scored via `sparse @ dense` matmul — `params.sparse_batch_size` bounds GPU residency the same way `dense_batch_size` does for dense.
 
 ### Filtering the corpus
 
@@ -182,10 +186,10 @@ The work splits into three layers: **reading** corpus parquet from S3, **decodin
 | `params.io_thread_count` | `0` (≈8) | **The real S3 fetch concurrency.** pyarrow funnels every read through one global IO pool, so this — not `io_workers` — is what raises throughput once decode keeps up. Try `64`–`128` on a fat NIC. |
 | `params.io_workers` | `16` | Concurrent corpus-file reader threads (each holds ~one file in RAM, so `io_workers × file_size` must fit host memory — **double that if any run mixes `vector_type: dense` and `vector_type: sparse` searches**, since each in-flight file then decodes both columns at once). Useful, but caps at `io_thread_count` — raising it alone won't lift throughput. |
 | instance vCPUs | — | Parquet decode is CPU-bound and scales ~linearly with cores. The brute-force matmul is light, so **pick the instance for vCPUs, not the GPU** (e.g. a single-GPU, high-core `g5.16xlarge`). |
-| a search's `corpus_batch_size` | `None` | The per-file score matrix is `queries × rows`. Big files (or very large query sets) can OOM the GPU; set this to score in row-batches. Values below that search's `k` are raised to `k`. Omit for the whole-file (fastest) path. **Searches sharing a `vector_type`+`filter` resolve to one shared batch size** — the smallest explicit request among them, still floored at the largest `k` in the group (see [One search, or several in one pass](#one-search-or-several-in-one-pass)). |
+| `params.dense_batch_size` / `sparse_batch_size` | `None` | The per-file score matrix is `queries × rows`. Big files (or very large query sets) can OOM the GPU; set this to score in row-batches. Omit for the whole-file (fastest) path. One value per vector_type, run-wide — every search of a vector_type ends up sharing one GPU pass over the corpus (see [One search, or several in one pass](#one-search-or-several-in-one-pass)). When some search of that vector_type is unfiltered (the shared-pass case), your configured value is always kept as-is — it's a memory bound, so it's never silently raised, even if some search's `k` exceeds it (that search just takes a few extra merge rounds). Otherwise, each filter group's own batch size floors at the largest `k` among that group's own members. |
 | region | — | `nova bf` is S3-read-heavy — run workers in the **same region** as the corpus bucket to avoid the cross-region bandwidth cap and egress. |
 
-A good starting point for a large corpus on AWS: a high-vCPU single-GPU instance, `io_thread_count: 128`, `io_workers: 32–64`. Raising query count shifts the balance toward the GPU — at that point batch the matmul (`corpus_batch_size`) and add GPUs/workers.
+A good starting point for a large corpus on AWS: a high-vCPU single-GPU instance, `io_thread_count: 128`, `io_workers: 32–64`. Raising query count shifts the balance toward the GPU — at that point batch the matmul (`params.dense_batch_size`/`sparse_batch_size`) and add GPUs/workers.
 
 > **Reading fewer bytes** helps every layer: `compute` projects only the vector column(s) any search needs (plus `id_column`/`filter` fields when configured), so the heavy work is unavoidable corpus data. Storing the dense column as fp16 (half the bytes to transfer *and* decode) is the next lever if the read path is still the bottleneck.
 

--- a/docs/brute-force/overview.md
+++ b/docs/brute-force/overview.md
@@ -99,7 +99,7 @@ Every entry needs a unique `name` — it's spliced into the output filename (`bf
 
 ### Sparse vectors
 
-Set a search's `vector_type: sparse` to score a `struct<indices: list<uint32>, values: list<float32>>` column instead of the dense one — the same schema `nova embed`'s sparse embedders write and `nova load` reads (default column name `sparse_column`, override via `corpus.sparse_column` / `queries.sparse_column`). Only `metric: dot` and `metric: cosine` are supported (`euclidean` has no real use case for sparse retrieval and is rejected at config load).
+Set a search's `vector_type: sparse` to score a `struct<indices: list<uint32>, values: list<float32>>` column instead of the dense one — the same schema `nova embed`'s sparse embedders write and `nova load` reads (default column name `sparse_embedding`, override via `corpus.sparse_column` / `queries.sparse_column`). Only `metric: dot` and `metric: cosine` are supported (`euclidean` has no real use case for sparse retrieval and is rejected at config load).
 
 Scoring densifies the query set once over its own token vocabulary (a corpus-only token id can never match any query, so dropping it is exact, not approximate) and keeps each corpus batch genuinely sparse (`torch.sparse_csr_tensor`) on the GPU, scored via `sparse @ dense` matmul — `params.sparse_batch_size` bounds GPU residency the same way `dense_batch_size` does for dense.
 

--- a/python/nova-bf/src/nova_bf/cli.py
+++ b/python/nova-bf/src/nova_bf/cli.py
@@ -55,7 +55,7 @@ def compute(
 @main.command()
 @click.argument("config")
 def merge(config: str) -> None:
-    """Merge per-rank partial results into a single top-K parquet."""
+    """Merge per-rank partial results into each search's own top-K parquet."""
     _setup_logging()
     from nova_bf.merge import run_merge
 

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -516,12 +516,14 @@ class FilterGroup:
     unfiltered, so there's no full-file score matrix to derive from, and this
     group compacts/transfers/scores its own rows once per batch instead —
     its members share the identical filter by construction, hence the
-    identical surviving row set. Carries the `Filter` itself (now hashable —
-    see `nova_bf.config.Filter`'s docstring) since it's this group's only,
-    primary key: the per-file loop looks up `keeps[group.filter]` directly,
-    with no separate string-keyed index to keep in sync."""
+    identical surviving row set. Carries `filter_idx`, this group's position
+    in `run_compute`'s `distinct_filters`/`keeps` (a plain list, aligned by
+    position) rather than the `Filter` object itself: the per-file loop looks
+    up `keeps[group.filter_idx]` once per file, and an `int` index costs
+    nothing to hash there, unlike re-hashing a `Filter` instance (pydantic's
+    frozen-model hash isn't cached on the instance the way `str`'s is)."""
 
-    filter: Filter | None
+    filter_idx: int
     member_idxs: list[int]
     batch_size: int | None  # resolved batch size; None = whole (compacted) file
 
@@ -571,12 +573,16 @@ def _path_a_batch_size(configured: int | None, k_floor: int, vt: str) -> int | N
 
 def _build_filter_groups(
     idxs: list[int], specs: list[SearchSpec], spec_filter: list[Filter | None],
-    batch_size_cfg: int | None, vt: str,
+    filter_idx: dict[Filter | None, int], batch_size_cfg: int | None, vt: str,
 ) -> list[FilterGroup]:
     """Group `idxs` (every spec of one vector_type, Path B only — none of
     them unfiltered) by exact filter equality (`Filter`'s own hash/eq), so
     specs sharing an identical filter compact/transfer/score together once
-    instead of each redoing it."""
+    instead of each redoing it. This grouping pass — unlike the resulting
+    `FilterGroup.filter_idx` — legitimately does hash every one of `idxs`'
+    filters once each; it runs only once per `run_compute` call, not once per
+    corpus file, so that cost is negligible (see `FilterGroup`'s docstring for
+    why the per-file path avoids it)."""
     by_filter: dict[Filter | None, list[int]] = {}
     for i in idxs:
         by_filter.setdefault(spec_filter[i], []).append(i)
@@ -584,7 +590,7 @@ def _build_filter_groups(
     for filt, members in by_filter.items():
         k_floor = max(specs[m].k for m in members)
         groups.append(FilterGroup(
-            filter=filt,
+            filter_idx=filter_idx[filt],
             member_idxs=members,
             batch_size=_path_b_group_batch_size(batch_size_cfg, k_floor, vt),
         ))
@@ -669,28 +675,31 @@ def _is_unfiltered(f: Filter | None) -> bool:
     return f is None or not f.fields()
 
 
-def _path_a_select(specs: list[SearchSpec], keeps: dict[Filter | None, np.ndarray | None], device: str):
+def _path_a_select(
+    specs: list[SearchSpec], spec_filter_idx: list[int], keeps: list[np.ndarray | None], device: str,
+):
     """Path A's `select` for `_process_batch_group`: an unfiltered member uses
     the shared slice as-is; a filtered member masks it down to its own
-    filter's surviving columns, via a `local_idx` cached per `Filter` (in
-    the caller-provided per-slice `cache`, keyed by the `Filter` object
-    itself — hashable, see its docstring) so two members sharing an
-    identical filter don't recompute `nonzero` twice. `Filter.__hash__` isn't
-    cached on the instance the way `str.__hash__` is, so each member's
-    `filt` is hashed at most once here (`cache.get`, then one more on a
-    miss to store it) rather than once per dict access."""
+    filter's surviving columns, via a `local_idx` cached per filter (in the
+    caller-provided per-slice `cache`) so two members sharing an identical
+    filter don't recompute `nonzero` twice. Cached and looked up by
+    `spec_filter_idx[m]` — this spec's position in `run_compute`'s
+    `distinct_filters`/`keeps` — rather than by the `Filter` object itself,
+    so this hot per-slice, per-member loop never re-hashes a `Filter`
+    instance (pydantic's frozen-model hash isn't cached on the instance the
+    way a plain `int`'s or `str`'s is)."""
     import torch
 
-    def select(m: int, r0: int, r1: int, rows, cache: dict[object, object]):
+    def select(m: int, r0: int, r1: int, rows, cache: dict[int, object]):
         s = specs[m]
-        filt = s.filter
-        if _is_unfiltered(filt):
+        if _is_unfiltered(s.filter):
             return rows, None
-        local_idx = cache.get(filt)
+        idx = spec_filter_idx[m]
+        local_idx = cache.get(idx)
         if local_idx is None:
-            local_np = np.nonzero(keeps[filt][r0:r1])[0]
+            local_np = np.nonzero(keeps[idx][r0:r1])[0]
             local_idx = torch.from_numpy(local_np).to(device, non_blocking=True)
-            cache[filt] = local_idx
+            cache[idx] = local_idx
         if local_idx.numel() == 0:
             return None, None
         return rows[local_idx], local_idx
@@ -708,7 +717,7 @@ def _path_b_select(m: int, r0: int, r1: int, rows, cache: dict[object, object]):
 
 def _process_shared_batch(
     batch, member_idxs: list[int], specs: list[SearchSpec], spec_Q, spec_top_scores, spec_top_enc,
-    keeps: dict[Filter | None, np.ndarray | None], batch_size: int | None,
+    spec_filter_idx: list[int], keeps: list[np.ndarray | None], batch_size: int | None,
     gidx: int, device: str,
 ) -> float:
     """Path A: every spec of this vector_type — filtered or not — shares one
@@ -718,7 +727,7 @@ def _process_shared_batch(
     return _process_batch_group(
         batch, member_idxs, specs, spec_Q, spec_top_scores, spec_top_enc,
         batch_size, gidx, device, orig_rows=None,
-        select=_path_a_select(specs, keeps, device),
+        select=_path_a_select(specs, spec_filter_idx, keeps, device),
     )
 
 
@@ -873,6 +882,14 @@ def run_compute(
     # derive from. See this module's docstring for the full rationale.
     spec_filter = [s.filter for s in specs]
     distinct_filters: list[Filter | None] = list(dict.fromkeys(spec_filter))
+    # Filter -> its position in `distinct_filters`/`keeps` — hashes each
+    # distinct Filter exactly once, here, at run-wide setup. Every per-file,
+    # per-batch-slice lookup below (`keeps[idx]`, `_path_a_select`'s cache)
+    # then indexes by this cheap `int` instead of re-hashing a `Filter`
+    # instance (pydantic's frozen-model hash isn't cached on the instance the
+    # way a plain `int`'s or `str`'s is).
+    filter_idx: dict[Filter | None, int] = {f: i for i, f in enumerate(distinct_filters)}
+    spec_filter_idx: list[int] = [filter_idx[f] for f in spec_filter]
 
     vt_spec_idxs: dict[str, list[int]] = {vt: [] for vt in vts_needed}
     for i, s in enumerate(specs):
@@ -892,7 +909,9 @@ def run_compute(
                 vt, len(idxs), path_a_batch_size[vt],
             )
         else:
-            path_b_groups[vt] = _build_filter_groups(idxs, specs, spec_filter, vt_configured_batch[vt], vt)
+            path_b_groups[vt] = _build_filter_groups(
+                idxs, specs, spec_filter, filter_idx, vt_configured_batch[vt], vt,
+            )
             logger.info(
                 "vector_type=%r: no unfiltered search — %d distinct filter group(s), "
                 "each compacting its own rows independently",
@@ -968,10 +987,12 @@ def run_compute(
                 t1 = time.perf_counter()
                 # One mask per DISTINCT filter (`None` for the unfiltered entry),
                 # evaluated against the same table — timed separately from the read
-                # above (CPU-vectorized work, not IO wait). Keyed by the `Filter`
-                # object itself (hashable — see its docstring) so two specs
-                # sharing an identical filter never evaluate it twice.
-                keeps = {f: evaluate(f, table) if f is not None else None for f in distinct_filters}
+                # above (CPU-vectorized work, not IO wait). A plain list, aligned by
+                # position with `distinct_filters`/`filter_idx` (not a dict keyed by
+                # the `Filter` object itself) so two specs sharing an identical
+                # filter never evaluate it twice, AND this per-file construction
+                # never hashes a `Filter` instance (see `FilterGroup`'s docstring).
+                keeps = [evaluate(f, table) if f is not None else None for f in distinct_filters]
                 t2 = time.perf_counter()
                 fq.put((gidx, arrs, ids, keeps, t1 - t0, t2 - t1))
             except Exception as exc:
@@ -1029,14 +1050,15 @@ def run_compute(
             #
             # corpus_ids is kept only for files where SOME spec could still
             # resolve a hit — i.e. it's unfiltered, or its filter keeps at least
-            # one row in this file. `keeps[f]` is a mask over this file's rows
-            # independent of vector_type (filters read payload columns, not the
-            # vector columns), so checking it here — before any vector-type-
-            # specific compaction below — is exact, not an approximation: a
-            # restrictive spec's filter dropping the whole file must never block
-            # a DIFFERENT spec's id resolution for that same file, but a file
-            # every spec's filter drops needs no ids kept at all.
-            if id_col and any(mask is None or mask.any() for mask in keeps.values()):
+            # one row in this file. Each entry of `keeps` is a mask over this
+            # file's rows independent of vector_type (filters read payload
+            # columns, not the vector columns), so checking it here — before
+            # any vector-type-specific compaction below — is exact, not an
+            # approximation: a restrictive spec's filter dropping the whole
+            # file must never block a DIFFERENT spec's id resolution for that
+            # same file, but a file every spec's filter drops needs no ids
+            # kept at all.
+            if id_col and any(mask is None or mask.any() for mask in keeps):
                 corpus_ids[gidx] = ids
             for vt in vts_needed:
                 rows_seen += batches[vt].n_rows
@@ -1047,11 +1069,11 @@ def run_compute(
                 if has_baseline[vt]:
                     gpu_secs += _process_shared_batch(
                         b, vt_spec_idxs[vt], specs, spec_Q, spec_top_scores, spec_top_enc,
-                        keeps, path_a_batch_size[vt], gidx, device,
+                        spec_filter_idx, keeps, path_a_batch_size[vt], gidx, device,
                     )
                 else:
                     for group in path_b_groups[vt]:
-                        keep = keeps[group.filter]
+                        keep = keeps[group.filter_idx]
                         gpu_secs += _process_filter_group(
                             b, group, specs, spec_Q, spec_top_scores, spec_top_enc, keep, gidx, device,
                         )

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -928,31 +928,43 @@ def run_compute(
                 gidx, f = work.get_nowait()
             except Empty:
                 return
-            t0 = time.perf_counter()
-            table = cstore.read_columns(f.read_path, read_cols)
-            # Decode each vector_type at most ONCE per file, regardless of how many
-            # specs need it — wrapped in the batch abstraction (`DenseCorpusBatch`/
-            # `SparseCorpusBatch`) in the consumer loop below, where every spec (Path
-            # A) or filter group (Path B) of that vector_type shares it.
-            arrs: dict[str, object] = {}
-            if "dense" in vts_needed:
-                arrs["dense"] = dense_to_2d(table[dense_col])
-            if "sparse" in vts_needed:
-                sp_offsets, sp_idx, sp_val = sparse_to_coo_parts(table[sparse_col])
-                sp_norms = _sparse_file_norms(sp_offsets, sp_idx, sp_val) if need_sparse_norms else None
-                arrs["sparse"] = (sp_offsets, sp_idx, sp_val, sp_norms)
-            # carry the id column (combined to one contiguous array) to decode;
-            # None when id_column isn't configured. Same row order as `arrs`.
-            ids = table[id_col].combine_chunks() if id_col else None
-            t1 = time.perf_counter()
-            # One mask per DISTINCT filter (`None` for the unfiltered entry),
-            # evaluated against the same table — timed separately from the read
-            # above (CPU-vectorized work, not IO wait). Keyed by the `Filter`
-            # object itself (hashable — see its docstring) so two specs
-            # sharing an identical filter never evaluate it twice.
-            keeps = {f: evaluate(f, table) if f is not None else None for f in distinct_filters}
-            t2 = time.perf_counter()
-            fq.put((gidx, arrs, ids, keeps, t1 - t0, t2 - t1))
+            # Wrapped in try/except so a bad read/decode/filter (e.g. a filter
+            # field missing from this file's schema, or a type pyarrow can't
+            # compare) fails the run loudly instead of silently killing this
+            # thread — an uncaught exception here would otherwise just print a
+            # traceback to stderr and die, leaving the consumer's fixed-count
+            # `fq.get()` loop blocked forever waiting for an item that will
+            # never arrive. Putting the exception itself on the queue lets the
+            # consumer re-raise it in the main thread with a clear message.
+            try:
+                t0 = time.perf_counter()
+                table = cstore.read_columns(f.read_path, read_cols)
+                # Decode each vector_type at most ONCE per file, regardless of how many
+                # specs need it — wrapped in the batch abstraction (`DenseCorpusBatch`/
+                # `SparseCorpusBatch`) in the consumer loop below, where every spec (Path
+                # A) or filter group (Path B) of that vector_type shares it.
+                arrs: dict[str, object] = {}
+                if "dense" in vts_needed:
+                    arrs["dense"] = dense_to_2d(table[dense_col])
+                if "sparse" in vts_needed:
+                    sp_offsets, sp_idx, sp_val = sparse_to_coo_parts(table[sparse_col])
+                    sp_norms = _sparse_file_norms(sp_offsets, sp_idx, sp_val) if need_sparse_norms else None
+                    arrs["sparse"] = (sp_offsets, sp_idx, sp_val, sp_norms)
+                # carry the id column (combined to one contiguous array) to decode;
+                # None when id_column isn't configured. Same row order as `arrs`.
+                ids = table[id_col].combine_chunks() if id_col else None
+                t1 = time.perf_counter()
+                # One mask per DISTINCT filter (`None` for the unfiltered entry),
+                # evaluated against the same table — timed separately from the read
+                # above (CPU-vectorized work, not IO wait). Keyed by the `Filter`
+                # object itself (hashable — see its docstring) so two specs
+                # sharing an identical filter never evaluate it twice.
+                keeps = {f: evaluate(f, table) if f is not None else None for f in distinct_filters}
+                t2 = time.perf_counter()
+                fq.put((gidx, arrs, ids, keeps, t1 - t0, t2 - t1))
+            except Exception as exc:
+                fq.put(exc)
+                return
 
     for _ in range(io_workers):
         Thread(target=reader, daemon=True).start()
@@ -975,7 +987,12 @@ def run_compute(
     with tqdm(total=len(mine), unit="file", dynamic_ncols=True, desc="bf") as bar:
         for _ in range(len(mine)):
             w0 = time.perf_counter()
-            gidx, arrs, ids, keeps, rsec, fsec = fq.get()
+            item = fq.get()
+            if isinstance(item, Exception):
+                raise RuntimeError(
+                    "a reader thread failed while reading/decoding/filtering a corpus file"
+                ) from item
+            gidx, arrs, ids, keeps, rsec, fsec = item
             io_wait += time.perf_counter() - w0
             read_secs += rsec
             filter_secs += fsec

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -592,58 +592,119 @@ def _build_filter_groups(
     return groups
 
 
-def _process_shared_batch(
+def _process_batch_group(
     batch, member_idxs: list[int], specs: list[SearchSpec], spec_Q, spec_top_scores, spec_top_enc,
-    keeps: dict[str, np.ndarray | None], spec_filter_key: list[str], batch_size: int | None,
-    gidx: int, device: str,
+    batch_size: int | None, gidx: int, device: str, orig_rows: np.ndarray | None, select,
 ) -> float:
-    """Path A: every spec of this vector_type — filtered or not — shares one
-    full-file batch grid. Built once per batch: the GPU transfer/CSR
-    (`batch.transfer`) and each DISTINCT metric's score matrix (`score_cache`,
-    keyed by metric — every spec needing that metric reads the same tensor,
-    filtered or not). Every member then merges its own top-k from those
-    shared columns: an unfiltered spec reads them directly; a filtered spec
-    masks them down to its own filter's surviving rows first (`local_idx`,
-    cached per filter so two specs sharing an identical filter don't
-    recompute `nonzero` twice). Returns elapsed wall-clock seconds (folded
-    into the caller's `gpu_secs`) — Path A never compacts, so the whole body
-    is GPU transfer/score/merge work."""
+    """Shared Path A / Path B primitive: iterate `batch` in `batch_size`-row
+    slices, transfer each slice once (`batch.transfer`), score it once per
+    DISTINCT metric among `member_idxs` (`score_cache` — every member needing
+    that metric reads the same tensor), and merge each member's own top-k
+    from those shared columns via `_merge_topk`.
+
+    `orig_rows` maps a slice position to its TRUE file-row number: `None`
+    means position IS the true row (Path A, `_process_shared_batch` below —
+    it never compacts, so `batch` is the raw, whole file); an array means
+    `batch` was already compacted by the caller (Path B,
+    `_process_filter_group` below) and this maps back to true rows for
+    `_merge_topk`'s encoding.
+
+    `select(m, r0, r1, rows, cache) -> (sel_rows, sel_cols)` is the per-member
+    filtering strategy: `sel_rows is None` skips the merge entirely for this
+    member/slice (e.g. a filter keeping zero rows here); otherwise `sel_cols`
+    is either `None` (use the slice's columns/rows unchanged — Path B, whose
+    members already share one filter via compaction) or a column-index tensor
+    used to mask both the score matrix and `rows` down to a per-member
+    filter's surviving columns (Path A). `cache` is a fresh dict per r0-slice
+    for `select` to memoize per-filter lookups shared across members (see
+    `_path_a_select`) — it does not persist across slices, since the mask is
+    slice-relative.
+
+    Returns elapsed wall-clock seconds spent in this loop (folded into the
+    caller's `gpu_secs`). Callers that pre-compact (Path B) must compact
+    BEFORE calling this function — its own timer starts only once this loop
+    begins, so CPU-side compaction time never counts as GPU time (see the
+    `io_wait`/`gpu_secs` split docs at the top of this module)."""
     import torch
 
-    t0 = time.perf_counter()
     n_rows = batch.n_rows
     if n_rows == 0:
-        return time.perf_counter() - t0
+        return 0.0
+    t0 = time.perf_counter()
     step = batch_size or n_rows
     for r0 in range(0, n_rows, step):
         r1 = min(r0 + step, n_rows)
         sl = batch.transfer(r0, r1, device)
-        rows = torch.arange(r0, r0 + sl.n_rows, dtype=torch.int64, device=device)
+        if orig_rows is None:
+            rows = torch.arange(r0, r0 + sl.n_rows, dtype=torch.int64, device=device)
+        else:
+            rows = torch.from_numpy(orig_rows[r0 : r0 + sl.n_rows]).to(device, non_blocking=True)
 
         score_cache: dict[str, object] = {}
-        local_idx_cache: dict[str, object] = {}
+        cache: dict[str, object] = {}
         for m in member_idxs:
             s = specs[m]
             if s.metric not in score_cache:
                 score_cache[s.metric] = sl.score(spec_Q[m], s.metric)
             scores = score_cache[s.metric]
 
-            if s.filter is None:
-                sel_scores, sel_rows = scores, rows
-            else:
-                fk = spec_filter_key[m]
-                if fk not in local_idx_cache:
-                    local_np = np.nonzero(keeps[fk][r0:r1])[0]
-                    local_idx_cache[fk] = torch.from_numpy(local_np).to(device, non_blocking=True)
-                local_idx = local_idx_cache[fk]
-                if local_idx.numel() == 0:
-                    continue
-                sel_scores, sel_rows = scores[:, local_idx], rows[local_idx]
+            sel_rows, sel_cols = select(m, r0, r1, rows, cache)
+            if sel_rows is None:
+                continue
+            sel_scores = scores if sel_cols is None else scores[:, sel_cols]
 
             spec_top_scores[m], spec_top_enc[m] = _merge_topk(
                 spec_top_scores[m], spec_top_enc[m], sel_scores, sel_rows, gidx, s.k
             )
     return time.perf_counter() - t0
+
+
+def _path_a_select(specs: list[SearchSpec], spec_filter_key: list[str], keeps: dict[str, np.ndarray | None], device: str):
+    """Path A's `select` for `_process_batch_group`: an unfiltered member uses
+    the shared slice as-is; a filtered member masks it down to its own
+    filter's surviving columns, via a `local_idx` cached per filter key (in
+    the caller-provided per-slice `cache`) so two members sharing an
+    identical filter don't recompute `nonzero` twice."""
+    import torch
+
+    def select(m: int, r0: int, r1: int, rows, cache: dict[str, object]):
+        s = specs[m]
+        if s.filter is None:
+            return rows, None
+        fk = spec_filter_key[m]
+        if fk not in cache:
+            local_np = np.nonzero(keeps[fk][r0:r1])[0]
+            cache[fk] = torch.from_numpy(local_np).to(device, non_blocking=True)
+        local_idx = cache[fk]
+        if local_idx.numel() == 0:
+            return None, None
+        return rows[local_idx], local_idx
+
+    return select
+
+
+def _path_b_select(m: int, r0: int, r1: int, rows, cache: dict[str, object]):
+    """Path B's `select` for `_process_batch_group`: every member of a
+    `FilterGroup` shares one identical filter, already applied via
+    `batch.compact()` before this loop runs — no further per-member masking
+    needed, so this is a no-op that always merges the slice unchanged."""
+    return rows, None
+
+
+def _process_shared_batch(
+    batch, member_idxs: list[int], specs: list[SearchSpec], spec_Q, spec_top_scores, spec_top_enc,
+    keeps: dict[str, np.ndarray | None], spec_filter_key: list[str], batch_size: int | None,
+    gidx: int, device: str,
+) -> float:
+    """Path A: every spec of this vector_type — filtered or not — shares one
+    full-file batch grid; a filtered spec masks the shared columns down to
+    its own filter's surviving rows (`_path_a_select`). See
+    `_process_batch_group` for the shared loop body."""
+    return _process_batch_group(
+        batch, member_idxs, specs, spec_Q, spec_top_scores, spec_top_enc,
+        batch_size, gidx, device, orig_rows=None,
+        select=_path_a_select(specs, spec_filter_key, keeps, device),
+    )
 
 
 def _process_filter_group(
@@ -652,36 +713,18 @@ def _process_filter_group(
 ) -> float:
     """Path B: no spec of this vector_type is unfiltered, so there's no
     full-file score matrix to derive from — this group's rows are compacted
-    once, then transferred/scored/batched independently, same as a single
-    spec running alone would. Returns elapsed wall-clock seconds spent on the
-    GPU transfer/score/merge loop (folded into the caller's `gpu_secs`) —
-    deliberately excludes `batch.compact()` above, a real CPU-side cost (row
-    filtering, array copies) that scales with corpus size, not GPU work; it's
-    real time, just not GPU time, so it shouldn't count toward the signal
-    `gpu_secs` exists to give (see the `io_wait`/`gpu_secs` split docs at the
-    top of this module)."""
-    import torch
-
+    once (`batch.compact`), then run through the shared loop
+    (`_process_batch_group`) unmasked (`_path_b_select`), same as a single
+    spec running alone would. `batch.compact()` runs OUTSIDE (before)
+    `_process_batch_group`'s own timer, so its real but CPU-side cost (row
+    filtering, array copies — scales with corpus size, not GPU work) never
+    counts toward the `gpu_secs` signal (see the `io_wait`/`gpu_secs` split
+    docs at the top of this module)."""
     compacted, orig_rows = batch.compact(keep)
-    n_rows = compacted.n_rows
-    if n_rows == 0:
-        return 0.0
-    t0 = time.perf_counter()
-    step = group.batch_size or n_rows
-    for r0 in range(0, n_rows, step):
-        r1 = min(r0 + step, n_rows)
-        sl = compacted.transfer(r0, r1, device)
-        rows = torch.from_numpy(orig_rows[r0 : r0 + sl.n_rows]).to(device)
-
-        score_cache: dict[str, object] = {}
-        for m in group.member_idxs:
-            s = specs[m]
-            if s.metric not in score_cache:
-                score_cache[s.metric] = sl.score(spec_Q[m], s.metric)
-            spec_top_scores[m], spec_top_enc[m] = _merge_topk(
-                spec_top_scores[m], spec_top_enc[m], score_cache[s.metric], rows, gidx, s.k
-            )
-    return time.perf_counter() - t0
+    return _process_batch_group(
+        compacted, group.member_idxs, specs, spec_Q, spec_top_scores, spec_top_enc,
+        group.batch_size, gidx, device, orig_rows=orig_rows, select=_path_b_select,
+    )
 
 
 def run_compute(

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -658,6 +658,17 @@ def _process_batch_group(
     return time.perf_counter() - t0
 
 
+def _is_unfiltered(f: Filter | None) -> bool:
+    """`None` is the common no-filter case; an explicit-but-empty `filter: {}`
+    (`Filter(must=(), should=(), must_not=())`) is semantically the same —
+    `evaluate()` keeps every row either way — so both must be treated
+    identically wherever "does this spec have an active filter" decides
+    Path A/B GPU-sharing (`has_baseline`) or per-member masking
+    (`_path_a_select`). `f.fields()` is empty iff every condition group is
+    empty, without duplicating that check against `Filter`'s own fields."""
+    return f is None or not f.fields()
+
+
 def _path_a_select(specs: list[SearchSpec], keeps: dict[Filter | None, np.ndarray | None], device: str):
     """Path A's `select` for `_process_batch_group`: an unfiltered member uses
     the shared slice as-is; a filtered member masks it down to its own
@@ -673,7 +684,7 @@ def _path_a_select(specs: list[SearchSpec], keeps: dict[Filter | None, np.ndarra
     def select(m: int, r0: int, r1: int, rows, cache: dict[object, object]):
         s = specs[m]
         filt = s.filter
-        if filt is None:
+        if _is_unfiltered(filt):
             return rows, None
         local_idx = cache.get(filt)
         if local_idx is None:
@@ -854,11 +865,12 @@ def run_compute(
         spec_top_scores.append(torch.full((n_q, s.k), float("-inf"), device=device))
         spec_top_enc.append(torch.zeros((n_q, s.k), dtype=torch.int64, device=device))
 
-    # Per vector_type: does any spec have no filter? If so every spec of that
-    # vector_type shares one full-file batch grid (Path A, `_process_shared_
-    # batch`); otherwise specs are grouped by exact filter equality instead
-    # (Path B, `_process_filter_group`) since there's no full-file computation
-    # to derive from. See this module's docstring for the full rationale.
+    # Per vector_type: does any spec have no filter (or an explicit-but-empty
+    # one — see `_is_unfiltered`)? If so every spec of that vector_type shares
+    # one full-file batch grid (Path A, `_process_shared_batch`); otherwise
+    # specs are grouped by exact filter equality instead (Path B,
+    # `_process_filter_group`) since there's no full-file computation to
+    # derive from. See this module's docstring for the full rationale.
     spec_filter = [s.filter for s in specs]
     distinct_filters: list[Filter | None] = list(dict.fromkeys(spec_filter))
 
@@ -871,7 +883,7 @@ def run_compute(
     path_a_batch_size: dict[str, int | None] = {}
     path_b_groups: dict[str, list[FilterGroup]] = {}
     for vt, idxs in vt_spec_idxs.items():
-        has_baseline[vt] = any(specs[i].filter is None for i in idxs)
+        has_baseline[vt] = any(_is_unfiltered(specs[i].filter) for i in idxs)
         if has_baseline[vt]:
             k_floor = max(specs[i].k for i in idxs)
             path_a_batch_size[vt] = _path_a_batch_size(vt_configured_batch[vt], k_floor, vt)

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -15,8 +15,8 @@ K via `make_point_id`, so the whole corpus's ids never materialize.
 If `corpus.id_column` is set, hit ids come from that pre-existing column instead
 of `make_point_id`. Such an id isn't recomputable from (file, row), so it's read
 alongside the dense column and kept in RAM per file (the worker's slice) to resolve
-the final top-K. Large files can be scored in row-batches (`SearchSpec.corpus_batch_size`)
-to bound the per-file score matrix `(n_queries × rows)` on the GPU.
+the final top-K. Large files can be scored in row-batches (`params.dense_batch_size`/
+`sparse_batch_size`) to bound the per-file score matrix `(n_queries × rows)` on the GPU.
 
 If a search's `filter` is set (see `nova_bf.filters`), each file's payload columns
 are read alongside the vector column and evaluated into a keep-mask *before*
@@ -31,13 +31,27 @@ from slow IO in the end-of-run timing log.
 independent searches (own vector_type/metric/k/filter), e.g. dense-unfiltered
 AND sparse-filtered against the same corpus in one invocation. Each corpus
 file is read and decoded ONCE per vector_type any spec needs, not once per
-spec. Searches sharing the exact same `vector_type` AND `filter` are further
-grouped (see `SpecGroup`/`_group_specs`): their filter-mask evaluation, row
-compaction, and GPU transfer/CSR build all happen ONCE per group per batch,
-since they score the identical set of corpus rows — only the final
-metric-specific scoring and top-K accumulation stay per-spec. This is purely
-a sharing of REDUNDANT work, never a fusion of scores: each search still gets
-its own independent ranked list, not a blended hybrid ranking.
+spec. This is purely a sharing of REDUNDANT work, never a fusion of scores:
+each search still gets its own independent ranked list, not a blended hybrid
+ranking.
+
+Per vector_type, searches share GPU work one of two ways (see `run_compute`'s
+`has_baseline` / `_process_shared_batch` / `_process_filter_group`):
+
+- If ANY search of that vector_type is unfiltered, EVERY search of that
+  vector_type — filtered or not — shares one full-file batch grid: the GPU
+  transfer/CSR build and each distinct metric's score matrix are computed
+  ONCE per batch, and every search merges its own top-K from those same
+  columns (an unfiltered search reads them directly; a filtered search masks
+  them down to its own filter's surviving rows first). Masking a raw,
+  per-row-independent score matrix is exact, not an approximation, so a
+  filtered search's metric never needs to already be used by anyone else —
+  computing one more metric on a batch that's already resident on the GPU is
+  cheap, unlike a second transfer.
+- Otherwise (no search of that vector_type is unfiltered), there's no
+  full-file computation to derive from: searches are grouped by exact filter
+  equality instead, and each such group compacts its own rows before
+  transfer/scoring, once per group per batch.
 """
 
 from __future__ import annotations
@@ -55,7 +69,7 @@ import numpy as np
 
 from tqdm import tqdm
 
-from nova_bf.config import BruteForceConfig, Filter, SearchSpec
+from nova_bf.config import BruteForceConfig, Filter, SearchSpec, filter_key
 from nova_bf.filters import evaluate
 from nova_bf.ids import make_point_id
 from nova_bf.io import ParquetFile, Store, dense_to_2d, sparse_to_coo_parts
@@ -274,9 +288,10 @@ def _sparse_batch_to_csr(
     vocabulary (out-of-vocab entries dropped — see `_build_query_vocab`).
 
     Deliberately takes no `norms`/metric argument and never scales `b_val` —
-    this builder is shared across every search in a `SpecGroup` (same
-    vector_type + filter, see `_group_specs`), including a mix of `cosine` and
-    `dot` searches, so it must stay metric-agnostic BY CONSTRUCTION. Cosine
+    this builder is shared across every search of this vector_type that scores
+    the same rows, whether via `_process_shared_batch` (Path A) or a
+    `FilterGroup` (Path B), including a mix of `cosine` and `dot` searches, so
+    it must stay metric-agnostic BY CONSTRUCTION. Cosine
     normalization is applied by the caller as a post-hoc divide on the score
     matrix (`raw / row_norms`, mathematically identical to pre-scaling these
     values by `1/row_norm` before the matmul, since a per-row scalar commutes
@@ -326,9 +341,9 @@ def _sparse_scores(Q, Cb):
     (cuSPARSE SpMM) — deliberately not sparse-sparse matmul, which torch has no
     stable binding for. Returns the raw dot-product score matrix; the caller
     applies any metric-specific transform (e.g. dividing by each row's L2 norm
-    for cosine) afterward — see the per-group batch loop in `run_compute`,
-    which shares one `Cb` across every search in a `SpecGroup` regardless of
-    metric, so this function itself must stay metric-agnostic."""
+    for cosine) afterward — see `SparseBatchSlice.score`, which shares one
+    `Cb` across every search scoring it regardless of metric, so this
+    function itself must stay metric-agnostic."""
     import torch
 
     return torch.matmul(Cb, Q.T).T
@@ -364,60 +379,309 @@ def _sparse_file_norms(row_offsets: np.ndarray, indices: np.ndarray, values: np.
     return np.sqrt(sumsq).astype(np.float32)
 
 
+class DenseCorpusBatch:
+    """Decoded dense corpus vectors for one file: `(n_rows, dim)`. Exposes the
+    same `.n_rows`/`.nbytes`/`.compact`/`.transfer` surface as
+    `SparseCorpusBatch` so `run_compute`'s per-file loop never branches on
+    vector_type."""
+
+    def __init__(self, arr: np.ndarray):
+        self.arr = arr
+
+    @property
+    def n_rows(self) -> int:
+        return self.arr.shape[0]
+
+    @property
+    def nbytes(self) -> int:
+        return int(self.arr.nbytes)
+
+    def compact(self, keep: np.ndarray) -> tuple["DenseCorpusBatch", np.ndarray]:
+        """`keep` is a per-row mask; returns the compacted batch plus each
+        surviving row's TRUE file-row number (`orig_rows`) — both
+        `make_point_id` and an `id_column` lookup are keyed on that true row,
+        not on position in the compacted array."""
+        orig_rows = np.nonzero(keep)[0]
+        return DenseCorpusBatch(self.arr[orig_rows]), orig_rows
+
+    def transfer(self, r0: int, r1: int, device: str) -> "DenseBatchSlice":
+        import torch
+
+        Cb = torch.from_numpy(self.arr[r0:r1]).to(device, non_blocking=True)
+        return DenseBatchSlice(Cb)
+
+
 @dataclass
-class SpecGroup:
-    """One or more `specs[]` sharing the exact same `vector_type` AND the
-    exact same `filter` (compared by value — `Filter` is a plain pydantic
-    model with structural equality, see `_group_specs`) — so they score the
-    identical set of corpus rows and can share one GPU transfer / CSR build
-    per batch instead of each doing its own (see the per-group loop in
-    `run_compute`). `member_idxs` indexes into `specs`/`spec_Q`/
-    `spec_top_scores`/`spec_top_enc` — those stay indexed by the ORIGINAL
-    per-spec position; grouping never renumbers them."""
+class DenseBatchSlice:
+    Cb: object  # torch.Tensor, (n_rows, dim)
 
-    vector_type: str
-    filter: Filter | None
+    @property
+    def n_rows(self) -> int:
+        return self.Cb.shape[0]
+
+    def score(self, Q, metric: str):
+        return _scores(Q, self.Cb, metric)
+
+
+class SparseCorpusBatch:
+    """Decoded sparse corpus CSR parts for one file, plus each row's true
+    (untruncated) L2 norm (`norms`, `None` unless some spec needs cosine —
+    see `_sparse_file_norms`). `vocab`/`need_row_norms` are fixed RUN-WIDE
+    (see `run_compute`'s `need_sparse_norms`) and carried through `.compact()`
+    unchanged, so `.transfer()` needs no extra args beyond the `(r0, r1,
+    device)` every corpus batch takes. This means a batch/filter-group made
+    up entirely of `dot` searches still moves `row_norms` to the GPU whenever
+    ANY search in the run needs cosine — a negligible extra transfer (one
+    float per row in the batch) that a `dot` search's own `.score()` never
+    reads, so it costs a little bandwidth, never correctness."""
+
+    def __init__(self, row_offsets, indices, values, norms, vocab: np.ndarray, need_row_norms: bool):
+        self.row_offsets = row_offsets
+        self.indices = indices
+        self.values = values
+        self.norms = norms
+        self.vocab = vocab
+        self.need_row_norms = need_row_norms
+
+    @property
+    def n_rows(self) -> int:
+        return len(self.row_offsets) - 1
+
+    @property
+    def nbytes(self) -> int:
+        # on-disk width (uint32 index + float32 value per nnz), not the
+        # in-memory int64 index array torch requires — keeps this comparable
+        # to the dense path's wire-byte estimate.
+        return len(self.indices) * 8
+
+    def compact(self, keep: np.ndarray) -> tuple["SparseCorpusBatch", np.ndarray]:
+        row_offsets, indices, values, norms, orig_rows = _compact_sparse_rows(
+            self.row_offsets, self.indices, self.values, self.norms, keep
+        )
+        return (
+            SparseCorpusBatch(row_offsets, indices, values, norms, self.vocab, self.need_row_norms),
+            orig_rows,
+        )
+
+    def transfer(self, r0: int, r1: int, device: str) -> "SparseBatchSlice":
+        import torch
+
+        Cb = _sparse_batch_to_csr(self.row_offsets, self.indices, self.values, r0, r1, self.vocab, device)
+        row_norms = (
+            torch.from_numpy(self.norms[r0:r1]).to(device, non_blocking=True)
+            if self.need_row_norms else None
+        )
+        return SparseBatchSlice(Cb, row_norms)
+
+
+@dataclass
+class SparseBatchSlice:
+    Cb: object  # torch.Tensor, sparse CSR (n_rows, vocab)
+    row_norms: object  # torch.Tensor | None
+
+    @property
+    def n_rows(self) -> int:
+        return self.Cb.shape[0]
+
+    def score(self, Q, metric: str):
+        raw = _sparse_scores(Q, self.Cb)
+        if metric == "cosine":
+            return raw / self.row_norms.clamp_min(1e-12)[None, :]
+        return raw
+
+
+def _merge_topk(top_scores, top_enc, batch_scores, batch_rows, gidx: int, k: int):
+    """Fold one batch's `(n_q, n_candidate_rows)` score matrix into a spec's
+    running `(top_scores, top_enc)` top-k state: top-k the batch on its own
+    (bounded by however many candidate rows it actually has), append to the
+    running state, and re-top-k down to `k`. `batch_rows` must be the TRUE
+    file row for each of `batch_scores`'s columns, so the encoding stays
+    `global_file_idx * MAX_ROWS_PER_FILE + row` regardless of batching,
+    compaction, or masking."""
+    import torch
+
+    bk = min(k, batch_scores.shape[1])
+    f_scores, f_local = torch.topk(batch_scores, k=bk, dim=1)
+    f_enc = (gidx * MAX_ROWS_PER_FILE + batch_rows)[f_local]
+    merged_s = torch.cat([top_scores, f_scores], dim=1)
+    merged_e = torch.cat([top_enc, f_enc], dim=1)
+    new_top_scores, idx = torch.topk(merged_s, k=k, dim=1)
+    return new_top_scores, merged_e.gather(1, idx)
+
+
+@dataclass(frozen=True)
+class FilterGroup:
+    """Specs sharing one vector_type and one exact filter (Path B only — see
+    `run_compute`'s `has_baseline`): no spec of this vector_type is
+    unfiltered, so there's no full-file score matrix to derive from, and this
+    group compacts/transfers/scores its own rows once per batch instead —
+    its members share the identical filter by construction, hence the
+    identical surviving row set. Doesn't carry the `Filter` object itself —
+    nothing downstream needs it (`run_compute`'s own `distinct_filters[key]`
+    already holds it, if a caller ever does), and keeping only `key` here
+    means there's exactly one place a group's filter identity lives, not two
+    that could in principle drift apart."""
+
+    key: str  # this group's filter_key — stored so the per-file loop never re-derives it
     member_idxs: list[int]
-    batch_size: int | None  # resolved group batch size; None = whole file
+    batch_size: int | None  # resolved batch size; None = whole (compacted) file
 
 
-def _merge_batch_size(current: int | None, new: int | None, k_floor: int) -> int | None:
-    """Resolve a group's `corpus_batch_size` from its members' individual
-    requests: the min of whatever was explicitly set (a smaller batch is
-    always safe, just less efficient — this is a memory CEILING each member
-    is trusting, not a target, so the group must never exceed any one
-    member's request), floored at `k_floor` (the largest `k` among the
-    group's members — mirrors the existing single-spec floor a few lines
-    below in `run_compute`: a batch smaller than a search's own `k` can't
-    fill its top-K and gives no memory benefit, so it's never useful to go
-    below it, and that stays true at group granularity)."""
-    candidates = [v for v in (current, new) if v is not None]
-    if not candidates:
-        return None
-    return max(min(candidates), k_floor)
+def _path_b_group_batch_size(configured: int | None, k_floor: int, vt: str) -> int | None:
+    """Path B's floor: `k_floor` is the largest `k` among one `FilterGroup`'s
+    own (related — they share an identical filter by construction) members.
+    Raise `configured` (`params.dense_batch_size`/`sparse_batch_size`) up to
+    `k_floor` when it's below — below that, a search can't fill its own
+    top-K from one batch and needs extra merge rounds to get there instead,
+    which buys nothing here (this group's own memory footprint is the same
+    either way), so there's no reason not to raise it."""
+    if configured is None or configured >= k_floor:
+        return configured
+    logger.warning(
+        "params.%s_batch_size=%d is below k=%d; raising to k (a smaller "
+        "batch can't fill a search's top-K and gives no memory benefit).",
+        vt, configured, k_floor,
+    )
+    return k_floor
 
 
-def _group_specs(specs: list[SearchSpec], spec_batch: list[int | None]) -> list["SpecGroup"]:
-    """Group `specs` by `(vector_type, filter)` — a linear scan (not a
-    dict/set keyed by `Filter`, since `Filter` is unhashable), fine given
-    typical spec counts are small and this runs once, not per file."""
-    groups: list[SpecGroup] = []
-    for i, s in enumerate(specs):
-        g = next((g for g in groups if g.vector_type == s.vector_type and g.filter == s.filter), None)
-        if g is None:
-            groups.append(SpecGroup(vector_type=s.vector_type, filter=s.filter, member_idxs=[i], batch_size=spec_batch[i]))
-        else:
-            k_floor = max(specs[m].k for m in g.member_idxs + [i])
-            new_batch_size = _merge_batch_size(g.batch_size, spec_batch[i], k_floor)
-            if new_batch_size != spec_batch[i]:
-                logger.info(
-                    "search=%r shares a corpus_batch_size group with %s — resolved group "
-                    "batch size is %s, not this search's own %s",
-                    s.name, [specs[m].name for m in g.member_idxs], new_batch_size, spec_batch[i],
-                )
-            g.batch_size = new_batch_size
-            g.member_idxs.append(i)
+def _path_a_batch_size(configured: int | None, k_floor: int, vt: str) -> int | None:
+    """Path A's floor: `k_floor` is the largest `k` across EVERY search of
+    the vector_type, related or not, since they all share one full-file
+    grid. Unlike `_path_b_group_batch_size`, NEVER raise an explicit
+    `configured` value here — doing so would let one search's large `k`
+    silently blow past a DIFFERENT search's own memory bound, exactly the
+    OOM footgun `dense_batch_size`/`sparse_batch_size` exists to prevent.
+    Just warn instead: the larger-`k` search takes extra merge rounds to
+    fill its own top-K (more of them the further `configured` sits below
+    `k_floor` — each round is its own `torch.topk` pass), but at no extra
+    GPU memory cost to anyone."""
+    if configured is None or configured >= k_floor:
+        return configured
+    logger.warning(
+        "params.%s_batch_size=%d is below k=%d, the largest among searches "
+        "sharing this vector_type's batch pass — keeping your configured "
+        "value (it's a memory bound, so it takes priority); the larger-k "
+        "search(es) will need extra merge rounds to fill their own top-K "
+        "instead (more of them the further below k=%d your batch size is), "
+        "at no extra GPU memory cost.",
+        vt, configured, k_floor, k_floor,
+    )
+    return configured
+
+
+def _build_filter_groups(
+    idxs: list[int], specs: list[SearchSpec], spec_filter_key: list[str],
+    batch_size_cfg: int | None, vt: str,
+) -> list[FilterGroup]:
+    """Group `idxs` (every spec of one vector_type, Path B only — none of
+    them unfiltered) by exact filter equality via `filter_key`, so specs
+    sharing an identical filter compact/transfer/score together once instead
+    of each redoing it."""
+    by_key: dict[str, list[int]] = {}
+    for i in idxs:
+        by_key.setdefault(spec_filter_key[i], []).append(i)
+    groups = []
+    for key, members in by_key.items():
+        k_floor = max(specs[m].k for m in members)
+        groups.append(FilterGroup(
+            key=key,
+            member_idxs=members,
+            batch_size=_path_b_group_batch_size(batch_size_cfg, k_floor, vt),
+        ))
     return groups
+
+
+def _process_shared_batch(
+    batch, member_idxs: list[int], specs: list[SearchSpec], spec_Q, spec_top_scores, spec_top_enc,
+    keeps: dict[str, np.ndarray | None], spec_filter_key: list[str], batch_size: int | None,
+    gidx: int, device: str,
+) -> float:
+    """Path A: every spec of this vector_type — filtered or not — shares one
+    full-file batch grid. Built once per batch: the GPU transfer/CSR
+    (`batch.transfer`) and each DISTINCT metric's score matrix (`score_cache`,
+    keyed by metric — every spec needing that metric reads the same tensor,
+    filtered or not). Every member then merges its own top-k from those
+    shared columns: an unfiltered spec reads them directly; a filtered spec
+    masks them down to its own filter's surviving rows first (`local_idx`,
+    cached per filter so two specs sharing an identical filter don't
+    recompute `nonzero` twice). Returns elapsed wall-clock seconds (folded
+    into the caller's `gpu_secs`) — Path A never compacts, so the whole body
+    is GPU transfer/score/merge work."""
+    import torch
+
+    t0 = time.perf_counter()
+    n_rows = batch.n_rows
+    if n_rows == 0:
+        return time.perf_counter() - t0
+    step = batch_size or n_rows
+    for r0 in range(0, n_rows, step):
+        r1 = min(r0 + step, n_rows)
+        sl = batch.transfer(r0, r1, device)
+        rows = torch.arange(r0, r0 + sl.n_rows, dtype=torch.int64, device=device)
+
+        score_cache: dict[str, object] = {}
+        local_idx_cache: dict[str, object] = {}
+        for m in member_idxs:
+            s = specs[m]
+            if s.metric not in score_cache:
+                score_cache[s.metric] = sl.score(spec_Q[m], s.metric)
+            scores = score_cache[s.metric]
+
+            if s.filter is None:
+                sel_scores, sel_rows = scores, rows
+            else:
+                fk = spec_filter_key[m]
+                if fk not in local_idx_cache:
+                    local_np = np.nonzero(keeps[fk][r0:r1])[0]
+                    local_idx_cache[fk] = torch.from_numpy(local_np).to(device, non_blocking=True)
+                local_idx = local_idx_cache[fk]
+                if local_idx.numel() == 0:
+                    continue
+                sel_scores, sel_rows = scores[:, local_idx], rows[local_idx]
+
+            spec_top_scores[m], spec_top_enc[m] = _merge_topk(
+                spec_top_scores[m], spec_top_enc[m], sel_scores, sel_rows, gidx, s.k
+            )
+    return time.perf_counter() - t0
+
+
+def _process_filter_group(
+    batch, group: FilterGroup, specs: list[SearchSpec], spec_Q, spec_top_scores, spec_top_enc,
+    keep: np.ndarray, gidx: int, device: str,
+) -> float:
+    """Path B: no spec of this vector_type is unfiltered, so there's no
+    full-file score matrix to derive from — this group's rows are compacted
+    once, then transferred/scored/batched independently, same as a single
+    spec running alone would. Returns elapsed wall-clock seconds spent on the
+    GPU transfer/score/merge loop (folded into the caller's `gpu_secs`) —
+    deliberately excludes `batch.compact()` above, a real CPU-side cost (row
+    filtering, array copies) that scales with corpus size, not GPU work; it's
+    real time, just not GPU time, so it shouldn't count toward the signal
+    `gpu_secs` exists to give (see the `io_wait`/`gpu_secs` split docs at the
+    top of this module)."""
+    import torch
+
+    compacted, orig_rows = batch.compact(keep)
+    n_rows = compacted.n_rows
+    if n_rows == 0:
+        return 0.0
+    t0 = time.perf_counter()
+    step = group.batch_size or n_rows
+    for r0 in range(0, n_rows, step):
+        r1 = min(r0 + step, n_rows)
+        sl = compacted.transfer(r0, r1, device)
+        rows = torch.from_numpy(orig_rows[r0 : r0 + sl.n_rows]).to(device)
+
+        score_cache: dict[str, object] = {}
+        for m in group.member_idxs:
+            s = specs[m]
+            if s.metric not in score_cache:
+                score_cache[s.metric] = sl.score(spec_Q[m], s.metric)
+            spec_top_scores[m], spec_top_enc[m] = _merge_topk(
+                spec_top_scores[m], spec_top_enc[m], score_cache[s.metric], rows, gidx, s.k
+            )
+    return time.perf_counter() - t0
 
 
 def run_compute(
@@ -431,10 +695,12 @@ def run_compute(
     """Runs every search in `cfg.searches` — independent vector_type/metric/k/
     filter combinations — against the corpus in ONE pass: each file is read
     and decoded once per vector_type actually needed (not once per spec), and
-    searches sharing the same vector_type+filter (see `SpecGroup`) further
-    share filter evaluation, row compaction, and GPU transfer/CSR build —
-    only each search's own scoring and top-K accumulation stay independent.
-    Returns `{spec.name: output_path}`.
+    every distinct filter is evaluated once per file regardless of how many
+    searches share it. Per vector_type, searches then share GPU work via
+    `_process_shared_batch` (Path A, when some search is unfiltered) or
+    `_process_filter_group` (Path B, otherwise) — see this module's
+    docstring. Only each search's own scoring and top-K accumulation stay
+    independent. Returns `{spec.name: output_path}`.
     """
     try:
         import torch
@@ -527,7 +793,7 @@ def run_compute(
         vt: torch.tensor(Q_np_by_vt[vt], dtype=torch.float32, device=device) for vt in vts_needed
     }
     normalized_Q_by_vt: dict[str, object] = {}
-    spec_Q, spec_top_scores, spec_top_enc, spec_batch = [], [], [], []
+    spec_Q, spec_top_scores, spec_top_enc = [], [], []
     for s in specs:
         if s.metric == "cosine":
             if s.vector_type not in normalized_Q_by_vt:
@@ -540,26 +806,41 @@ def run_compute(
         spec_Q.append(Qv)
         spec_top_scores.append(torch.full((n_q, s.k), float("-inf"), device=device))
         spec_top_enc.append(torch.zeros((n_q, s.k), dtype=torch.int64, device=device))
-        # Score each file in row-batches to bound the (n_q × rows) score matrix; None
-        # = whole file. Below k is pointless (a batch can't fill the top-K and isn't
-        # smaller than the resident n_q × k state), so raise it to k with a warning.
-        cb = s.corpus_batch_size
-        if cb is not None and cb < s.k:
-            logger.warning(
-                "search=%r corpus_batch_size=%d is below k=%d; raising to k (a smaller "
-                "batch can't fill the top-K and gives no memory benefit).",
-                s.name, cb, s.k,
-            )
-            cb = s.k
-        spec_batch.append(cb)
 
-    # Group specs sharing (vector_type, filter) — they score the identical
-    # set of corpus rows, so their GPU transfer/CSR build can be shared once
-    # per group per batch instead of once per spec (see SpecGroup/_group_specs
-    # and the per-group consumer loop below). `groups` is fixed for the whole
-    # run; only `specs`/`spec_Q`/`spec_top_scores`/`spec_top_enc`/`spec_batch`
-    # stay indexed by the original per-spec position.
-    groups = _group_specs(specs, spec_batch)
+    # Per vector_type: does any spec have no filter? If so every spec of that
+    # vector_type shares one full-file batch grid (Path A, `_process_shared_
+    # batch`); otherwise specs are grouped by exact filter equality instead
+    # (Path B, `_process_filter_group`) since there's no full-file computation
+    # to derive from. See this module's docstring for the full rationale.
+    spec_filter_key = [filter_key(s.filter) for s in specs]
+    distinct_filters: dict[str, Filter | None] = {}
+    for s, fk in zip(specs, spec_filter_key):
+        distinct_filters.setdefault(fk, s.filter)
+
+    vt_spec_idxs: dict[str, list[int]] = {vt: [] for vt in vts_needed}
+    for i, s in enumerate(specs):
+        vt_spec_idxs[s.vector_type].append(i)
+
+    vt_configured_batch = {"dense": cfg.params.dense_batch_size, "sparse": cfg.params.sparse_batch_size}
+    has_baseline: dict[str, bool] = {}
+    path_a_batch_size: dict[str, int | None] = {}
+    path_b_groups: dict[str, list[FilterGroup]] = {}
+    for vt, idxs in vt_spec_idxs.items():
+        has_baseline[vt] = any(specs[i].filter is None for i in idxs)
+        if has_baseline[vt]:
+            k_floor = max(specs[i].k for i in idxs)
+            path_a_batch_size[vt] = _path_a_batch_size(vt_configured_batch[vt], k_floor, vt)
+            logger.info(
+                "vector_type=%r: %d search(es) share one full-file batch pass (batch_size=%s)",
+                vt, len(idxs), path_a_batch_size[vt],
+            )
+        else:
+            path_b_groups[vt] = _build_filter_groups(idxs, specs, spec_filter_key, vt_configured_batch[vt], vt)
+            logger.info(
+                "vector_type=%r: no unfiltered search — %d distinct filter group(s), "
+                "each compacting its own rows independently",
+                vt, len(path_b_groups[vt]),
+            )
 
     # Prefetch corpus files with a POOL of reader threads so many S3 GETs are in
     # flight at once — otherwise the GPU sits idle behind one file's latency at a
@@ -605,10 +886,9 @@ def run_compute(
             t0 = time.perf_counter()
             table = cstore.read_columns(f.read_path, read_cols)
             # Decode each vector_type at most ONCE per file, regardless of how many
-            # specs need it — every group sharing that vector_type (see SpecGroup)
-            # slices/compacts this same decoded array independently in the consumer
-            # loop below, and groups sharing a filter too go on to share the GPU
-            # transfer/CSR build itself, not just this decode step.
+            # specs need it — wrapped in the batch abstraction (`DenseCorpusBatch`/
+            # `SparseCorpusBatch`) in the consumer loop below, where every spec (Path
+            # A) or filter group (Path B) of that vector_type shares it.
             arrs: dict[str, object] = {}
             if "dense" in vts_needed:
                 arrs["dense"] = dense_to_2d(table[dense_col])
@@ -620,12 +900,11 @@ def run_compute(
             # None when id_column isn't configured. Same row order as `arrs`.
             ids = table[id_col].combine_chunks() if id_col else None
             t1 = time.perf_counter()
-            # One mask per GROUP (None where that group has no filter), evaluated
-            # against the same table — timed separately from the read above (CPU-
-            # vectorized work, not IO wait). Every spec in a group shares the
-            # identical filter by construction (that's the grouping key), so this
-            # is already deduped — no separate dedup logic needed.
-            keeps = [evaluate(g.filter, table) if g.filter else None for g in groups]
+            # One mask per DISTINCT filter (`None` for the unfiltered key),
+            # evaluated against the same table — timed separately from the read
+            # above (CPU-vectorized work, not IO wait). Keyed by `filter_key` so
+            # two specs sharing an identical filter never evaluate it twice.
+            keeps = {fk: evaluate(f, table) if f is not None else None for fk, f in distinct_filters.items()}
             t2 = time.perf_counter()
             fq.put((gidx, arrs, ids, keeps, t1 - t0, t2 - t1))
 
@@ -656,132 +935,51 @@ def run_compute(
             filter_secs += fsec
             bar.update(1)
 
+            # Wrap this file's decoded arrays in the vector_type-agnostic batch
+            # abstraction ONCE — every spec of a vector_type (Path A) or every
+            # filter group of it (Path B) shares the same wrapper below, never
+            # rebuilding or mutating the underlying decoded arrays.
+            batches: dict[str, object] = {}
+            if "dense" in vts_needed:
+                batches["dense"] = DenseCorpusBatch(arrs["dense"])
+            if "sparse" in vts_needed:
+                sp_offsets, sp_idx, sp_val, sp_norms = arrs["sparse"]
+                batches["sparse"] = SparseCorpusBatch(sp_offsets, sp_idx, sp_val, sp_norms, query_vocab, need_sparse_norms)
+
             # Whole-file bookkeeping, computed BEFORE any spec's per-vector-type
             # compaction below. rows_seen/bytes_seen are counted once per file per
             # distinct vector_type present (pre-filter), not per spec — with
             # multiple specs there's no longer a single "the" filtered row count
             # to report.
             #
-            # corpus_ids is kept only for files where SOME group could still
-            # resolve a hit — i.e. any group is unfiltered, or has a filter with
-            # at least one surviving row in this file. `keeps[gi]` is a mask over
-            # this file's rows independent of vector_type (filters read payload
-            # columns, not the vector columns), so checking it here — before the
-            # per-group loop's own vector-type-specific compaction — is exact,
-            # not an approximation: a restrictive group's filter dropping the
-            # whole file must never block a DIFFERENT group's id resolution for
-            # that same file, but a file every group's filter drops needs no ids
-            # kept at all (restores the pre-multi-spec memory behavior for that case).
-            if id_col and any(mask is None or mask.any() for mask in keeps):
+            # corpus_ids is kept only for files where SOME spec could still
+            # resolve a hit — i.e. it's unfiltered, or its filter keeps at least
+            # one row in this file. `keeps[fk]` is a mask over this file's rows
+            # independent of vector_type (filters read payload columns, not the
+            # vector columns), so checking it here — before any vector-type-
+            # specific compaction below — is exact, not an approximation: a
+            # restrictive spec's filter dropping the whole file must never block
+            # a DIFFERENT spec's id resolution for that same file, but a file
+            # every spec's filter drops needs no ids kept at all.
+            if id_col and any(mask is None or mask.any() for mask in keeps.values()):
                 corpus_ids[gidx] = ids
             for vt in vts_needed:
-                if vt == "dense":
-                    rows_seen += len(arrs["dense"])
-                    bytes_seen += int(arrs["dense"].nbytes)
+                rows_seen += batches[vt].n_rows
+                bytes_seen += batches[vt].nbytes
+
+            for vt in vts_needed:
+                b = batches[vt]
+                if has_baseline[vt]:
+                    gpu_secs += _process_shared_batch(
+                        b, vt_spec_idxs[vt], specs, spec_Q, spec_top_scores, spec_top_enc,
+                        keeps, spec_filter_key, path_a_batch_size[vt], gidx, device,
+                    )
                 else:
-                    sp_offsets, sp_idx, _, _ = arrs["sparse"]
-                    rows_seen += len(sp_offsets) - 1
-                    # on-disk width (uint32 index + float32 value per nnz), not
-                    # sp_idx's in-memory int64 (torch requires int64 indices) —
-                    # keeps this comparable to the dense path's wire-byte estimate.
-                    bytes_seen += len(sp_idx) * 8
-
-            for gi, g in enumerate(groups):
-                keep = keeps[gi]
-                # `orig_rows` is the TRUE file row a compacted row came from —
-                # identity when unfiltered, else the surviving indices of `keep`.
-                # Filtering compacts the array (fewer/smaller matmuls) but must
-                # never renumber rows: both make_point_id(file, row) and
-                # corpus_ids[gidx][row] need the row the vector actually occupies
-                # in the parquet file, not its position in the filtered-down array.
-                # `arr[orig_rows]`/`_compact_sparse_rows` both copy, so this never
-                # mutates the shared `arrs[vt]` other groups still need. Computed
-                # ONCE per group per file (was: once per spec) — every member of
-                # `g` shares the identical filter by construction, so they share
-                # the identical compacted row set too.
-                if g.vector_type == "sparse":
-                    sp_offsets, sp_idx, sp_val, sp_norms = arrs["sparse"]
-                    if keep is not None:
-                        sp_offsets, sp_idx, sp_val, sp_norms, orig_rows = _compact_sparse_rows(
-                            sp_offsets, sp_idx, sp_val, sp_norms, keep
+                    for group in path_b_groups[vt]:
+                        keep = keeps[group.key]
+                        gpu_secs += _process_filter_group(
+                            b, group, specs, spec_Q, spec_top_scores, spec_top_enc, keep, gidx, device,
                         )
-                    else:
-                        orig_rows = None
-                    n_rows = len(sp_offsets) - 1
-                    if n_rows == 0:
-                        continue
-                else:
-                    arr = arrs["dense"]
-                    if keep is not None:
-                        orig_rows = np.nonzero(keep)[0]
-                        arr = arr[orig_rows]
-                    else:
-                        orig_rows = None
-                    if len(arr) == 0:
-                        continue
-                    n_rows = arr.shape[0]
-
-                # Whether THIS group needs each batch's true per-row L2 norm at
-                # all — i.e. whether any member's metric is "cosine". Sparse
-                # only: `_sparse_batch_to_csr` always builds a RAW (unnormalized)
-                # CSR now (see its docstring), so cosine normalization is applied
-                # here, per group per batch, as a post-hoc divide on each cosine
-                # member's OWN score matrix — never baked into the shared `Cb`,
-                # which is exactly what makes sharing `Cb` across members with
-                # DIFFERENT metrics (e.g. a cosine and a dot search in one group)
-                # safe: a dot member simply never touches `row_norms`.
-                needs_row_norms = g.vector_type == "sparse" and any(
-                    specs[m].metric == "cosine" for m in g.member_idxs
-                )
-
-                g0 = time.perf_counter()
-                step = g.batch_size or n_rows  # None → whole file in one matmul
-                for r0 in range(0, n_rows, step):
-                    r1 = min(r0 + step, n_rows)
-                    # Copy only this batch to the GPU, not the whole file. A big corpus
-                    # parquet (~1M rows ≈ 3 GB at 768-dim f32) would otherwise sit
-                    # resident on the GPU for the whole file even though scoring is
-                    # batched — the real driver of the OOM on large parquets. Per-batch
-                    # H2D moves the same total bytes but caps corpus residency at `step`
-                    # rows (so GPU memory is bounded by corpus_batch_size, as intended).
-                    # Done ONCE per group per batch — every member of `g` scores this
-                    # SAME `Cb` (see the per-member loop below), instead of each
-                    # member independently re-transferring/re-building it.
-                    if g.vector_type == "sparse":
-                        Cb = _sparse_batch_to_csr(
-                            sp_offsets, sp_idx, sp_val, r0, r1, query_vocab, device,
-                        )
-                        row_norms = (
-                            torch.from_numpy(sp_norms[r0:r1]).to(device, non_blocking=True)
-                            if needs_row_norms else None
-                        )
-                    else:
-                        Cb = torch.from_numpy(arr[r0:r1]).to(device, non_blocking=True)
-                    # rows are the TRUE file row for each entry of Cb (see orig_rows
-                    # above), so the encoding stays global_file_idx * MAX_ROWS_PER_FILE
-                    # + row regardless of batching or filtering. Shared across every
-                    # member of `g` — it depends only on the group's compaction/batch
-                    # boundaries, never on a member's own k/metric.
-                    if orig_rows is not None:
-                        rows = torch.from_numpy(orig_rows[r0 : r0 + Cb.shape[0]]).to(device)
-                    else:
-                        rows = torch.arange(r0, r0 + Cb.shape[0], dtype=torch.int64, device=device)
-
-                    for m in g.member_idxs:
-                        s = specs[m]
-                        if g.vector_type == "sparse":
-                            raw = _sparse_scores(spec_Q[m], Cb)  # (n_q, ≤step)
-                            scores = raw / row_norms.clamp_min(1e-12)[None, :] if s.metric == "cosine" else raw
-                        else:
-                            scores = _scores(spec_Q[m], Cb, s.metric)  # (n_q, ≤step), UNCHANGED
-                        bk = min(s.k, Cb.shape[0])
-                        f_scores, f_local = torch.topk(scores, k=bk, dim=1)
-                        f_enc = (gidx * MAX_ROWS_PER_FILE + rows)[f_local]
-                        merged_s = torch.cat([spec_top_scores[m], f_scores], dim=1)
-                        merged_e = torch.cat([spec_top_enc[m], f_enc], dim=1)
-                        spec_top_scores[m], idx = torch.topk(merged_s, k=s.k, dim=1)
-                        spec_top_enc[m] = merged_e.gather(1, idx)
-                gpu_secs += time.perf_counter() - g0
 
             if bar.n % 200 == 0:
                 postfix = f"io_wait={io_wait:.0f}s gpu={gpu_secs:.0f}s"

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -528,37 +528,37 @@ class FilterGroup:
     batch_size: int | None  # resolved batch size; None = whole (compacted) file
 
 
-def _path_b_group_batch_size(configured: int | None, k_floor: int, vt: str) -> int | None:
-    """Path B's floor: `k_floor` is the largest `k` among one `FilterGroup`'s
-    own (related — they share an identical filter by construction) members.
-    Raise `configured` (`params.dense_batch_size`/`sparse_batch_size`) up to
-    `k_floor` when it's below — below that, a search can't fill its own
-    top-K from one batch and needs extra merge rounds to get there instead,
-    which buys nothing here (this group's own memory footprint is the same
-    either way), so there's no reason not to raise it."""
+def _resolve_vt_batch_size(configured: int | None, k_floor: int, vt: str, raise_to_floor: bool) -> int | None:
+    """Shared floor-check behind `_path_b_group_batch_size`/`_path_a_batch_size`:
+    `configured` (`params.dense_batch_size`/`sparse_batch_size`) is fine as-is
+    whenever it's unset or already at/above `k_floor` — a batch that size can
+    already fill any of these searches' own top-K in one pass. Below that, the
+    two paths diverge on what `k_floor` even means:
+
+    - Path B (`raise_to_floor=True`, via `_path_b_group_batch_size`): `k_floor`
+      is the largest `k` among one `FilterGroup`'s own (related — they share
+      an identical filter by construction) members, so raising `configured`
+      up to it only helps: this group's memory footprint is the same either
+      way, and a smaller batch just can't fill a search's top-K for no
+      benefit.
+    - Path A (`raise_to_floor=False`, via `_path_a_batch_size`): `k_floor` is
+      the largest `k` across EVERY search of the vector_type, related or not,
+      since they all share one full-file grid — raising `configured` here
+      would let one search's large `k` silently blow past a DIFFERENT
+      search's own memory bound, exactly the OOM footgun `dense_batch_size`/
+      `sparse_batch_size` exists to prevent. Warn instead: the larger-`k`
+      search just takes extra merge rounds to fill its own top-K (more of
+      them the further `configured` sits below `k_floor`), at no extra GPU
+      memory cost to anyone."""
     if configured is None or configured >= k_floor:
         return configured
-    logger.warning(
-        "params.%s_batch_size=%d is below k=%d; raising to k (a smaller "
-        "batch can't fill a search's top-K and gives no memory benefit).",
-        vt, configured, k_floor,
-    )
-    return k_floor
-
-
-def _path_a_batch_size(configured: int | None, k_floor: int, vt: str) -> int | None:
-    """Path A's floor: `k_floor` is the largest `k` across EVERY search of
-    the vector_type, related or not, since they all share one full-file
-    grid. Unlike `_path_b_group_batch_size`, NEVER raise an explicit
-    `configured` value here — doing so would let one search's large `k`
-    silently blow past a DIFFERENT search's own memory bound, exactly the
-    OOM footgun `dense_batch_size`/`sparse_batch_size` exists to prevent.
-    Just warn instead: the larger-`k` search takes extra merge rounds to
-    fill its own top-K (more of them the further `configured` sits below
-    `k_floor` — each round is its own `torch.topk` pass), but at no extra
-    GPU memory cost to anyone."""
-    if configured is None or configured >= k_floor:
-        return configured
+    if raise_to_floor:
+        logger.warning(
+            "params.%s_batch_size=%d is below k=%d; raising to k (a smaller "
+            "batch can't fill a search's top-K and gives no memory benefit).",
+            vt, configured, k_floor,
+        )
+        return k_floor
     logger.warning(
         "params.%s_batch_size=%d is below k=%d, the largest among searches "
         "sharing this vector_type's batch pass — keeping your configured "
@@ -569,6 +569,14 @@ def _path_a_batch_size(configured: int | None, k_floor: int, vt: str) -> int | N
         vt, configured, k_floor, k_floor,
     )
     return configured
+
+
+def _path_b_group_batch_size(configured: int | None, k_floor: int, vt: str) -> int | None:
+    return _resolve_vt_batch_size(configured, k_floor, vt, raise_to_floor=True)
+
+
+def _path_a_batch_size(configured: int | None, k_floor: int, vt: str) -> int | None:
+    return _resolve_vt_batch_size(configured, k_floor, vt, raise_to_floor=False)
 
 
 def _build_filter_groups(

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -108,6 +108,27 @@ def filter_corpus_files(
     return kept
 
 
+def _next_in_order(want_gidx: int, pending: dict[int, tuple], fetch) -> tuple:
+    """Returns the `(gidx, ...)` item for `want_gidx`, buffering (in
+    `pending`) any item `fetch()` delivers out of turn until it's needed.
+    `fetch()` returns the next available item in ARRIVAL order, which may
+    not be `want_gidx`'s turn yet — used so items produced by an unordered
+    pool of worker threads can still be consumed in a fixed, deterministic
+    order. `run_compute`'s consumer loop uses this to fold corpus files into
+    the running top-K merge in ascending `gidx` order regardless of which
+    reader thread's file arrives first — the merge is commutative in the
+    SCORES it produces, but not in which of several EXACTLY tied candidates
+    a run picks, so without this, that pick varied nondeterministically run
+    to run for the identical corpus and queries."""
+    if want_gidx in pending:
+        return pending.pop(want_gidx)
+    while True:
+        item = fetch()
+        if item[0] == want_gidx:
+            return item
+        pending[item[0]] = item
+
+
 def _resolve_rank(num_jobs: int | None, job_rank: int | None) -> int | None:
     if num_jobs is None:
         return None
@@ -928,8 +949,12 @@ def run_compute(
 
     # Prefetch corpus files with a POOL of reader threads so many S3 GETs are in
     # flight at once — otherwise the GPU sits idle behind one file's latency at a
-    # time. Order doesn't matter (the top-K merge is commutative). pyarrow releases
-    # the GIL during IO, so threads parallelize.
+    # time. pyarrow releases the GIL during IO, so threads parallelize. Reader
+    # threads may FINISH in any order, but the consumer below folds files into
+    # the running top-K in a FIXED order (ascending `gidx`) regardless of
+    # arrival order — see the comment above the consumer loop for why: the
+    # merge is commutative in the SCORES it produces, but not in which of
+    # several EXACTLY tied candidates a run picks.
     dense_col, sparse_col = cfg.corpus.dense_column, cfg.corpus.sparse_column
     id_col = cfg.corpus.id_column  # None → derive make_point_id(file_key, row) at decode
     # Union of every spec's filter fields — read_cols below stays exactly (and only)
@@ -1025,15 +1050,26 @@ def run_compute(
     bytes_seen = 0  # decoded float32 bytes consumed (~= wire bytes for snappy-float32)
     wall0 = time.perf_counter()
 
+    def _fetch_or_raise() -> tuple:
+        it = fq.get()
+        if isinstance(it, Exception):
+            raise RuntimeError(
+                "a reader thread failed while reading/decoding/filtering a corpus file"
+            ) from it
+        return it
+
+    # `mine` already lists this worker's files in a fixed, deterministic
+    # order (ascending `gidx`); `_next_in_order` reorders reader threads'
+    # arbitrary-arrival-order output back into that order (bounded by
+    # `io_workers`-many buffered items, since `fq`'s own bound already caps
+    # how far readers can race ahead) — see its docstring for why this
+    # matters for reproducibility, not just correctness.
+    pending: dict[int, tuple] = {}
+
     with tqdm(total=len(mine), unit="file", dynamic_ncols=True, desc="bf") as bar:
-        for _ in range(len(mine)):
+        for want_gidx, _f in mine:
             w0 = time.perf_counter()
-            item = fq.get()
-            if isinstance(item, Exception):
-                raise RuntimeError(
-                    "a reader thread failed while reading/decoding/filtering a corpus file"
-                ) from item
-            gidx, arrs, ids, keeps, rsec, fsec = item
+            gidx, arrs, ids, keeps, rsec, fsec = _next_in_order(want_gidx, pending, _fetch_or_raise)
             io_wait += time.perf_counter() - w0
             read_secs += rsec
             filter_secs += fsec

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -640,7 +640,7 @@ def _process_batch_group(
             rows = torch.from_numpy(orig_rows[r0 : r0 + sl.n_rows]).to(device, non_blocking=True)
 
         score_cache: dict[str, object] = {}
-        cache: dict[str, object] = {}
+        cache: dict[object, object] = {}  # keyed by whatever select() memoizes on (e.g. Filter)
         for m in member_idxs:
             s = specs[m]
             if s.metric not in score_cache:
@@ -664,17 +664,22 @@ def _path_a_select(specs: list[SearchSpec], keeps: dict[Filter | None, np.ndarra
     filter's surviving columns, via a `local_idx` cached per `Filter` (in
     the caller-provided per-slice `cache`, keyed by the `Filter` object
     itself — hashable, see its docstring) so two members sharing an
-    identical filter don't recompute `nonzero` twice."""
+    identical filter don't recompute `nonzero` twice. `Filter.__hash__` isn't
+    cached on the instance the way `str.__hash__` is, so each member's
+    `filt` is hashed at most once here (`cache.get`, then one more on a
+    miss to store it) rather than once per dict access."""
     import torch
 
     def select(m: int, r0: int, r1: int, rows, cache: dict[object, object]):
         s = specs[m]
-        if s.filter is None:
+        filt = s.filter
+        if filt is None:
             return rows, None
-        if s.filter not in cache:
-            local_np = np.nonzero(keeps[s.filter][r0:r1])[0]
-            cache[s.filter] = torch.from_numpy(local_np).to(device, non_blocking=True)
-        local_idx = cache[s.filter]
+        local_idx = cache.get(filt)
+        if local_idx is None:
+            local_np = np.nonzero(keeps[filt][r0:r1])[0]
+            local_idx = torch.from_numpy(local_np).to(device, non_blocking=True)
+            cache[filt] = local_idx
         if local_idx.numel() == 0:
             return None, None
         return rows[local_idx], local_idx
@@ -682,7 +687,7 @@ def _path_a_select(specs: list[SearchSpec], keeps: dict[Filter | None, np.ndarra
     return select
 
 
-def _path_b_select(m: int, r0: int, r1: int, rows, cache: dict[str, object]):
+def _path_b_select(m: int, r0: int, r1: int, rows, cache: dict[object, object]):
     """Path B's `select` for `_process_batch_group`: every member of a
     `FilterGroup` shares one identical filter, already applied via
     `batch.compact()` before this loop runs — no further per-member masking

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -69,7 +69,7 @@ import numpy as np
 
 from tqdm import tqdm
 
-from nova_bf.config import BruteForceConfig, Filter, SearchSpec, filter_key
+from nova_bf.config import BruteForceConfig, Filter, SearchSpec
 from nova_bf.filters import evaluate
 from nova_bf.ids import make_point_id
 from nova_bf.io import ParquetFile, Store, dense_to_2d, sparse_to_coo_parts
@@ -516,13 +516,12 @@ class FilterGroup:
     unfiltered, so there's no full-file score matrix to derive from, and this
     group compacts/transfers/scores its own rows once per batch instead —
     its members share the identical filter by construction, hence the
-    identical surviving row set. Doesn't carry the `Filter` object itself —
-    nothing downstream needs it (`run_compute`'s own `distinct_filters[key]`
-    already holds it, if a caller ever does), and keeping only `key` here
-    means there's exactly one place a group's filter identity lives, not two
-    that could in principle drift apart."""
+    identical surviving row set. Carries the `Filter` itself (now hashable —
+    see `nova_bf.config.Filter`'s docstring) since it's this group's only,
+    primary key: the per-file loop looks up `keeps[group.filter]` directly,
+    with no separate string-keyed index to keep in sync."""
 
-    key: str  # this group's filter_key — stored so the per-file loop never re-derives it
+    filter: Filter | None
     member_idxs: list[int]
     batch_size: int | None  # resolved batch size; None = whole (compacted) file
 
@@ -571,21 +570,21 @@ def _path_a_batch_size(configured: int | None, k_floor: int, vt: str) -> int | N
 
 
 def _build_filter_groups(
-    idxs: list[int], specs: list[SearchSpec], spec_filter_key: list[str],
+    idxs: list[int], specs: list[SearchSpec], spec_filter: list[Filter | None],
     batch_size_cfg: int | None, vt: str,
 ) -> list[FilterGroup]:
     """Group `idxs` (every spec of one vector_type, Path B only — none of
-    them unfiltered) by exact filter equality via `filter_key`, so specs
-    sharing an identical filter compact/transfer/score together once instead
-    of each redoing it."""
-    by_key: dict[str, list[int]] = {}
+    them unfiltered) by exact filter equality (`Filter`'s own hash/eq), so
+    specs sharing an identical filter compact/transfer/score together once
+    instead of each redoing it."""
+    by_filter: dict[Filter | None, list[int]] = {}
     for i in idxs:
-        by_key.setdefault(spec_filter_key[i], []).append(i)
+        by_filter.setdefault(spec_filter[i], []).append(i)
     groups = []
-    for key, members in by_key.items():
+    for filt, members in by_filter.items():
         k_floor = max(specs[m].k for m in members)
         groups.append(FilterGroup(
-            key=key,
+            filter=filt,
             member_idxs=members,
             batch_size=_path_b_group_batch_size(batch_size_cfg, k_floor, vt),
         ))
@@ -659,23 +658,23 @@ def _process_batch_group(
     return time.perf_counter() - t0
 
 
-def _path_a_select(specs: list[SearchSpec], spec_filter_key: list[str], keeps: dict[str, np.ndarray | None], device: str):
+def _path_a_select(specs: list[SearchSpec], keeps: dict[Filter | None, np.ndarray | None], device: str):
     """Path A's `select` for `_process_batch_group`: an unfiltered member uses
     the shared slice as-is; a filtered member masks it down to its own
-    filter's surviving columns, via a `local_idx` cached per filter key (in
-    the caller-provided per-slice `cache`) so two members sharing an
+    filter's surviving columns, via a `local_idx` cached per `Filter` (in
+    the caller-provided per-slice `cache`, keyed by the `Filter` object
+    itself — hashable, see its docstring) so two members sharing an
     identical filter don't recompute `nonzero` twice."""
     import torch
 
-    def select(m: int, r0: int, r1: int, rows, cache: dict[str, object]):
+    def select(m: int, r0: int, r1: int, rows, cache: dict[object, object]):
         s = specs[m]
         if s.filter is None:
             return rows, None
-        fk = spec_filter_key[m]
-        if fk not in cache:
-            local_np = np.nonzero(keeps[fk][r0:r1])[0]
-            cache[fk] = torch.from_numpy(local_np).to(device, non_blocking=True)
-        local_idx = cache[fk]
+        if s.filter not in cache:
+            local_np = np.nonzero(keeps[s.filter][r0:r1])[0]
+            cache[s.filter] = torch.from_numpy(local_np).to(device, non_blocking=True)
+        local_idx = cache[s.filter]
         if local_idx.numel() == 0:
             return None, None
         return rows[local_idx], local_idx
@@ -693,7 +692,7 @@ def _path_b_select(m: int, r0: int, r1: int, rows, cache: dict[str, object]):
 
 def _process_shared_batch(
     batch, member_idxs: list[int], specs: list[SearchSpec], spec_Q, spec_top_scores, spec_top_enc,
-    keeps: dict[str, np.ndarray | None], spec_filter_key: list[str], batch_size: int | None,
+    keeps: dict[Filter | None, np.ndarray | None], batch_size: int | None,
     gidx: int, device: str,
 ) -> float:
     """Path A: every spec of this vector_type — filtered or not — shares one
@@ -703,7 +702,7 @@ def _process_shared_batch(
     return _process_batch_group(
         batch, member_idxs, specs, spec_Q, spec_top_scores, spec_top_enc,
         batch_size, gidx, device, orig_rows=None,
-        select=_path_a_select(specs, spec_filter_key, keeps, device),
+        select=_path_a_select(specs, keeps, device),
     )
 
 
@@ -855,10 +854,8 @@ def run_compute(
     # batch`); otherwise specs are grouped by exact filter equality instead
     # (Path B, `_process_filter_group`) since there's no full-file computation
     # to derive from. See this module's docstring for the full rationale.
-    spec_filter_key = [filter_key(s.filter) for s in specs]
-    distinct_filters: dict[str, Filter | None] = {}
-    for s, fk in zip(specs, spec_filter_key):
-        distinct_filters.setdefault(fk, s.filter)
+    spec_filter = [s.filter for s in specs]
+    distinct_filters: list[Filter | None] = list(dict.fromkeys(spec_filter))
 
     vt_spec_idxs: dict[str, list[int]] = {vt: [] for vt in vts_needed}
     for i, s in enumerate(specs):
@@ -878,7 +875,7 @@ def run_compute(
                 vt, len(idxs), path_a_batch_size[vt],
             )
         else:
-            path_b_groups[vt] = _build_filter_groups(idxs, specs, spec_filter_key, vt_configured_batch[vt], vt)
+            path_b_groups[vt] = _build_filter_groups(idxs, specs, spec_filter, vt_configured_batch[vt], vt)
             logger.info(
                 "vector_type=%r: no unfiltered search — %d distinct filter group(s), "
                 "each compacting its own rows independently",
@@ -943,11 +940,12 @@ def run_compute(
             # None when id_column isn't configured. Same row order as `arrs`.
             ids = table[id_col].combine_chunks() if id_col else None
             t1 = time.perf_counter()
-            # One mask per DISTINCT filter (`None` for the unfiltered key),
+            # One mask per DISTINCT filter (`None` for the unfiltered entry),
             # evaluated against the same table — timed separately from the read
-            # above (CPU-vectorized work, not IO wait). Keyed by `filter_key` so
-            # two specs sharing an identical filter never evaluate it twice.
-            keeps = {fk: evaluate(f, table) if f is not None else None for fk, f in distinct_filters.items()}
+            # above (CPU-vectorized work, not IO wait). Keyed by the `Filter`
+            # object itself (hashable — see its docstring) so two specs
+            # sharing an identical filter never evaluate it twice.
+            keeps = {f: evaluate(f, table) if f is not None else None for f in distinct_filters}
             t2 = time.perf_counter()
             fq.put((gidx, arrs, ids, keeps, t1 - t0, t2 - t1))
 
@@ -997,7 +995,7 @@ def run_compute(
             #
             # corpus_ids is kept only for files where SOME spec could still
             # resolve a hit — i.e. it's unfiltered, or its filter keeps at least
-            # one row in this file. `keeps[fk]` is a mask over this file's rows
+            # one row in this file. `keeps[f]` is a mask over this file's rows
             # independent of vector_type (filters read payload columns, not the
             # vector columns), so checking it here — before any vector-type-
             # specific compaction below — is exact, not an approximation: a
@@ -1015,11 +1013,11 @@ def run_compute(
                 if has_baseline[vt]:
                     gpu_secs += _process_shared_batch(
                         b, vt_spec_idxs[vt], specs, spec_Q, spec_top_scores, spec_top_enc,
-                        keeps, spec_filter_key, path_a_batch_size[vt], gidx, device,
+                        keeps, path_a_batch_size[vt], gidx, device,
                     )
                 else:
                     for group in path_b_groups[vt]:
-                        keep = keeps[group.key]
+                        keep = keeps[group.filter]
                         gpu_secs += _process_filter_group(
                             b, group, specs, spec_Q, spec_top_scores, spec_top_enc, keep, gidx, device,
                         )

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -537,14 +537,13 @@ class FilterGroup:
     unfiltered, so there's no full-file score matrix to derive from, and this
     group compacts/transfers/scores its own rows once per batch instead —
     its members share the identical filter by construction, hence the
-    identical surviving row set. Carries `filter_idx`, this group's position
-    in `run_compute`'s `distinct_filters`/`keeps` (a plain list, aligned by
-    position) rather than the `Filter` object itself: the per-file loop looks
-    up `keeps[group.filter_idx]` once per file, and an `int` index costs
-    nothing to hash there, unlike re-hashing a `Filter` instance (pydantic's
-    frozen-model hash isn't cached on the instance the way `str`'s is)."""
+    identical surviving row set. Carries the `Filter` itself: the per-file
+    loop looks up `keeps[group.filter]` once per file — `Filter` is frozen
+    and hashable (see `nova_bf.config.Filter`), and a run has at most a
+    handful of distinct filters, so hashing it here costs nothing next to
+    the corpus read/GPU work this whole module exists to overlap."""
 
-    filter_idx: int
+    filter: Filter | None
     member_idxs: list[int]
     batch_size: int | None  # resolved batch size; None = whole (compacted) file
 
@@ -602,16 +601,12 @@ def _path_a_batch_size(configured: int | None, k_floor: int, vt: str) -> int | N
 
 def _build_filter_groups(
     idxs: list[int], specs: list[SearchSpec], spec_filter: list[Filter | None],
-    filter_idx: dict[Filter | None, int], batch_size_cfg: int | None, vt: str,
+    batch_size_cfg: int | None, vt: str,
 ) -> list[FilterGroup]:
     """Group `idxs` (every spec of one vector_type, Path B only — none of
     them unfiltered) by exact filter equality (`Filter`'s own hash/eq), so
     specs sharing an identical filter compact/transfer/score together once
-    instead of each redoing it. This grouping pass — unlike the resulting
-    `FilterGroup.filter_idx` — legitimately does hash every one of `idxs`'
-    filters once each; it runs only once per `run_compute` call, not once per
-    corpus file, so that cost is negligible (see `FilterGroup`'s docstring for
-    why the per-file path avoids it)."""
+    instead of each redoing it."""
     by_filter: dict[Filter | None, list[int]] = {}
     for i in idxs:
         by_filter.setdefault(spec_filter[i], []).append(i)
@@ -619,7 +614,7 @@ def _build_filter_groups(
     for filt, members in by_filter.items():
         k_floor = max(specs[m].k for m in members)
         groups.append(FilterGroup(
-            filter_idx=filter_idx[filt],
+            filter=filt,
             member_idxs=members,
             batch_size=_path_b_group_batch_size(batch_size_cfg, k_floor, vt),
         ))
@@ -705,30 +700,24 @@ def _is_unfiltered(f: Filter | None) -> bool:
 
 
 def _path_a_select(
-    specs: list[SearchSpec], spec_filter_idx: list[int], keeps: list[np.ndarray | None], device: str,
+    specs: list[SearchSpec], keeps: dict[Filter | None, np.ndarray | None], device: str,
 ):
     """Path A's `select` for `_process_batch_group`: an unfiltered member uses
     the shared slice as-is; a filtered member masks it down to its own
     filter's surviving columns, via a `local_idx` cached per filter (in the
     caller-provided per-slice `cache`) so two members sharing an identical
-    filter don't recompute `nonzero` twice. Cached and looked up by
-    `spec_filter_idx[m]` — this spec's position in `run_compute`'s
-    `distinct_filters`/`keeps` — rather than by the `Filter` object itself,
-    so this hot per-slice, per-member loop never re-hashes a `Filter`
-    instance (pydantic's frozen-model hash isn't cached on the instance the
-    way a plain `int`'s or `str`'s is)."""
+    filter don't recompute `nonzero` twice."""
     import torch
 
-    def select(m: int, r0: int, r1: int, rows, cache: dict[int, object]):
+    def select(m: int, r0: int, r1: int, rows, cache: dict[object, object]):
         s = specs[m]
         if _is_unfiltered(s.filter):
             return rows, None
-        idx = spec_filter_idx[m]
-        local_idx = cache.get(idx)
+        local_idx = cache.get(s.filter)
         if local_idx is None:
-            local_np = np.nonzero(keeps[idx][r0:r1])[0]
+            local_np = np.nonzero(keeps[s.filter][r0:r1])[0]
             local_idx = torch.from_numpy(local_np).to(device, non_blocking=True)
-            cache[idx] = local_idx
+            cache[s.filter] = local_idx
         if local_idx.numel() == 0:
             return None, None
         return rows[local_idx], local_idx
@@ -746,7 +735,7 @@ def _path_b_select(m: int, r0: int, r1: int, rows, cache: dict[object, object]):
 
 def _process_shared_batch(
     batch, member_idxs: list[int], specs: list[SearchSpec], spec_Q, spec_top_scores, spec_top_enc,
-    spec_filter_idx: list[int], keeps: list[np.ndarray | None], batch_size: int | None,
+    keeps: dict[Filter | None, np.ndarray | None], batch_size: int | None,
     gidx: int, device: str,
 ) -> float:
     """Path A: every spec of this vector_type — filtered or not — shares one
@@ -756,7 +745,7 @@ def _process_shared_batch(
     return _process_batch_group(
         batch, member_idxs, specs, spec_Q, spec_top_scores, spec_top_enc,
         batch_size, gidx, device, orig_rows=None,
-        select=_path_a_select(specs, spec_filter_idx, keeps, device),
+        select=_path_a_select(specs, keeps, device),
     )
 
 
@@ -911,14 +900,6 @@ def run_compute(
     # derive from. See this module's docstring for the full rationale.
     spec_filter = [s.filter for s in specs]
     distinct_filters: list[Filter | None] = list(dict.fromkeys(spec_filter))
-    # Filter -> its position in `distinct_filters`/`keeps` — hashes each
-    # distinct Filter exactly once, here, at run-wide setup. Every per-file,
-    # per-batch-slice lookup below (`keeps[idx]`, `_path_a_select`'s cache)
-    # then indexes by this cheap `int` instead of re-hashing a `Filter`
-    # instance (pydantic's frozen-model hash isn't cached on the instance the
-    # way a plain `int`'s or `str`'s is).
-    filter_idx: dict[Filter | None, int] = {f: i for i, f in enumerate(distinct_filters)}
-    spec_filter_idx: list[int] = [filter_idx[f] for f in spec_filter]
 
     vt_spec_idxs: dict[str, list[int]] = {vt: [] for vt in vts_needed}
     for i, s in enumerate(specs):
@@ -939,7 +920,7 @@ def run_compute(
             )
         else:
             path_b_groups[vt] = _build_filter_groups(
-                idxs, specs, spec_filter, filter_idx, vt_configured_batch[vt], vt,
+                idxs, specs, spec_filter, vt_configured_batch[vt], vt,
             )
             logger.info(
                 "vector_type=%r: no unfiltered search — %d distinct filter group(s), "
@@ -1020,12 +1001,10 @@ def run_compute(
                 t1 = time.perf_counter()
                 # One mask per DISTINCT filter (`None` for the unfiltered entry),
                 # evaluated against the same table — timed separately from the read
-                # above (CPU-vectorized work, not IO wait). A plain list, aligned by
-                # position with `distinct_filters`/`filter_idx` (not a dict keyed by
-                # the `Filter` object itself) so two specs sharing an identical
-                # filter never evaluate it twice, AND this per-file construction
-                # never hashes a `Filter` instance (see `FilterGroup`'s docstring).
-                keeps = [evaluate(f, table) if f is not None else None for f in distinct_filters]
+                # above (CPU-vectorized work, not IO wait). Keyed by the `Filter`
+                # object itself (frozen, hashable — see `nova_bf.config.Filter`)
+                # so two specs sharing an identical filter never evaluate it twice.
+                keeps = {f: (evaluate(f, table) if f is not None else None) for f in distinct_filters}
                 t2 = time.perf_counter()
                 fq.put((gidx, arrs, ids, keeps, t1 - t0, t2 - t1))
             except Exception as exc:
@@ -1102,7 +1081,7 @@ def run_compute(
             # file must never block a DIFFERENT spec's id resolution for that
             # same file, but a file every spec's filter drops needs no ids
             # kept at all.
-            if id_col and any(mask is None or mask.any() for mask in keeps):
+            if id_col and any(mask is None or mask.any() for mask in keeps.values()):
                 corpus_ids[gidx] = ids
             for vt in vts_needed:
                 rows_seen += batches[vt].n_rows
@@ -1113,11 +1092,11 @@ def run_compute(
                 if has_baseline[vt]:
                     gpu_secs += _process_shared_batch(
                         b, vt_spec_idxs[vt], specs, spec_Q, spec_top_scores, spec_top_enc,
-                        spec_filter_idx, keeps, path_a_batch_size[vt], gidx, device,
+                        keeps, path_a_batch_size[vt], gidx, device,
                     )
                 else:
                     for group in path_b_groups[vt]:
-                        keep = keeps[group.filter_idx]
+                        keep = keeps[group.filter]
                         gpu_secs += _process_filter_group(
                             b, group, specs, spec_Q, spec_top_scores, spec_top_enc, keep, gidx, device,
                         )

--- a/python/nova-bf/src/nova_bf/config.py
+++ b/python/nova-bf/src/nova_bf/config.py
@@ -12,11 +12,8 @@
 
 from __future__ import annotations
 
-import json
-import math
 import re
 
-from fractions import Fraction
 from typing import Literal
 
 import yaml
@@ -164,9 +161,16 @@ MatchValue = str | int | float | bool
 
 
 class RangeCondition(BaseModel):
-    """Numeric bounds, combinable like Qdrant's Range (e.g. `gte` + `lt` together)."""
+    """Numeric bounds, combinable like Qdrant's Range (e.g. `gte` + `lt` together).
 
-    model_config = ConfigDict(extra="forbid")
+    Frozen: makes this — and, transitively, `FilterCondition`/`Filter`, which
+    contain it — hashable via pydantic's auto-generated `__hash__` (a tuple of
+    field values), so a `Filter` can be used directly as a dict key wherever
+    specs need grouping/deduping by identical filter (see compute.py). Also
+    enforces the invariant that a `Filter` is never mutated after grouping,
+    previously just assumed."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     gt: float | None = None
     gte: float | None = None
@@ -187,13 +191,17 @@ class FilterCondition(BaseModel):
     MatchAny). Exactly one of `match`/`range` must be set.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     # The corpus column this condition reads and matches against — this is the
     # only place a filtered field is named; nothing else needs to declare it,
     # so `compute` reads exactly (and only) the columns the filter references.
     field: str
-    match: MatchValue | list[MatchValue] | None = None
+    # tuple, not list: lists aren't hashable, and this needs to be for Filter
+    # (which contains this) to be usable as a dict key — see RangeCondition's
+    # docstring. Pydantic coerces a YAML/list literal (`match: [1, 2, 3]`)
+    # into a tuple automatically at validation time.
+    match: MatchValue | tuple[MatchValue, ...] | None = None
     range: RangeCondition | None = None
 
     @model_validator(mode="after")
@@ -211,88 +219,35 @@ class Filter(BaseModel):
     Restricts which corpus points are eligible neighbors for every query in the
     run — it does not touch queries themselves, same as a Qdrant search filter.
     `must` = AND, `should` = OR-at-least-one, `must_not` = AND-NOT.
+
+    Frozen and hashable (see `RangeCondition`'s docstring) — usable directly
+    as a dict key wherever specs need grouping/deduping by identical filter
+    (see compute.py's `spec_filter`/`FilterGroup.filter`/`keeps`), via
+    pydantic's own `__eq__`/`__hash__`, with no separate canonicalization
+    scheme needed: two `Filter`s are "the same" iff Python's own `==` says so,
+    which for `int`/`float`/`nan`/`inf` `match` values already has exactly the
+    right semantics (`5 == 5.0`, no precision loss for large ints, `nan`
+    never equal to itself, `inf`/`-inf` equal to themselves by sign).
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     # The one place the three condition-group names are listed — `fields()`
-    # and `filter_key()` both walk them via this, not their own hardcoded
-    # tuple, so a future group added here can't update one and silently miss
-    # the other (which would let two filters differing only in that group
-    # collide as "the same" wherever the missed one is used).
+    # walks them via this, not its own hardcoded tuple, so a future group
+    # added here can't be missed by `fields()`.
     _CONDITION_GROUPS = ("must", "should", "must_not")
 
-    must: list[FilterCondition] = []
-    should: list[FilterCondition] = []
-    must_not: list[FilterCondition] = []
+    # tuple, not list: needed for this model to be hashable (see
+    # RangeCondition's docstring). Pydantic coerces a YAML/list literal
+    # (`must: [...]`) into a tuple automatically at validation time.
+    must: tuple[FilterCondition, ...] = ()
+    should: tuple[FilterCondition, ...] = ()
+    must_not: tuple[FilterCondition, ...] = ()
 
     def fields(self) -> set[str]:
         return {
             c.field for group in self._CONDITION_GROUPS for c in getattr(self, group)
         }
-
-
-def _canonical_match(value: MatchValue | list[MatchValue]) -> object:
-    """`match` values that Python treats as equal (`5 == 5.0`, which is what
-    `Filter`'s own by-value equality relies on) must produce the same key —
-    plain JSON text doesn't guarantee that on its own (`5` and `5.0` serialize
-    to different text, e.g. from a YAML author writing one search's filter
-    with an int literal and another's with a float literal).
-
-    Deliberately `Fraction`, not `float(value)`: Python's own `int == float`
-    comparison is exact (no precision loss), but `float(value)` on a large
-    int is NOT — `float(2**53) == float(2**53 + 1)` (both round to the same
-    float64), so two DIFFERENT filters would collide onto the same key,
-    silently merging their masks (see the regression this guards against —
-    a filter on a large payload value, e.g. a nanosecond timestamp or a
-    snowflake id, both common in the ~1e18 range where float64 precision
-    runs out). `Fraction` represents any Python `int` or `float` exactly (a
-    float is itself an exact binary fraction — `Fraction(x)` never rounds),
-    so two values compare equal here iff they're actually equal, matching
-    `Filter.__eq__` exactly instead of approximately. `bool`/`str` pass
-    through unchanged (`bool` is technically an `int` subclass, but
-    conflating `match: true` with `match: 1` isn't the case this guards
-    against, so it's left alone).
-
-    `nan`/`inf` are handled separately because `Fraction` can't represent
-    them at all (`Fraction(float("nan"))` raises `ValueError`, `Fraction(float("inf"))`
-    raises `OverflowError` — both are legal YAML/pydantic `match` values, so
-    this must never crash `run_compute` outright, the way it did before this
-    special case existed). `inf`/`-inf` compare equal to themselves under
-    Python's own `==` (what `Filter.__eq__` relies on), so they canonicalize
-    to a stable sentinel by sign. `nan` is the opposite — `nan != nan`, even
-    against itself — so no two `nan` match values are ever "the same filter"
-    either; a fresh sentinel per call guarantees this key never collides
-    with anything, matching that never-equal-to-itself semantics exactly."""
-    if isinstance(value, list):
-        return [_canonical_match(v) for v in value]
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, float) and math.isnan(value):
-        return f"__nan_{id(value)}__"
-    if isinstance(value, float) and math.isinf(value):
-        return "+inf" if value > 0 else "-inf"
-    if isinstance(value, (int, float)):
-        frac = Fraction(value)
-        return [frac.numerator, frac.denominator]
-    return value
-
-
-def filter_key(f: Filter | None) -> str:
-    """Canonical, hashable key for a filter — `"none"` for no filter, else a
-    JSON dump of its fields (with `match` values canonicalized, see
-    `_canonical_match`). Two specs are considered "the same filter" iff this
-    key matches, which is order-sensitive (a `must` list reordered in YAML is
-    a different key) — same as `Filter`'s own by-value equality, just usable
-    as a real dict key instead of a linear `==` scan."""
-    if f is None:
-        return "none"
-    dumped = f.model_dump()
-    for group in ("must", "should", "must_not"):
-        for cond in dumped[group]:
-            if cond.get("match") is not None:
-                cond["match"] = _canonical_match(cond["match"])
-    return json.dumps(dumped, sort_keys=True)
 
 
 class SearchSpec(BaseModel):

--- a/python/nova-bf/src/nova_bf/config.py
+++ b/python/nova-bf/src/nova_bf/config.py
@@ -12,13 +12,16 @@
 
 from __future__ import annotations
 
+import json
+import math
 import re
 
+from fractions import Fraction
 from typing import Literal
 
 import yaml
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 import os
 
@@ -116,6 +119,25 @@ class ParamsConfig(BaseModel):
     # pool-bound; if it stays flat you're network-bound. Applied via
     # pa.set_io_thread_count() once at startup.
     io_thread_count: int = 0
+    # Bounds the per-file score matrix (`queries × rows`) for dense/sparse
+    # searches respectively — a big file (or large query set) can otherwise
+    # OOM the GPU; set this to score in row-batches instead of the whole file
+    # at once. None (default) = whole file in one matmul. Lives here (one
+    # value per vector_type, run-wide) rather than per-search: every search of
+    # a given vector_type ends up sharing one GPU pass over the corpus anyway
+    # (see compute.py), so a per-search value would just be resolved down to
+    # this same shared number regardless — this makes that explicit instead of
+    # implicit. Values below a search's own `k` are raised to `k` (a batch
+    # smaller than `k` can't fill that search's top-K and gives no memory
+    # benefit).
+    # `gt=0`: a batch size of 0 or negative isn't just useless, it's actively
+    # wrong — `range(0, n_rows, step)` with a non-positive `step` is EMPTY, so
+    # every file's batch loop would silently skip all rows, no exception, no
+    # partial results, just an empty top-K for every query. Reject it here at
+    # config-load time (the system boundary) rather than let it manifest as a
+    # silent all-empty run downstream.
+    dense_batch_size: int | None = Field(default=None, gt=0)
+    sparse_batch_size: int | None = Field(default=None, gt=0)
     # `merge` reduces the W per-rank partials in row-batches of this many queries,
     # streaming the result to disk so the full output never sits in RAM (that's what
     # let the old merge OOM at 1M queries). Peak host memory is ~(this × W × k)
@@ -193,22 +215,95 @@ class Filter(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    # The one place the three condition-group names are listed — `fields()`
+    # and `filter_key()` both walk them via this, not their own hardcoded
+    # tuple, so a future group added here can't update one and silently miss
+    # the other (which would let two filters differing only in that group
+    # collide as "the same" wherever the missed one is used).
+    _CONDITION_GROUPS = ("must", "should", "must_not")
+
     must: list[FilterCondition] = []
     should: list[FilterCondition] = []
     must_not: list[FilterCondition] = []
 
     def fields(self) -> set[str]:
-        return {c.field for group in (self.must, self.should, self.must_not) for c in group}
+        return {
+            c.field for group in self._CONDITION_GROUPS for c in getattr(self, group)
+        }
+
+
+def _canonical_match(value: MatchValue | list[MatchValue]) -> object:
+    """`match` values that Python treats as equal (`5 == 5.0`, which is what
+    `Filter`'s own by-value equality relies on) must produce the same key —
+    plain JSON text doesn't guarantee that on its own (`5` and `5.0` serialize
+    to different text, e.g. from a YAML author writing one search's filter
+    with an int literal and another's with a float literal).
+
+    Deliberately `Fraction`, not `float(value)`: Python's own `int == float`
+    comparison is exact (no precision loss), but `float(value)` on a large
+    int is NOT — `float(2**53) == float(2**53 + 1)` (both round to the same
+    float64), so two DIFFERENT filters would collide onto the same key,
+    silently merging their masks (see the regression this guards against —
+    a filter on a large payload value, e.g. a nanosecond timestamp or a
+    snowflake id, both common in the ~1e18 range where float64 precision
+    runs out). `Fraction` represents any Python `int` or `float` exactly (a
+    float is itself an exact binary fraction — `Fraction(x)` never rounds),
+    so two values compare equal here iff they're actually equal, matching
+    `Filter.__eq__` exactly instead of approximately. `bool`/`str` pass
+    through unchanged (`bool` is technically an `int` subclass, but
+    conflating `match: true` with `match: 1` isn't the case this guards
+    against, so it's left alone).
+
+    `nan`/`inf` are handled separately because `Fraction` can't represent
+    them at all (`Fraction(float("nan"))` raises `ValueError`, `Fraction(float("inf"))`
+    raises `OverflowError` — both are legal YAML/pydantic `match` values, so
+    this must never crash `run_compute` outright, the way it did before this
+    special case existed). `inf`/`-inf` compare equal to themselves under
+    Python's own `==` (what `Filter.__eq__` relies on), so they canonicalize
+    to a stable sentinel by sign. `nan` is the opposite — `nan != nan`, even
+    against itself — so no two `nan` match values are ever "the same filter"
+    either; a fresh sentinel per call guarantees this key never collides
+    with anything, matching that never-equal-to-itself semantics exactly."""
+    if isinstance(value, list):
+        return [_canonical_match(v) for v in value]
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float) and math.isnan(value):
+        return f"__nan_{id(value)}__"
+    if isinstance(value, float) and math.isinf(value):
+        return "+inf" if value > 0 else "-inf"
+    if isinstance(value, (int, float)):
+        frac = Fraction(value)
+        return [frac.numerator, frac.denominator]
+    return value
+
+
+def filter_key(f: Filter | None) -> str:
+    """Canonical, hashable key for a filter — `"none"` for no filter, else a
+    JSON dump of its fields (with `match` values canonicalized, see
+    `_canonical_match`). Two specs are considered "the same filter" iff this
+    key matches, which is order-sensitive (a `must` list reordered in YAML is
+    a different key) — same as `Filter`'s own by-value equality, just usable
+    as a real dict key instead of a linear `==` scan."""
+    if f is None:
+        return "none"
+    dumped = f.model_dump()
+    for group in ("must", "should", "must_not"):
+        for cond in dumped[group]:
+            if cond.get("match") is not None:
+                cond["match"] = _canonical_match(cond["match"])
+    return json.dumps(dumped, sort_keys=True)
 
 
 class SearchSpec(BaseModel):
     """One independent top-K search to compute in a `nova-bf compute` run —
-    its own vector_type, metric, k, corpus_batch_size and (optional) filter,
-    scored and top-K'd independently of every other spec in
-    `BruteForceConfig.searches` (NOT fused into one hybrid score). Multiple
-    specs sharing a run still share corpus file IO/decode (see compute.py) —
-    that sharing is the whole point of listing several here instead of
-    running `nova-bf compute` once per spec.
+    its own vector_type, metric, k, and (optional) filter, scored and top-K'd
+    independently of every other spec in `BruteForceConfig.searches` (NOT
+    fused into one hybrid score). Multiple specs sharing a run still share
+    corpus file IO/decode (see compute.py) — that sharing is the whole point
+    of listing several here instead of running `nova-bf compute` once per
+    spec. GPU batching (`params.dense_batch_size`/`sparse_batch_size`) is a
+    run-level knob, not a per-search one — see `ParamsConfig`.
 
     `name` becomes part of the output filename (see `nova_bf.results`), so
     every spec in a run needs a distinct one.
@@ -220,7 +315,6 @@ class SearchSpec(BaseModel):
     k: int = 1000
     metric: Literal["cosine", "dot", "euclidean"] = "cosine"
     vector_type: Literal["dense", "sparse"] = "dense"
-    corpus_batch_size: int | None = None
     filter: Filter | None = None
 
     @model_validator(mode="after")

--- a/python/nova-bf/src/nova_bf/filters.py
+++ b/python/nova-bf/src/nova_bf/filters.py
@@ -19,7 +19,7 @@ from nova_bf.config import Filter, FilterCondition
 def _condition_mask(cond: FilterCondition, table: pa.Table) -> np.ndarray:
     col = table[cond.field]
     if cond.match is not None:
-        values = cond.match if isinstance(cond.match, list) else [cond.match]
+        values = cond.match if isinstance(cond.match, tuple) else [cond.match]
         mask = pc.is_in(col, value_set=pa.array(values))
     else:
         r = cond.range

--- a/python/nova-bf/src/nova_bf/merge.py
+++ b/python/nova-bf/src/nova_bf/merge.py
@@ -188,6 +188,26 @@ def run_merge(cfg: BruteForceConfig) -> dict[str, str]:
             )
         partials_by_name[spec.name] = partials
 
+    # Every search in one `compute` run is written by the SAME set of ranks
+    # (each rank writes one partial per search, back to back, in a single
+    # invocation) — so with more than one search, every search must end up
+    # with the identical partial COUNT. A mismatch means some rank died
+    # partway through writing its per-search partials (crash/OOM/preemption
+    # between two of its writes), silently leaving one search's merge short
+    # a rank's worth of candidates with no other signal. Catch it here,
+    # before reducing, rather than let it manifest as a suspiciously-low
+    # top-K for just that search.
+    if len(partials_by_name) > 1:
+        counts = {name: len(partials) for name, partials in partials_by_name.items()}
+        if len(set(counts.values())) > 1:
+            raise RuntimeError(
+                f"searches have mismatched partial counts: {counts} — every search in "
+                "one `compute` run should have the same number of per-rank partials; "
+                "this points to a rank that died partway through writing its per-search "
+                "outputs (crash/OOM/preemption). Re-run the missing rank(s) with "
+                "`bf compute --num-jobs N --job-rank R` before merging."
+            )
+
     staged_dirs: list[str] = []
     readers_by_name: dict[str, list[pq.ParquetFile]] = {}
     try:

--- a/python/nova-bf/tests/test_compute.py
+++ b/python/nova-bf/tests/test_compute.py
@@ -2,9 +2,9 @@
 
 Exercises the GPU topk path on CPU (small synthetic corpus + queries), covering
 the two pieces most prone to silent corruption:
-  - corpus_batch_size tiling: must yield the *same* top-K as scoring the whole
-    file at once (the `gidx * MAX_ROWS_PER_FILE + row` encoding uses file-local
-    row offsets, so an off-by-a-batch bug would scramble hit ids), and
+  - params.dense_batch_size tiling: must yield the *same* top-K as scoring the
+    whole file at once (the `gidx * MAX_ROWS_PER_FILE + row` encoding uses
+    file-local row offsets, so an off-by-a-batch bug would scramble hit ids), and
   - id resolution: hit_ids come from `corpus.id_column` when set (a real,
     pre-existing identifier) and from `make_point_id(file_key, row)` otherwise.
 """
@@ -106,8 +106,8 @@ def _run(ds, *, batch, id_column, out_name, filt=None):
         corpus=CorpusConfig(path=ds["cdir"], dense_column="dense_embedding", id_column=id_column),
         queries=QueriesConfig(path=ds["qpath"], dense_column="dense_embedding", id_column="qid"),
         output=OutputConfig(path=str(out)),
-        params=ParamsConfig(io_workers=2),
-        searches=[SearchSpec(name="test", k=K, metric="dot", corpus_batch_size=batch, filter=filt)],
+        params=ParamsConfig(io_workers=2, dense_batch_size=batch),
+        searches=[SearchSpec(name="test", k=K, metric="dot", filter=filt)],
     )
     t = pq.read_table(run_compute(cfg)["test"]).to_pydict()
     return {q: list(zip(hi, hs)) for q, hi, hs in zip(t["query_id"], t["hit_ids"], t["hit_scores"])}
@@ -194,8 +194,8 @@ def test_filter_range_condition(ds):
 @pytest.mark.parametrize("batch", [None, K])
 def test_filter_preserves_row_numbers_under_batching(ds, batch):
     """A filter must resolve the same (correct) point ids whether or not
-    corpus_batch_size tiles the file — the bug this guards against is filtering
-    renumbering rows instead of keeping their true file-row number."""
+    params.dense_batch_size tiles the file — the bug this guards against is
+    filtering renumbering rows instead of keeping their true file-row number."""
     filt = Filter(must=[FilterCondition(field="language", match="eng")])
     res = _run(ds, batch=batch, id_column=None, out_name=f"filter_defid_{batch}", filt=filt)
     eng_globals = [g for g, lang in enumerate(ds["lang_by_g"]) if lang == "eng"]

--- a/python/nova-bf/tests/test_compute.py
+++ b/python/nova-bf/tests/test_compute.py
@@ -220,3 +220,15 @@ def test_filter_timing_is_reported_only_when_filtering(ds, caplog):
         _run(ds, batch=None, id_column="id", out_name="filter_timing_off")
     assert not any("filter eval" in r.message for r in caplog.records)
     assert any("filter_s=0.0" in r.message for r in caplog.records)  # stable bf-bench schema
+
+
+def test_bad_filter_field_raises_instead_of_hanging(ds):
+    """A filter referencing a column absent from the corpus schema makes
+    `evaluate()` raise inside a reader thread — this must surface as a clear
+    exception in the main thread, not hang forever (an uncaught exception in
+    a daemon thread silently kills it, and the consumer's fixed-count
+    `fq.get()` loop would otherwise block waiting for an item that never
+    arrives)."""
+    filt = Filter(must=[FilterCondition(field="no_such_column", match="eng")])
+    with pytest.raises(RuntimeError, match="reader thread failed"):
+        _run(ds, batch=None, id_column="id", out_name="filter_bad_field", filt=filt)

--- a/python/nova-bf/tests/test_compute.py
+++ b/python/nova-bf/tests/test_compute.py
@@ -232,3 +232,33 @@ def test_bad_filter_field_raises_instead_of_hanging(ds):
     filt = Filter(must=[FilterCondition(field="no_such_column", match="eng")])
     with pytest.raises(RuntimeError, match="reader thread failed"):
         _run(ds, batch=None, id_column="id", out_name="filter_bad_field", filt=filt)
+
+
+def test_next_in_order_reorders_scrambled_arrivals():
+    """Regression test: reader threads can finish corpus files in any order,
+    but `_next_in_order` must always hand the consumer files back in a
+    fixed, deterministic order (ascending `gidx`) — otherwise which of
+    several EXACTLY tied candidates wins a spot in the top-K merge varies
+    nondeterministically run to run, even for the identical corpus and
+    queries (see `run_compute`'s consumer loop)."""
+    from nova_bf.compute import _next_in_order
+
+    # Arrives scrambled: 2, 0, 3, 1 — must still be consumable in order 0, 1, 2, 3.
+    arrivals = iter([(2, "b"), (0, "a"), (3, "d"), (1, "c")])
+    pending: dict = {}
+    results = [_next_in_order(g, pending, lambda: next(arrivals)) for g in [0, 1, 2, 3]]
+    assert results == [(0, "a"), (1, "c"), (2, "b"), (3, "d")]
+    assert pending == {}  # every buffered arrival was eventually consumed
+
+
+def test_next_in_order_reraises_from_fetch():
+    """`fetch` raising (e.g. the consumer's `_fetch_or_raise` re-raising a
+    reader thread's forwarded exception) must propagate straight through,
+    not get silently swallowed while waiting for `want_gidx`'s turn."""
+    from nova_bf.compute import _next_in_order
+
+    def fetch():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _next_in_order(0, {}, fetch)

--- a/python/nova-bf/tests/test_compute_multi.py
+++ b/python/nova-bf/tests/test_compute_multi.py
@@ -1,10 +1,18 @@
 """Correctness tests for `BruteForceConfig.searches` — running several
 independent top-K searches (dense/sparse x filtered/unfiltered) against the
 SAME corpus in one `run_compute`/`run_merge` call, sharing corpus file IO and
-per-vector-type decode across specs, with specs sharing the same
-vector_type+filter further sharing filter evaluation, row compaction, and GPU
-transfer/CSR build (see compute.py's `SpecGroup`) — only each search's own
-scoring and top-K stay independent.
+per-vector-type decode across specs. Per vector_type, searches additionally
+share GPU work one of two ways (see compute.py's module docstring):
+
+- Path A (`_process_shared_batch`): if ANY search of that vector_type is
+  unfiltered, every search of that vector_type shares one full-file batch
+  pass — a filtered search's own `metric` never needs to match anyone
+  else's, since scoring one more metric on an already-resident batch is
+  cheap.
+- Path B (`_process_filter_group`): otherwise, searches are grouped by exact
+  filter equality and each such group compacts its own rows independently.
+
+Only each search's own scoring and top-K stay independent either way.
 
 Ground truth for each spec is computed independently in plain numpy (not by
 re-deriving nova_bf's own scoring), mirroring test_compute.py/
@@ -12,6 +20,8 @@ test_compute_sparse.py's pattern.
 """
 
 from __future__ import annotations
+
+import logging
 
 import numpy as np
 import pytest
@@ -137,13 +147,14 @@ def test_multi_spec_matches_independent_ground_truth(ds):
     specs = [
         SearchSpec(name="dense_all", vector_type="dense", metric="dot", k=3),
         SearchSpec(name="dense_eng", vector_type="dense", metric="dot", k=2, filter=eng_filter),
-        SearchSpec(name="sparse_all", vector_type="sparse", metric="dot", k=3, corpus_batch_size=2),
+        SearchSpec(name="sparse_all", vector_type="sparse", metric="dot", k=3),
         SearchSpec(name="sparse_eng", vector_type="sparse", metric="dot", k=2, filter=eng_filter),
     ]
     cfg = BruteForceConfig(
         corpus=CorpusConfig(path=ds["cdir"], id_column="id"),
         queries=QueriesConfig(path=ds["qpath"], id_column="qid"),
         output=OutputConfig(path=_out(ds, "multi_out")),
+        params=ParamsConfig(sparse_batch_size=2),
         searches=specs,
     )
     paths = run_compute(cfg)
@@ -164,24 +175,24 @@ def test_multi_spec_matches_independent_ground_truth(ds):
 
 
 def test_grouped_matches_ungrouped_per_search(ds):
-    """The core regression guard for SpecGroup: running several searches
-    together (several of which share the same vector_type+filter, so they
-    land in the same SpecGroup and share GPU transfer/CSR build) must produce
-    results BIT-IDENTICAL to running each of those same searches alone, one
-    per `run_compute` call. Covers dense+sparse, and — for dense — all three
-    metrics (cosine/dot/euclidean) sharing one group, since dense cosine/dot/
-    euclidean all read the SAME shared, un-normalized `Cb` (see `_scores`)."""
+    """The core regression guard for shared-batch processing: running several
+    searches together must produce results BIT-IDENTICAL to running each of
+    those same searches alone, one per `run_compute` call. Covers dense+
+    sparse, all three dense metrics (cosine/dot/euclidean) sharing the SAME
+    unfiltered pass (Path A — see `_scores`), and a filtered dense search
+    (`dense_eng`) riding that same pass alongside them."""
     eng_filter = Filter(must=[FilterCondition(field="language", match="eng")])
     specs = [
-        # group: (dense, filter=None) — 3 members, all 3 metrics
+        # dense: 3 unfiltered members (all 3 metrics) -> Path A baseline
         SearchSpec(name="dense_dot", vector_type="dense", metric="dot", k=3),
         SearchSpec(name="dense_cos", vector_type="dense", metric="cosine", k=2),
         SearchSpec(name="dense_euclid", vector_type="dense", metric="euclidean", k=2),
-        # group: (dense, eng_filter) — 1 member (distinct group from the above)
+        # dense: filtered, but an unfiltered dense sibling exists above -> also
+        # rides Path A (masked down to its own filter), not processed alone
         SearchSpec(name="dense_eng", vector_type="dense", metric="dot", k=2, filter=eng_filter),
-        # group: (sparse, filter=None) — 2 members, mixed metrics (the
-        # restructured path — see test_three_member_group_mixed_metrics for
-        # a 3-member version with independently-verified ground truth)
+        # sparse: 2 unfiltered members, mixed metrics — Path A again (the
+        # shared-metric-cache path; see test_three_member_group_mixed_metrics
+        # for a 3-member version with independently-verified ground truth)
         SearchSpec(name="sparse_dot", vector_type="sparse", metric="dot", k=3),
         SearchSpec(name="sparse_cos", vector_type="sparse", metric="cosine", k=2),
     ]
@@ -211,8 +222,8 @@ def test_grouped_matches_ungrouped_per_search(ds):
 
 
 def test_three_member_group_mixed_metrics(tmp_path):
-    """One SpecGroup (same vector_type=sparse, both unfiltered) with THREE
-    members: two `cosine`, one `dot` — directly targets the two riskiest new
+    """One Path A shared batch (vector_type=sparse, all three unfiltered) with
+    THREE members: two `cosine`, one `dot` — directly targets the two riskiest
     bug classes from grouping sparse searches: double-normalization (a cosine
     member's score divided by row_norms twice) and cross-member contamination
     (one member reading another's scores). Verified against independently
@@ -266,46 +277,86 @@ def test_three_member_group_mixed_metrics(tmp_path):
             assert cos[cid] == pytest.approx(expected, abs=1e-4), f"search={name} id={cid}"
 
 
-def test_group_specs_batch_size_floors_at_group_max_k():
-    """Unit test for `_merge_batch_size`/`_group_specs`: a group's resolved
-    batch size must never fall below the largest `k` among its members, even
-    when a different, lower-k member explicitly requests a smaller
-    `corpus_batch_size` — mirrors the existing single-spec floor (a batch
-    smaller than k can't fill the top-K and gives no memory benefit) at group
-    granularity."""
-    specs = [
-        SearchSpec(name="big_k_wholefile", vector_type="dense", metric="dot", k=100),
-        SearchSpec(name="small_k_tiny_batch", vector_type="dense", metric="dot", k=5, corpus_batch_size=10),
-    ]
-    # spec_batch mirrors what run_compute's setup loop resolves per spec BEFORE
-    # grouping (each spec's own corpus_batch_size, already floored to its own
-    # k) — neither is below its OWN k here, so this is each spec's
-    # corpus_batch_size verbatim.
-    spec_batch = [None, 10]
-    groups = compute_mod._group_specs(specs, spec_batch)
-    assert len(groups) == 1  # same vector_type, both unfiltered -> one group
-    assert groups[0].batch_size == 100  # min(10) floored at max(k)=100, NOT 10
+def test_path_b_group_batch_size_raises_to_k_floor():
+    """Unit test for `_path_b_group_batch_size` — `k_floor` is scoped to one
+    `FilterGroup`'s own (related) members: a configured batch below that
+    floor is raised to it, never left below — the extra merge rounds below
+    `k` buy nothing since the group's own memory footprint is unaffected
+    either way."""
+    assert compute_mod._path_b_group_batch_size(10, k_floor=100, vt="dense") == 100
+    assert compute_mod._path_b_group_batch_size(500, k_floor=100, vt="dense") == 500
+    assert compute_mod._path_b_group_batch_size(None, k_floor=100, vt="dense") is None
 
 
-def test_group_batch_size_floor_end_to_end_still_correct(ds):
-    """End-to-end companion to the unit test above: a member requesting a
-    tiny `corpus_batch_size` sharing a group with a higher-`k` member must
-    still produce correct, ground-truth-matching results for BOTH members —
-    the floor changes only memory/perf, never correctness."""
+def test_path_a_batch_size_respects_configured_value():
+    """Unit test for `_path_a_batch_size` — `k_floor` spans EVERY search of a
+    vector_type, related or not. Raising it here would let one search's
+    large `k` silently blow past a DIFFERENT search's own memory bound, so a
+    configured value is never overridden — only warned about — even when
+    it's below `k_floor`."""
+    assert compute_mod._path_a_batch_size(10, k_floor=100, vt="dense") == 10
+    assert compute_mod._path_a_batch_size(500, k_floor=100, vt="dense") == 500
+    assert compute_mod._path_a_batch_size(None, k_floor=100, vt="dense") is None
+
+
+def test_batch_size_floor_end_to_end_still_correct(ds):
+    """End-to-end companion to the unit tests above: a tiny `params.
+    dense_batch_size` shared by a low-k and a high-k search (both unfiltered
+    -> Path A, so the configured value is kept rather than raised — see
+    test_path_a_batch_size_respects_configured_value) must still produce
+    correct, ground-truth-matching results for BOTH — an under-filled batch
+    means more merge rounds, never a wrong answer."""
     specs = [
-        SearchSpec(name="low_k_tiny_batch", vector_type="dense", metric="dot", k=2, corpus_batch_size=1),
+        SearchSpec(name="low_k", vector_type="dense", metric="dot", k=2),
         SearchSpec(name="high_k", vector_type="dense", metric="dot", k=5),
     ]
     cfg = BruteForceConfig(
         corpus=CorpusConfig(path=ds["cdir"], id_column="id"),
         queries=QueriesConfig(path=ds["qpath"], id_column="qid"),
         output=OutputConfig(path=_out(ds, "batch_floor_out")),
+        params=ParamsConfig(dense_batch_size=1),  # NOT raised to 5 — Path A keeps it at 1
         searches=specs,
     )
     paths = run_compute(cfg)
     expectations = {
-        "low_k_tiny_batch": ds["ground_truth"]("dense", 2),
+        "low_k": ds["ground_truth"]("dense", 2),
         "high_k": ds["ground_truth"]("dense", 5),
+    }
+    for name, expected in expectations.items():
+        t = pq.read_table(paths[name]).to_pydict()
+        got = {q: hi for q, hi in zip(t["query_id"], t["hit_ids"])}
+        for q in ds["qids"]:
+            assert got[q] == expected[q], f"search={name} query={q}"
+
+
+def test_unrelated_large_k_filtered_spec_does_not_inflate_shared_path_a_batch(ds, caplog):
+    """Regression test: under Path A, an unfiltered spec's own configured
+    `dense_batch_size` must not be silently widened just because a DIFFERENT,
+    filtered spec sharing the same vector_type has a much larger `k` — that
+    would defeat the memory bound the batch size exists to enforce. Both
+    specs must still produce correct results; only the log should note the
+    larger-k search needs extra merge rounds, not raise the resolved batch."""
+    eng_filter = Filter(must=[FilterCondition(field="language", match="eng")])
+    specs = [
+        SearchSpec(name="dense_all_smallk", vector_type="dense", metric="dot", k=2),
+        SearchSpec(name="dense_eng_bigk", vector_type="dense", metric="dot", k=1000, filter=eng_filter),
+    ]
+    cfg = BruteForceConfig(
+        corpus=CorpusConfig(path=ds["cdir"], id_column="id"),
+        queries=QueriesConfig(path=ds["qpath"], id_column="qid"),
+        output=OutputConfig(path=_out(ds, "no_inflate_out")),
+        params=ParamsConfig(dense_batch_size=1),
+        searches=specs,
+    )
+    with caplog.at_level(logging.INFO, logger="nova_bf.compute"):
+        paths = run_compute(cfg)
+    assert any("batch_size=1)" in r.message for r in caplog.records), "batch size must stay at the configured 1, not be raised to k=1000"
+    assert not any("raising to k" in r.message for r in caplog.records), "Path A must never force-raise a configured batch size"
+
+    eng_globals = [g for g, lang in enumerate(ds["lang_by_g"]) if lang == "eng"]
+    expectations = {
+        "dense_all_smallk": ds["ground_truth"]("dense", 2),
+        "dense_eng_bigk": ds["ground_truth"]("dense", 1000, allowed=eng_globals),
     }
     for name, expected in expectations.items():
         t = pq.read_table(paths[name]).to_pydict()
@@ -360,6 +411,172 @@ def test_sparse_dot_spec_not_corrupted_by_coscheduled_cosine_spec(tmp_path):
     # both corpus rows are the same unit direction as the query -> cosine ~1.0 for both
     assert cos_scores["c0"] == pytest.approx(1.0, abs=1e-4)
     assert cos_scores["c1"] == pytest.approx(1.0, abs=1e-4)
+
+
+def test_filtered_spec_metric_not_used_by_baseline_still_shares_batch(ds):
+    """Locks in the design decision that dropped the old "metrics must be a
+    subset of the baseline's" precondition: `dense_eng` here is `cosine`, but
+    the only unfiltered dense sibling (`dense_all`) is `dot` — under the old
+    SpecGroup/borrower model this metric mismatch would have forced
+    `dense_eng` into fully independent processing; now it still rides the
+    shared Path A batch (computing one more metric — `cosine` — on the
+    already-resident batch is cheap), and must produce results BIT-IDENTICAL
+    to running it alone."""
+    eng_filter = Filter(must=[FilterCondition(field="language", match="eng")])
+    specs = [
+        SearchSpec(name="dense_all", vector_type="dense", metric="dot", k=3),
+        SearchSpec(name="dense_eng", vector_type="dense", metric="cosine", k=2, filter=eng_filter),
+    ]
+    combined_cfg = BruteForceConfig(
+        corpus=CorpusConfig(path=ds["cdir"], id_column="id"),
+        queries=QueriesConfig(path=ds["qpath"], id_column="qid"),
+        output=OutputConfig(path=_out(ds, "mismatch_metric_combined")),
+        searches=specs,
+    )
+    combined_paths = run_compute(combined_cfg)
+
+    solo_cfg = BruteForceConfig(
+        corpus=CorpusConfig(path=ds["cdir"], id_column="id"),
+        queries=QueriesConfig(path=ds["qpath"], id_column="qid"),
+        output=OutputConfig(path=_out(ds, "mismatch_metric_solo")),
+        searches=[specs[1]],
+    )
+    solo_path = run_compute(solo_cfg)["dense_eng"]
+
+    # Crucially, the solo run here has NO unfiltered dense sibling, so it takes
+    # Path B (independent compaction) — a different code path than the
+    # combined run's Path A. Matching bit-for-bit across both paths is a
+    # stronger proof than comparing either one to itself.
+    combined_t = pq.read_table(combined_paths["dense_eng"]).to_pydict()
+    solo_t = pq.read_table(solo_path).to_pydict()
+    assert combined_t["hit_ids"] == solo_t["hit_ids"]
+    for combined_scores, solo_scores in zip(combined_t["hit_scores"], solo_t["hit_scores"]):
+        assert np.allclose(combined_scores, solo_scores, atol=1e-5)
+
+
+def test_sparse_cosine_filtered_spec_riding_dot_baseline_not_double_normalized(tmp_path):
+    """Sparse analog of the test above, with hand-computed expected scores
+    (not nova_bf's own scoring, like `test_three_member_group_mixed_metrics`):
+    the only unfiltered sparse sibling is `dot`, so the filtered `cosine`
+    search must compute its OWN normalization on the masked-down columns of
+    the shared (raw, unnormalized) score matrix — never double-normalized,
+    never silently left un-normalized."""
+    cdir = tmp_path / "corpus"
+    cdir.mkdir()
+    # c0 (eng) = {1: 3.0, 2: 4.0}, norm 5.0 | c1 (fra) = {1: 1.0}, norm 1.0
+    corpus_rows = [([1, 2], [3.0, 4.0]), ([1], [1.0])]
+    dummy_dense = np.random.default_rng(6).standard_normal((2, DIM)).astype(np.float32)
+    _write_combined(
+        cdir / "f0.parquet", dummy_dense, corpus_rows, id=["c0", "c1"], language=["eng", "fra"],
+    )
+
+    # q0 = {1: 1.0, 2: 1.0}, norm sqrt(2)
+    query_rows = [([1, 2], [1.0, 1.0])]
+    qpath = tmp_path / "queries.parquet"
+    _write_combined(
+        qpath, np.random.default_rng(7).standard_normal((1, DIM)).astype(np.float32), query_rows, qid=["q0"],
+    )
+
+    out = tmp_path / "out"
+    out.mkdir()
+    eng_filter = Filter(must=[FilterCondition(field="language", match="eng")])
+    cfg = BruteForceConfig(
+        corpus=CorpusConfig(path=str(cdir), id_column="id"),
+        queries=QueriesConfig(path=str(qpath), id_column="qid"),
+        output=OutputConfig(path=str(out)),
+        searches=[
+            SearchSpec(name="sparse_dot_all", vector_type="sparse", metric="dot", k=2),
+            SearchSpec(name="sparse_cos_eng", vector_type="sparse", metric="cosine", k=2, filter=eng_filter),
+        ],
+    )
+    paths = run_compute(cfg)
+
+    cos_scores = dict(zip(*[pq.read_table(paths["sparse_cos_eng"]).to_pydict()[c][0] for c in ("hit_ids", "hit_scores")]))
+    # only c0 survives the "eng" filter; dot(q0, c0) = 1*3+1*4 = 7, norms sqrt(2) and 5.0
+    sqrt2 = np.sqrt(2.0)
+    assert list(cos_scores) == ["c0"]
+    assert cos_scores["c0"] == pytest.approx(7.0 / (sqrt2 * 5.0), abs=1e-4)
+
+
+def test_multi_batch_filtered_spec_riding_shared_batch_correct(ds):
+    """A filtered dense search sharing Path A's batch grid with an unfiltered
+    sibling must still accumulate the correct top-K across MULTIPLE batch
+    boundaries (`params.dense_batch_size` forces several batches per file) —
+    not just when the whole file fits in one batch."""
+    eng_filter = Filter(must=[FilterCondition(field="language", match="eng")])
+    specs = [
+        SearchSpec(name="dense_all", vector_type="dense", metric="dot", k=3),
+        SearchSpec(name="dense_eng", vector_type="dense", metric="dot", k=2, filter=eng_filter),
+    ]
+    cfg = BruteForceConfig(
+        corpus=CorpusConfig(path=ds["cdir"], id_column="id"),
+        queries=QueriesConfig(path=ds["qpath"], id_column="qid"),
+        output=OutputConfig(path=_out(ds, "multi_batch_shared")),
+        params=ParamsConfig(dense_batch_size=2),  # SIZES = [5, 7, 4] -> multiple batches/file
+        searches=specs,
+    )
+    paths = run_compute(cfg)
+
+    eng_globals = [g for g, lang in enumerate(ds["lang_by_g"]) if lang == "eng"]
+    expectations = {
+        "dense_all": ds["ground_truth"]("dense", 3),
+        "dense_eng": ds["ground_truth"]("dense", 2, allowed=eng_globals),
+    }
+    for name, expected in expectations.items():
+        t = pq.read_table(paths[name]).to_pydict()
+        got = {q: hi for q, hi in zip(t["query_id"], t["hit_ids"])}
+        for q in ds["qids"]:
+            assert got[q] == expected[q], f"search={name} query={q}"
+
+
+def test_filtered_spec_zero_surviving_rows_in_a_middle_batch(tmp_path):
+    """A filtered search riding Path A's shared batch grid must handle a
+    batch where NONE of its rows survive its filter — not just an all-or-
+    nothing whole-file case (see `test_corpus_ids_resolved_even_when_a_
+    different_specs_filter_drops_the_file` for the whole-file version). Rows
+    are laid out `eng, eng, fra, fra, eng, eng` with `dense_batch_size=2`, so
+    the SECOND batch (rows 2-3) has zero survivors for the "eng" filter while
+    the first and third batches have two each."""
+    cdir = tmp_path / "corpus"
+    cdir.mkdir()
+    n = 6
+    rng = np.random.default_rng(8)
+    dense_rows = rng.standard_normal((n, DIM)).astype(np.float32)
+    sparse_rows = [_random_sparse_row(rng) for _ in range(n)]
+    ids = [f"c{i}" for i in range(n)]
+    lang = ["eng", "eng", "fra", "fra", "eng", "eng"]
+    _write_combined(cdir / "f0.parquet", dense_rows, sparse_rows, id=ids, language=lang)
+
+    q_dense = rng.standard_normal((2, DIM)).astype(np.float32)
+    q_sparse = [_random_sparse_row(rng) for _ in range(2)]
+    qids = ["q0", "q1"]
+    qpath = tmp_path / "queries.parquet"
+    _write_combined(qpath, q_dense, q_sparse, qid=qids)
+
+    eng_globals = [i for i, lg in enumerate(lang) if lg == "eng"]
+    expected_s = q_dense @ dense_rows[eng_globals].T
+    expected = {
+        qids[i]: [ids[eng_globals[j]] for j in np.argsort(-expected_s[i])[:2]] for i in range(2)
+    }
+
+    out = tmp_path / "out"
+    out.mkdir()
+    eng_filter = Filter(must=[FilterCondition(field="language", match="eng")])
+    cfg = BruteForceConfig(
+        corpus=CorpusConfig(path=str(cdir), id_column="id"),
+        queries=QueriesConfig(path=str(qpath), id_column="qid"),
+        output=OutputConfig(path=str(out)),
+        params=ParamsConfig(dense_batch_size=2),
+        searches=[
+            SearchSpec(name="dense_all", vector_type="dense", metric="dot", k=2),
+            SearchSpec(name="dense_eng", vector_type="dense", metric="dot", k=2, filter=eng_filter),
+        ],
+    )
+    paths = run_compute(cfg)
+    t = pq.read_table(paths["dense_eng"]).to_pydict()
+    got = {q: hi for q, hi in zip(t["query_id"], t["hit_ids"])}
+    for q in qids:
+        assert got[q] == expected[q]
 
 
 def test_mismatched_dense_and_sparse_query_loads_are_rejected(ds, monkeypatch):

--- a/python/nova-bf/tests/test_compute_multi.py
+++ b/python/nova-bf/tests/test_compute_multi.py
@@ -365,6 +365,37 @@ def test_unrelated_large_k_filtered_spec_does_not_inflate_shared_path_a_batch(ds
             assert got[q] == expected[q], f"search={name} query={q}"
 
 
+def test_explicit_empty_filter_still_rides_path_a(ds, caplog):
+    """Regression test: an explicit-but-empty `filter: {}` (`Filter()`) is
+    semantically identical to no filter at all — `evaluate()` keeps every
+    row either way — so a vector_type where every spec sets one must still
+    take Path A's zero-copy full-file batch grid, not Path B's per-group row
+    compaction (which `has_baseline`'s `is None` check alone would have
+    mistakenly ruled out, since `Filter()` is not `None`)."""
+    specs = [
+        SearchSpec(name="dense_a", vector_type="dense", metric="dot", k=3, filter=Filter()),
+        SearchSpec(name="dense_b", vector_type="dense", metric="dot", k=3, filter=Filter()),
+    ]
+    cfg = BruteForceConfig(
+        corpus=CorpusConfig(path=ds["cdir"], id_column="id"),
+        queries=QueriesConfig(path=ds["qpath"], id_column="qid"),
+        output=OutputConfig(path=_out(ds, "empty_filter_out")),
+        searches=specs,
+    )
+    with caplog.at_level(logging.INFO, logger="nova_bf.compute"):
+        paths = run_compute(cfg)
+    assert any("share one full-file batch pass" in r.message for r in caplog.records), \
+        "an explicit-but-empty filter must still route to Path A, not Path B's row compaction"
+    assert not any("no unfiltered search" in r.message for r in caplog.records)
+
+    expected = ds["ground_truth"]("dense", 3)
+    for name in ("dense_a", "dense_b"):
+        t = pq.read_table(paths[name]).to_pydict()
+        got = {q: hi for q, hi in zip(t["query_id"], t["hit_ids"])}
+        for q in ds["qids"]:
+            assert got[q] == expected[q], f"search={name} query={q}"
+
+
 def test_sparse_dot_spec_not_corrupted_by_coscheduled_cosine_spec(tmp_path):
     """Regression test: `need_sparse_norms` (compute.py) gates whether a
     file's sparse rows get their L2 norm computed at all, but that's a

--- a/python/nova-bf/tests/test_compute_sparse.py
+++ b/python/nova-bf/tests/test_compute_sparse.py
@@ -160,8 +160,8 @@ def _run(ds, *, metric, batch, id_column, out_name, filt=None):
         corpus=CorpusConfig(path=ds["cdir"], sparse_column="sparse_embedding", id_column=id_column),
         queries=QueriesConfig(path=ds["qpath"], sparse_column="sparse_embedding", id_column="qid"),
         output=OutputConfig(path=str(out)),
-        params=ParamsConfig(io_workers=2),
-        searches=[SearchSpec(name="test", k=K, metric=metric, vector_type="sparse", corpus_batch_size=batch, filter=filt)],
+        params=ParamsConfig(io_workers=2, sparse_batch_size=batch),
+        searches=[SearchSpec(name="test", k=K, metric=metric, vector_type="sparse", filter=filt)],
     )
     t = pq.read_table(run_compute(cfg)["test"]).to_pydict()
     return {q: list(zip(hi, hs)) for q, hi, hs in zip(t["query_id"], t["hit_ids"], t["hit_scores"])}
@@ -232,8 +232,8 @@ def test_filter_match_restricts_candidates(ds):
 @pytest.mark.parametrize("batch", [None, K])
 def test_filter_preserves_row_numbers_under_batching(ds, batch):
     """A filter must resolve the same (correct) point ids whether or not
-    corpus_batch_size tiles the file — guards against filtering renumbering
-    rows instead of keeping their true file-row number."""
+    params.sparse_batch_size tiles the file — guards against filtering
+    renumbering rows instead of keeping their true file-row number."""
     filt = Filter(must=[FilterCondition(field="language", match="eng")])
     res = _run(ds, metric="dot", batch=batch, id_column=None, out_name=f"filter_defid_{batch}", filt=filt)
     eng_globals = [g for g, lang in enumerate(ds["lang_by_g"]) if lang == "eng"]
@@ -373,11 +373,12 @@ def test_duplicate_indices_cosine_norm_is_correct(ds):
 @pytest.mark.parametrize("batch", [None, 2])
 def test_filter_compaction_with_multibatch_tiling(tmp_path, batch):
     """The shared `ds` fixture's per-file row counts are too small for any
-    `corpus_batch_size` tiling to actually span more than one batch AFTER a
-    filter has compacted a file — so this exercises that specific interaction
-    directly: a file where filtering leaves enough rows that batch=2 forces
-    multiple iterations (r0=0, 2, 4) of the post-compaction array, checking
-    the same row-number-preservation invariant `orig_rows` relies on."""
+    `params.sparse_batch_size` tiling to actually span more than one batch
+    AFTER a filter has compacted a file — so this exercises that specific
+    interaction directly: a file where filtering leaves enough rows that
+    batch=2 forces multiple iterations (r0=0, 2, 4) of the post-compaction
+    array, checking the same row-number-preservation invariant `orig_rows`
+    relies on."""
     rng = np.random.default_rng(1)
     vocab, nnz = 10, 6  # 2*nnz > vocab: pigeonhole guarantees overlap, avoids ties
     cdir = tmp_path / "corpus"
@@ -406,9 +407,9 @@ def test_filter_compaction_with_multibatch_tiling(tmp_path, batch):
         corpus=CorpusConfig(path=str(cdir), sparse_column="sparse_embedding", id_column="id"),
         queries=QueriesConfig(path=str(qpath), sparse_column="sparse_embedding", id_column="qid"),
         output=OutputConfig(path=str(out)),
-        params=ParamsConfig(io_workers=1),
+        params=ParamsConfig(io_workers=1, sparse_batch_size=batch),
         searches=[SearchSpec(
-            name="test", k=2, metric="dot", vector_type="sparse", corpus_batch_size=batch,
+            name="test", k=2, metric="dot", vector_type="sparse",
             filter=Filter(must=[FilterCondition(field="language", match="eng")]),
         )],
     )

--- a/python/nova-bf/tests/test_config_searches.py
+++ b/python/nova-bf/tests/test_config_searches.py
@@ -17,8 +17,8 @@ from nova_bf.config import (
     OutputConfig,
     ParamsConfig,
     QueriesConfig,
+    RangeCondition,
     SearchSpec,
-    filter_key,
 )
 
 
@@ -113,115 +113,126 @@ def test_searches_multiple_specs_preserve_order():
     assert [s.name for s in cfg.searches] == ["dense_all", "sparse_all"]
 
 
-def test_filter_key_none_is_distinct_from_any_real_filter():
+def test_filter_is_hashable_and_usable_as_a_dict_key():
+    """`Filter`/`FilterCondition`/`RangeCondition` are frozen, so pydantic
+    auto-generates `__hash__` from their field values — this is what lets
+    compute.py key `keeps`/group directly by the `Filter` object instead of a
+    separate string-key scheme."""
     filt = Filter(must=[FilterCondition(field="language", match="eng")])
-    assert filter_key(None) != filter_key(filt)
+    d = {filt: "value"}
+    assert d[filt] == "value"
+    assert hash(FilterCondition(field="cost", range=RangeCondition(lt=10)))
+    assert hash(RangeCondition(lt=10))
+    # None (the "no filter" case) is hashable too, natively
+    assert hash(None) == hash(None)
 
 
-def test_filter_key_identical_filters_share_a_key():
+def test_structurally_identical_filters_hash_and_compare_equal():
     a = Filter(must=[FilterCondition(field="language", match="eng")])
     b = Filter(must=[FilterCondition(field="language", match="eng")])
-    assert filter_key(a) == filter_key(b)
+    assert a == b
+    assert hash(a) == hash(b)
 
 
-def test_filter_key_is_order_sensitive_like_filter_equality():
-    """Two filters differing only in `must` list order are NOT the same
-    filter (`Filter`'s own by-value equality is order-sensitive too, since
-    it's a plain list comparison) — `filter_key` must agree, or two specs
-    that `Filter.__eq__` treats as different would incorrectly dedupe."""
+def test_filters_differing_in_must_order_are_not_equal():
+    """Order-sensitive, same as a plain tuple/list comparison — a `must` list
+    reordered in YAML is a genuinely different filter."""
     a = Filter(must=[
         FilterCondition(field="language", match="eng"),
-        FilterCondition(field="cost", range={"lt": 10}),
+        FilterCondition(field="cost", range=RangeCondition(lt=10)),
     ])
     b = Filter(must=[
-        FilterCondition(field="cost", range={"lt": 10}),
+        FilterCondition(field="cost", range=RangeCondition(lt=10)),
         FilterCondition(field="language", match="eng"),
     ])
     assert a != b
-    assert filter_key(a) != filter_key(b)
 
 
-def test_filter_key_treats_numerically_equal_int_and_float_match_as_the_same_filter():
-    """Regression test: `Filter`'s own equality is Python's `==`, which treats
-    `5 == 5.0` as True — a filter authored with `match: 5` (YAML int) must
-    produce the SAME filter_key as one authored with `match: 5.0` (YAML
-    float), or two specs meant to share a filter would silently land in
-    different dedup buckets (the filter evaluated twice, and — under Path B
-    — no shared compaction/transfer) despite `Filter.__eq__` agreeing they're
-    identical."""
+def test_filter_hash_treats_numerically_equal_int_and_float_match_as_the_same():
+    """Native Python `int`/`float` equality (`5 == 5.0`) is exact, with no
+    precision loss even for large ints past 2**53 (unlike `float(value)`,
+    which would collide `float(2**53) == float(2**53 + 1)`) — a frozen
+    `Filter`'s hash/eq comes straight from pydantic's tuple-of-fields hash
+    over the native values, so this falls out for free with no
+    canonicalization scheme needed."""
     int_filt = Filter(must=[FilterCondition(field="cost", match=5)])
     float_filt = Filter(must=[FilterCondition(field="cost", match=5.0)])
     assert int_filt == float_filt
-    assert filter_key(int_filt) == filter_key(float_filt)
+    assert hash(int_filt) == hash(float_filt)
 
-    # sanity: a genuinely different numeric value still produces a different key
     other = Filter(must=[FilterCondition(field="cost", match=6)])
-    assert filter_key(int_filt) != filter_key(other)
+    assert int_filt != other
 
-    # match lists containing numeric values are canonicalized element-wise too
-    list_int = Filter(must=[FilterCondition(field="cost", match=[1, 2, 3])])
-    list_float = Filter(must=[FilterCondition(field="cost", match=[1.0, 2.0, 3.0])])
-    assert filter_key(list_int) == filter_key(list_float)
-
-    # bool is left alone, not folded into the numeric canonicalization
-    bool_filt = Filter(must=[FilterCondition(field="active", match=True)])
-    one_filt = Filter(must=[FilterCondition(field="active", match=1)])
-    assert filter_key(bool_filt) != filter_key(one_filt)
-
-
-def test_filter_key_does_not_collide_large_ints_via_float_precision_loss():
-    """Regression test: canonicalizing `match` via `float(value)` (an earlier
-    version of this fix) silently collides distinct large integers, since
-    float64 can't represent every int exactly past 2**53 — e.g.
-    `float(2**53) == float(2**53 + 1)`. Python's own `==` (what `Filter`'s
-    equality relies on) compares int/float exactly, with no such precision
-    loss, so `filter_key` must too — two DIFFERENT filters (differing only in
-    a large `match` value, e.g. a nanosecond timestamp or snowflake id in the
-    ~1e18 range where this bites) must never produce the same key, or
-    `_build_filter_groups`/`distinct_filters` would silently merge them and
-    evaluate one spec's results against the WRONG filter."""
     big = 2**53
     a = Filter(must=[FilterCondition(field="id", match=big)])
     b = Filter(must=[FilterCondition(field="id", match=big + 1)])
     assert a != b
-    assert float(big) == float(big + 1)  # sanity: this is genuinely a float-precision trap
-    assert filter_key(a) != filter_key(b)
-
-    # still unifies a large int with an EQUAL float (no regression on the original fix)
+    assert float(big) == float(big + 1)  # sanity: genuinely a float-precision trap
     c = Filter(must=[FilterCondition(field="id", match=float(big))])
     assert a == c
-    assert filter_key(a) == filter_key(c)
+    assert hash(a) == hash(c)
+
+    # Native Python treats `True == 1` (bool is an int subclass), so under
+    # this native-equality scheme match=True and match=1 are now the SAME
+    # filter — a deliberate behavior change from the old filter_key, which
+    # special-cased bool to keep it distinct from 1. That carve-out doesn't
+    # survive retiring the custom canonicalization: this is a case where the
+    # native scheme is MORE consistent with Filter.__eq__ than the old
+    # filter_key was (the old filter_key actually disagreed with
+    # Filter.__eq__ here, since `FilterCondition(match=True) ==
+    # FilterCondition(match=1)` was already True under Filter's own
+    # by-value equality).
+    bool_filt = Filter(must=[FilterCondition(field="active", match=True)])
+    one_filt = Filter(must=[FilterCondition(field="active", match=1)])
+    assert bool_filt == one_filt
+    assert hash(bool_filt) == hash(one_filt)
 
 
-def test_filter_key_does_not_crash_on_nan_or_inf_match_values():
-    """Regression test: `Fraction` (the fix for the 2**53 collision above)
-    can't represent NaN or Infinity at all — `Fraction(float("nan"))` raises
-    `ValueError`, `Fraction(float("inf"))` raises `OverflowError` — but both
-    are legal YAML/pydantic `match` values, so `filter_key` (called
-    unconditionally at `run_compute` setup for every spec) must never crash
-    on them the way an earlier version of the Fraction fix did."""
+def test_filter_hash_handles_nan_and_inf_match_values():
+    """`nan != nan` (even against itself) and `inf`/`-inf` compare equal to
+    themselves by sign — native Python float semantics, which a frozen
+    `Filter`'s hash/eq inherits directly with no special-casing."""
     nan_filt = Filter(must=[FilterCondition(field="n", match=float("nan"))])
     inf_filt = Filter(must=[FilterCondition(field="n", match=float("inf"))])
     neg_inf_filt = Filter(must=[FilterCondition(field="n", match=float("-inf"))])
 
-    filter_key(nan_filt)  # must not raise
-    filter_key(inf_filt)  # must not raise
+    hash(nan_filt)  # must not raise
+    hash(inf_filt)  # must not raise
 
-    # inf == inf under Python's own `==` (what Filter.__eq__ relies on), so
-    # two inf-matching filters must still share a key
     inf_filt2 = Filter(must=[FilterCondition(field="n", match=float("inf"))])
     assert inf_filt == inf_filt2
-    assert filter_key(inf_filt) == filter_key(inf_filt2)
+    assert hash(inf_filt) == hash(inf_filt2)
 
-    # +inf and -inf are NOT the same filter
     assert inf_filt != neg_inf_filt
-    assert filter_key(inf_filt) != filter_key(neg_inf_filt)
 
-    # nan != nan even against itself, so two nan-matching filters (however
-    # constructed) must never share a key either
+    # Two SEPARATE nan-valued Filter instances never compare equal — nan is
+    # never equal to anything, itself included — so specs with independently
+    # constructed nan filters never wrongly dedupe/merge into one filter
+    # group. (Comparing the identical object to itself, `nan_filt ==
+    # nan_filt`, is True — pydantic's generated `__eq__` short-circuits on
+    # `self is other`, same as CPython dict lookups do internally — but that
+    # never happens in compute.py's usage: every `keeps[filter]`/dict-key
+    # lookup is either the exact same object stored earlier for that spec, or
+    # a distinct spec's distinct nan filter, which is what matters here.)
     nan_filt2 = Filter(must=[FilterCondition(field="n", match=float("nan"))])
-    assert nan_filt != nan_filt2  # Filter.__eq__ agrees: nan != nan
-    assert filter_key(nan_filt) != filter_key(nan_filt2)
+    assert nan_filt != nan_filt2
+
+
+def test_filter_condition_match_list_literal_coerces_to_tuple():
+    """YAML/pydantic accepts a list literal for `match` (`match: [1, 2, 3]`)
+    but stores it as a tuple — needed for `FilterCondition`/`Filter` to stay
+    hashable."""
+    cond = FilterCondition(field="cost", match=[1, 2, 3])
+    assert cond.match == (1, 2, 3)
+    hash(cond)  # must not raise
+
+
+def test_filter_is_immutable():
+    filt = Filter(must=[FilterCondition(field="language", match="eng")])
+    with pytest.raises(ValidationError):
+        filt.must = ()
+    with pytest.raises(ValidationError):
+        filt.must[0].match = "other"
 
 
 def test_params_rejects_non_positive_batch_size():

--- a/python/nova-bf/tests/test_config_searches.py
+++ b/python/nova-bf/tests/test_config_searches.py
@@ -18,6 +18,7 @@ from nova_bf.config import (
     ParamsConfig,
     QueriesConfig,
     SearchSpec,
+    filter_key,
 )
 
 
@@ -61,14 +62,31 @@ def test_search_spec_sparse_euclidean_rejected():
 
 
 def test_params_no_longer_accepts_search_semantics_fields():
-    """k/metric/vector_type/corpus_batch_size moved to SearchSpec — ParamsConfig
-    only has run-level IO/merge knobs left, so pydantic's own `extra="forbid"`
-    now rejects these natively (no custom validator needed)."""
-    for bad_kwargs in (
-        {"k": 500}, {"metric": "dot"}, {"vector_type": "sparse"}, {"corpus_batch_size": 4096},
-    ):
+    """k/metric/vector_type moved to SearchSpec — ParamsConfig only has
+    run-level IO/merge/GPU-batching knobs left, so pydantic's own
+    `extra="forbid"` now rejects these natively (no custom validator
+    needed)."""
+    for bad_kwargs in ({"k": 500}, {"metric": "dot"}, {"vector_type": "sparse"}):
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
             ParamsConfig(**bad_kwargs)
+
+
+def test_search_spec_no_longer_accepts_corpus_batch_size():
+    """`corpus_batch_size` moved OFF `SearchSpec` onto `ParamsConfig`
+    (`dense_batch_size`/`sparse_batch_size`) — every search of a vector_type
+    ends up sharing one GPU pass over the corpus regardless of grouping (see
+    compute.py), so it was never really a per-search setting."""
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        SearchSpec(name="a", corpus_batch_size=4096)
+
+
+def test_params_dense_and_sparse_batch_size_fields_work():
+    cfg = BruteForceConfig(**_base(
+        params=ParamsConfig(dense_batch_size=4096, sparse_batch_size=2048),
+        searches=[SearchSpec(name="a")],
+    ))
+    assert cfg.params.dense_batch_size == 4096
+    assert cfg.params.sparse_batch_size == 2048
 
 
 def test_params_run_level_fields_still_work():
@@ -93,3 +111,130 @@ def test_searches_multiple_specs_preserve_order():
         SearchSpec(name="sparse_all", vector_type="sparse", metric="dot"),
     ]))
     assert [s.name for s in cfg.searches] == ["dense_all", "sparse_all"]
+
+
+def test_filter_key_none_is_distinct_from_any_real_filter():
+    filt = Filter(must=[FilterCondition(field="language", match="eng")])
+    assert filter_key(None) != filter_key(filt)
+
+
+def test_filter_key_identical_filters_share_a_key():
+    a = Filter(must=[FilterCondition(field="language", match="eng")])
+    b = Filter(must=[FilterCondition(field="language", match="eng")])
+    assert filter_key(a) == filter_key(b)
+
+
+def test_filter_key_is_order_sensitive_like_filter_equality():
+    """Two filters differing only in `must` list order are NOT the same
+    filter (`Filter`'s own by-value equality is order-sensitive too, since
+    it's a plain list comparison) — `filter_key` must agree, or two specs
+    that `Filter.__eq__` treats as different would incorrectly dedupe."""
+    a = Filter(must=[
+        FilterCondition(field="language", match="eng"),
+        FilterCondition(field="cost", range={"lt": 10}),
+    ])
+    b = Filter(must=[
+        FilterCondition(field="cost", range={"lt": 10}),
+        FilterCondition(field="language", match="eng"),
+    ])
+    assert a != b
+    assert filter_key(a) != filter_key(b)
+
+
+def test_filter_key_treats_numerically_equal_int_and_float_match_as_the_same_filter():
+    """Regression test: `Filter`'s own equality is Python's `==`, which treats
+    `5 == 5.0` as True — a filter authored with `match: 5` (YAML int) must
+    produce the SAME filter_key as one authored with `match: 5.0` (YAML
+    float), or two specs meant to share a filter would silently land in
+    different dedup buckets (the filter evaluated twice, and — under Path B
+    — no shared compaction/transfer) despite `Filter.__eq__` agreeing they're
+    identical."""
+    int_filt = Filter(must=[FilterCondition(field="cost", match=5)])
+    float_filt = Filter(must=[FilterCondition(field="cost", match=5.0)])
+    assert int_filt == float_filt
+    assert filter_key(int_filt) == filter_key(float_filt)
+
+    # sanity: a genuinely different numeric value still produces a different key
+    other = Filter(must=[FilterCondition(field="cost", match=6)])
+    assert filter_key(int_filt) != filter_key(other)
+
+    # match lists containing numeric values are canonicalized element-wise too
+    list_int = Filter(must=[FilterCondition(field="cost", match=[1, 2, 3])])
+    list_float = Filter(must=[FilterCondition(field="cost", match=[1.0, 2.0, 3.0])])
+    assert filter_key(list_int) == filter_key(list_float)
+
+    # bool is left alone, not folded into the numeric canonicalization
+    bool_filt = Filter(must=[FilterCondition(field="active", match=True)])
+    one_filt = Filter(must=[FilterCondition(field="active", match=1)])
+    assert filter_key(bool_filt) != filter_key(one_filt)
+
+
+def test_filter_key_does_not_collide_large_ints_via_float_precision_loss():
+    """Regression test: canonicalizing `match` via `float(value)` (an earlier
+    version of this fix) silently collides distinct large integers, since
+    float64 can't represent every int exactly past 2**53 — e.g.
+    `float(2**53) == float(2**53 + 1)`. Python's own `==` (what `Filter`'s
+    equality relies on) compares int/float exactly, with no such precision
+    loss, so `filter_key` must too — two DIFFERENT filters (differing only in
+    a large `match` value, e.g. a nanosecond timestamp or snowflake id in the
+    ~1e18 range where this bites) must never produce the same key, or
+    `_build_filter_groups`/`distinct_filters` would silently merge them and
+    evaluate one spec's results against the WRONG filter."""
+    big = 2**53
+    a = Filter(must=[FilterCondition(field="id", match=big)])
+    b = Filter(must=[FilterCondition(field="id", match=big + 1)])
+    assert a != b
+    assert float(big) == float(big + 1)  # sanity: this is genuinely a float-precision trap
+    assert filter_key(a) != filter_key(b)
+
+    # still unifies a large int with an EQUAL float (no regression on the original fix)
+    c = Filter(must=[FilterCondition(field="id", match=float(big))])
+    assert a == c
+    assert filter_key(a) == filter_key(c)
+
+
+def test_filter_key_does_not_crash_on_nan_or_inf_match_values():
+    """Regression test: `Fraction` (the fix for the 2**53 collision above)
+    can't represent NaN or Infinity at all — `Fraction(float("nan"))` raises
+    `ValueError`, `Fraction(float("inf"))` raises `OverflowError` — but both
+    are legal YAML/pydantic `match` values, so `filter_key` (called
+    unconditionally at `run_compute` setup for every spec) must never crash
+    on them the way an earlier version of the Fraction fix did."""
+    nan_filt = Filter(must=[FilterCondition(field="n", match=float("nan"))])
+    inf_filt = Filter(must=[FilterCondition(field="n", match=float("inf"))])
+    neg_inf_filt = Filter(must=[FilterCondition(field="n", match=float("-inf"))])
+
+    filter_key(nan_filt)  # must not raise
+    filter_key(inf_filt)  # must not raise
+
+    # inf == inf under Python's own `==` (what Filter.__eq__ relies on), so
+    # two inf-matching filters must still share a key
+    inf_filt2 = Filter(must=[FilterCondition(field="n", match=float("inf"))])
+    assert inf_filt == inf_filt2
+    assert filter_key(inf_filt) == filter_key(inf_filt2)
+
+    # +inf and -inf are NOT the same filter
+    assert inf_filt != neg_inf_filt
+    assert filter_key(inf_filt) != filter_key(neg_inf_filt)
+
+    # nan != nan even against itself, so two nan-matching filters (however
+    # constructed) must never share a key either
+    nan_filt2 = Filter(must=[FilterCondition(field="n", match=float("nan"))])
+    assert nan_filt != nan_filt2  # Filter.__eq__ agrees: nan != nan
+    assert filter_key(nan_filt) != filter_key(nan_filt2)
+
+
+def test_params_rejects_non_positive_batch_size():
+    """Regression test: `range(0, n_rows, step)` with a non-positive `step`
+    is an EMPTY range — a negative or zero `dense_batch_size`/
+    `sparse_batch_size` (a plausible config typo) would otherwise silently
+    skip every row of every file, producing an empty top-K for every query
+    with no error or warning. Reject it at config-load time instead."""
+    for bad in (-5, 0):
+        with pytest.raises(ValidationError):
+            ParamsConfig(dense_batch_size=bad)
+        with pytest.raises(ValidationError):
+            ParamsConfig(sparse_batch_size=bad)
+    # positive values and None (whole-file) still work
+    assert ParamsConfig(dense_batch_size=100).dense_batch_size == 100
+    assert ParamsConfig(sparse_batch_size=None).sparse_batch_size is None

--- a/python/nova-bf/tests/test_merge.py
+++ b/python/nova-bf/tests/test_merge.py
@@ -180,3 +180,25 @@ def test_merge_prefetch_shares_one_pool_across_searches(scenario, monkeypatch, t
             ref_ids, ref_scores = reference[q]
             assert got[q][0] == ref_ids
             assert np.allclose(got[q][1], ref_scores)
+
+
+def test_mismatched_partial_counts_across_searches_raises(scenario, tmp_path):
+    """Every search in one `compute` run is written by the same set of ranks,
+    so a mismatched partial count between two searches means some rank died
+    partway through writing its per-search outputs — this must raise loudly
+    at merge time instead of silently merging the short search from fewer
+    ranks than it actually had."""
+    cfg, qids, reference = scenario
+
+    second = SearchSpec(name="test2", k=K)
+    cfg.searches = [*cfg.searches, second]
+    src_dir = tmp_path / "out" / partial_dir(cfg, cfg.searches[0])
+    dst_dir = tmp_path / "out" / partial_dir(cfg, second)
+    dst_dir.mkdir(parents=True)
+    # Copy only W-1 of the W partials — simulates a rank that wrote the first
+    # search's partial but died before writing this second search's.
+    for f in sorted(src_dir.iterdir())[:-1]:
+        (dst_dir / f.name).write_bytes(f.read_bytes())
+
+    with pytest.raises(RuntimeError, match="mismatched partial counts"):
+        run_merge(cfg)

--- a/python/nova-dist/src/nova_dist/cli.py
+++ b/python/nova-dist/src/nova_dist/cli.py
@@ -226,7 +226,7 @@ def bf_compute(config, resources, num_jobs, pool_name, dry_run):
 @click.argument("config")
 def bf_merge(config):
     """
-    Merge per-rank partial results into one top-K parquet (runs on the controller).
+    Merge per-rank partial results into each search's own top-K parquet (runs on the controller).
     """
     _run_local("nova-bf", ["merge", config])
 


### PR DESCRIPTION
Fast-forward merge of the full multi-search GPU-sharing work (dense+sparse
searches sharing corpus IO/decode and, per vector_type, GPU batch passes —
see compute.py's module docstring) plus the just-merged filter-indexing
simplification (#33), into single-pass-bf.

single-pass-bf's tip is an ancestor of bf-simplify-sharing (this is where
bf-simplify-sharing branched from), so this is a pure fast-forward — no
conflicts, nothing on single-pass-bf is overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)