### PR TITLE
bf config: make SearchSpec.name optional, auto-derived when omitted

### DIFF
--- a/configs/brute_force/example.yaml
+++ b/configs/brute_force/example.yaml
@@ -54,7 +54,10 @@ params:
 # corpus file is read/decoded once per vector_type any search below needs, not
 # once per search — see docs/brute-force/overview.md#one-search-or-several-in-one-pass).
 searches:
-  - name: dense                # required, unique, [A-Za-z0-9_-]+ — goes into the output filename
+  - name: dense                # optional, unique if set, [A-Za-z0-9_-]+ — goes into the output
+                                # filename. Omit it and one is derived from vector_type/metric
+                                # (e.g. "dense_cosine", "_filtered" appended if `filter` is set),
+                                # with collisions disambiguated automatically (_2, _3, …).
     vector_type: dense          # dense | sparse
     metric: cosine               # cosine | dot | euclidean (euclidean unsupported with vector_type: sparse)
     k: 1000

--- a/docs/brute-force/overview.md
+++ b/docs/brute-force/overview.md
@@ -45,7 +45,7 @@ params:
   # merge_prefetch: false
 
 searches:
-  - name: dense_all          # required, unique, [A-Za-z0-9_-]+ — goes into the output filename
+  - name: dense_all          # optional, unique if set, [A-Za-z0-9_-]+ — goes into the output filename
     vector_type: dense       # dense | sparse
     metric: cosine           # cosine | dot | euclidean (euclidean unsupported with vector_type: sparse)
     k: 1000
@@ -93,7 +93,7 @@ searches:
           match: eng
 ```
 
-Every entry needs a unique `name` — it's spliced into the output filename (`bf_<queries-stem>_<name>_k<K>.parquet`) so searches never collide.
+`name` is optional — it's spliced into the output filename (`bf_<queries-stem>_<name>_k<K>.parquet`), so if you set it, it must be unique. Omit it and one is derived from `vector_type`/`metric` (e.g. `dense_cosine`), with `_filtered` appended when `filter` is set and any collision (with another default, or with an explicit name elsewhere in `searches`) disambiguated by an incrementing suffix (`_2`, `_3`, …) — so the single-search case above needs no `name:` line at all.
 
 **Mixing `vector_type: dense` and `vector_type: sparse` in one run doubles the per-file host-RAM budget**: each in-flight file's reader decodes both columns at once, so `io_workers × file_size` (see [Performance & tuning](#performance--tuning)) becomes `io_workers × (dense_bytes + sparse_bytes)`. Lower `io_workers` accordingly on memory-constrained boxes when mixing vector_types.
 

--- a/python/nova-bf/src/nova_bf/config.py
+++ b/python/nova-bf/src/nova_bf/config.py
@@ -261,12 +261,16 @@ class SearchSpec(BaseModel):
     run-level knob, not a per-search one — see `ParamsConfig`.
 
     `name` becomes part of the output filename (see `nova_bf.results`), so
-    every spec in a run needs a distinct one.
+    every spec in a run needs a distinct one. Optional: if omitted, `Brute
+    ForceConfig` derives one from `vector_type`/`metric` (plus `_filtered`
+    when a filter is set) and disambiguates collisions automatically — see
+    `_assign_default_names`. A lone `SearchSpec` can't do this itself since
+    disambiguation needs to see every spec in the run's `searches` list.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    name: str
+    name: str | None = None
     k: int = 1000
     metric: Literal["cosine", "dot", "euclidean"] = "cosine"
     vector_type: Literal["dense", "sparse"] = "dense"
@@ -276,20 +280,44 @@ class SearchSpec(BaseModel):
     def _no_sparse_euclidean(self) -> "SearchSpec":
         if self.vector_type == "sparse" and self.metric == "euclidean":
             raise ValueError(
-                f"search '{self.name}': metric='euclidean' is not supported with "
-                "vector_type='sparse' (sparse retrieval only ever uses dot/cosine) "
-                "— use 'dot' or 'cosine'"
+                "metric='euclidean' is not supported with vector_type='sparse' "
+                "(sparse retrieval only ever uses dot/cosine) — use 'dot' or 'cosine'"
+                + (f" (search {self.name!r})" if self.name else "")
             )
         return self
 
     @model_validator(mode="after")
     def _name_is_filename_safe(self) -> "SearchSpec":
-        if not re.fullmatch(r"[A-Za-z0-9_-]+", self.name):
+        # None (not yet assigned — see BruteForceConfig._assign_default_names)
+        # is fine here; an explicitly-set name is validated immediately.
+        if self.name is not None and not re.fullmatch(r"[A-Za-z0-9_-]+", self.name):
             raise ValueError(
                 f"search name '{self.name}' must be non-empty and match "
                 "[A-Za-z0-9_-]+ (it becomes part of the output filename)"
             )
         return self
+
+
+def _assign_default_names(specs: list[SearchSpec]) -> None:
+    """Fill in `.name` for every spec that didn't set one explicitly, deriving
+    a readable default from `vector_type`/`metric` (plus `_filtered` when a
+    filter is set) and disambiguating any collision — with each other, or
+    with an explicit name elsewhere in `specs` — by appending an incrementing
+    numeric suffix. Runs once over the whole list (not as a per-SearchSpec
+    validator): a spec can't see its siblings, and disambiguation needs to."""
+    used = {s.name for s in specs if s.name is not None}
+    for s in specs:
+        if s.name is not None:
+            continue
+        base = f"{s.vector_type}_{s.metric}"
+        if s.filter is not None and s.filter.fields():
+            base += "_filtered"
+        name, n = base, 2
+        while name in used:
+            name = f"{base}_{n}"
+            n += 1
+        used.add(name)
+        s.name = name
 
 
 class BruteForceConfig(BaseModel):
@@ -311,6 +339,7 @@ class BruteForceConfig(BaseModel):
     def _validate_searches(self) -> "BruteForceConfig":
         if not self.searches:
             raise ValueError("`searches` must list at least one SearchSpec")
+        _assign_default_names(self.searches)
         names = [s.name for s in self.searches]
         if len(set(names)) != len(names):
             raise ValueError(f"`searches` names must be unique, got {names}")

--- a/python/nova-bf/tests/test_config_searches.py
+++ b/python/nova-bf/tests/test_config_searches.py
@@ -113,6 +113,56 @@ def test_searches_multiple_specs_preserve_order():
     assert [s.name for s in cfg.searches] == ["dense_all", "sparse_all"]
 
 
+def test_search_spec_name_is_optional():
+    """A lone SearchSpec can omit `name` — it's left `None` until
+    BruteForceConfig assigns a default (a single spec can't disambiguate
+    against siblings it can't see)."""
+    assert SearchSpec().name is None
+
+
+def test_search_spec_default_name_derived_from_vector_type_and_metric():
+    cfg = BruteForceConfig(**_base(searches=[SearchSpec()]))
+    assert cfg.searches[0].name == "dense_cosine"
+
+    cfg = BruteForceConfig(**_base(searches=[SearchSpec(vector_type="sparse", metric="dot")]))
+    assert cfg.searches[0].name == "sparse_dot"
+
+
+def test_search_spec_default_name_gets_filtered_suffix():
+    filt = Filter(must=[FilterCondition(field="language", match="eng")])
+    cfg = BruteForceConfig(**_base(searches=[SearchSpec(filter=filt)]))
+    assert cfg.searches[0].name == "dense_cosine_filtered"
+
+    # an explicit-but-empty filter has no active fields, so it's treated the
+    # same as no filter at all — same convention as compute.py's _is_unfiltered.
+    cfg = BruteForceConfig(**_base(searches=[SearchSpec(filter=Filter())]))
+    assert cfg.searches[0].name == "dense_cosine"
+
+
+def test_search_spec_default_names_disambiguate_collisions():
+    cfg = BruteForceConfig(**_base(searches=[
+        SearchSpec(), SearchSpec(), SearchSpec(),
+    ]))
+    assert [s.name for s in cfg.searches] == ["dense_cosine", "dense_cosine_2", "dense_cosine_3"]
+
+
+def test_search_spec_default_name_avoids_explicit_name_collision():
+    cfg = BruteForceConfig(**_base(searches=[
+        SearchSpec(name="dense_cosine"),
+        SearchSpec(),
+    ]))
+    assert [s.name for s in cfg.searches] == ["dense_cosine", "dense_cosine_2"]
+
+
+def test_search_spec_explicit_name_mixed_with_default_preserves_order():
+    cfg = BruteForceConfig(**_base(searches=[
+        SearchSpec(),
+        SearchSpec(name="my_search", vector_type="sparse", metric="dot"),
+        SearchSpec(vector_type="sparse", metric="dot"),
+    ]))
+    assert [s.name for s in cfg.searches] == ["dense_cosine", "my_search", "sparse_dot"]
+
+
 def test_filter_is_hashable_and_usable_as_a_dict_key():
     """`Filter`/`FilterCondition`/`RangeCondition` are frozen, so pydantic
     auto-generates `__hash__` from their field values — this is what lets


### PR DESCRIPTION
## Summary
- `SearchSpec.name` is now optional (`str | None = None`). When omitted, `BruteForceConfig` derives a readable default from `vector_type`/`metric` (e.g. `dense_cosine`), appending `_filtered` when a filter is set, and disambiguates any collision (against another default, or an explicit name elsewhere in `searches`) with an incrementing suffix (`_2`, `_3`, …).
- Naming was pure ceremony for the common single-search case — the name only ever existed to keep output filenames apart, which the auto-derivation now handles.
- Assignment happens once at `BruteForceConfig` level (`_assign_default_names`), not per-`SearchSpec`, since disambiguation needs visibility into every spec in the run.

## Verification
- `pytest` (95 tests, 6 new) passes.
- Ran the actual CLI against real FIQA data with a 3-search config that has **no `name:` field anywhere** — got `dense_cosine`, `dense_cosine_filtered`, `sparse_dot` output files as expected, correctly sharing GPU work across Path A/B same as before.

## Test plan
- [x] `pytest tests/` — 95 passed
- [x] Real-data CLI run with an entirely name-less `searches:` config — correct auto-derived output filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)