### PR TITLE
bf compute: unify Path A/Path B into one shared-batch mechanism (Option A)

### DIFF
--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -35,23 +35,44 @@ spec. This is purely a sharing of REDUNDANT work, never a fusion of scores:
 each search still gets its own independent ranked list, not a blended hybrid
 ranking.
 
-Per vector_type, searches share GPU work one of two ways (see `run_compute`'s
-`has_baseline` / `_process_shared_batch` / `_process_filter_group`):
+Per vector_type, EVERY search sharing that vector_type shares ONE batch grid
+(see `run_compute`'s `has_baseline` and `_process_shared_batch`): the GPU
+transfer/CSR build and each distinct metric's score matrix are computed ONCE
+per batch, and every search merges its own top-K from those same columns,
+masking them down to its own filter's surviving rows first if it has one.
+Masking a raw, per-row-independent score matrix is exact, not an
+approximation, so a filtered search's metric never needs to already be used
+by anyone else — computing one more metric on a batch that's already
+resident on the GPU is cheap, unlike a second transfer.
 
-- If ANY search of that vector_type is unfiltered, EVERY search of that
-  vector_type — filtered or not — shares one full-file batch grid: the GPU
-  transfer/CSR build and each distinct metric's score matrix are computed
-  ONCE per batch, and every search merges its own top-K from those same
-  columns (an unfiltered search reads them directly; a filtered search masks
-  them down to its own filter's surviving rows first). Masking a raw,
-  per-row-independent score matrix is exact, not an approximation, so a
-  filtered search's metric never needs to already be used by anyone else —
-  computing one more metric on a batch that's already resident on the GPU is
-  cheap, unlike a second transfer.
-- Otherwise (no search of that vector_type is unfiltered), there's no
-  full-file computation to derive from: searches are grouped by exact filter
-  equality instead, and each such group compacts its own rows before
-  transfer/scoring, once per group per batch.
+What rows make up that shared grid depends on whether any search of the
+vector_type is unfiltered:
+
+- If ANY search is unfiltered (or has an explicit-but-empty filter — see
+  `_is_unfiltered`), the shared grid is the WHOLE file, uncompacted: that
+  search needs every row anyway, so every OTHER (filtered) search of the
+  vector_type just rides along for free, masking down to its own rows
+  afterward.
+- Otherwise (every search of the vector_type has an active filter), the
+  shared grid is the UNION of every DISTINCT active filter's surviving rows
+  (`_union_keep`), compacted/transferred/scored ONCE, with each search then
+  masking down further to its own filter's subset of that union. This never
+  does MORE row-scoring than treating each distinct filter independently
+  would — in the worst case (fully disjoint filters) it's exactly the same
+  total rows, just one transfer/launch instead of several — and strictly
+  less whenever two filters' surviving rows overlap. The tradeoff: unlike
+  treating each filter independently (which bounds each one's own transfer
+  to its own, typically smaller, surviving-row count), the union's peak
+  transfer size is bounded by `params.dense_batch_size`/`sparse_batch_size`
+  alone when left at their None default — several large, mostly-disjoint
+  filters can produce a union nearly the size of the whole file. Set that
+  batch size explicitly if you have many such filters (see `ParamsConfig`).
+
+Either way, `_process_shared_batch` does the per-search masking: an
+unfiltered search uses the shared grid as-is; a filtered one narrows it
+further to its own filter's rows, with two searches sharing an identical
+filter memoizing that lookup once (keyed by the `Filter` object itself,
+frozen+hashable) rather than repeating it.
 """
 
 from __future__ import annotations
@@ -310,9 +331,8 @@ def _sparse_batch_to_csr(
 
     Deliberately takes no `norms`/metric argument and never scales `b_val` —
     this builder is shared across every search of this vector_type that scores
-    the same rows, whether via `_process_shared_batch` (Path A) or a
-    `FilterGroup` (Path B), including a mix of `cosine` and `dot` searches, so
-    it must stay metric-agnostic BY CONSTRUCTION. Cosine
+    the same rows via `_process_shared_batch`, including a mix of `cosine` and
+    `dot` searches, so it must stay metric-agnostic BY CONSTRUCTION. Cosine
     normalization is applied by the caller as a post-hoc divide on the score
     matrix (`raw / row_norms`, mathematically identical to pre-scaling these
     values by `1/row_norm` before the matmul, since a per-row scalar commutes
@@ -530,55 +550,21 @@ def _merge_topk(top_scores, top_enc, batch_scores, batch_rows, gidx: int, k: int
     return new_top_scores, merged_e.gather(1, idx)
 
 
-@dataclass(frozen=True)
-class FilterGroup:
-    """Specs sharing one vector_type and one exact filter (Path B only — see
-    `run_compute`'s `has_baseline`): no spec of this vector_type is
-    unfiltered, so there's no full-file score matrix to derive from, and this
-    group compacts/transfers/scores its own rows once per batch instead —
-    its members share the identical filter by construction, hence the
-    identical surviving row set. Carries the `Filter` itself: the per-file
-    loop looks up `keeps[group.filter]` once per file — `Filter` is frozen
-    and hashable (see `nova_bf.config.Filter`), and a run has at most a
-    handful of distinct filters, so hashing it here costs nothing next to
-    the corpus read/GPU work this whole module exists to overlap."""
-
-    filter: Filter | None
-    member_idxs: list[int]
-    batch_size: int | None  # resolved batch size; None = whole (compacted) file
-
-
-def _resolve_vt_batch_size(configured: int | None, k_floor: int, vt: str, raise_to_floor: bool) -> int | None:
-    """Shared floor-check behind `_path_b_group_batch_size`/`_path_a_batch_size`:
-    `configured` (`params.dense_batch_size`/`sparse_batch_size`) is fine as-is
-    whenever it's unset or already at/above `k_floor` — a batch that size can
-    already fill any of these searches' own top-K in one pass. Below that, the
-    two paths diverge on what `k_floor` even means:
-
-    - Path B (`raise_to_floor=True`, via `_path_b_group_batch_size`): `k_floor`
-      is the largest `k` among one `FilterGroup`'s own (related — they share
-      an identical filter by construction) members, so raising `configured`
-      up to it only helps: this group's memory footprint is the same either
-      way, and a smaller batch just can't fill a search's top-K for no
-      benefit.
-    - Path A (`raise_to_floor=False`, via `_path_a_batch_size`): `k_floor` is
-      the largest `k` across EVERY search of the vector_type, related or not,
-      since they all share one full-file grid — raising `configured` here
-      would let one search's large `k` silently blow past a DIFFERENT
-      search's own memory bound, exactly the OOM footgun `dense_batch_size`/
-      `sparse_batch_size` exists to prevent. Warn instead: the larger-`k`
-      search just takes extra merge rounds to fill its own top-K (more of
-      them the further `configured` sits below `k_floor`), at no extra GPU
-      memory cost to anyone."""
+def _resolve_vt_batch_size(configured: int | None, k_floor: int, vt: str) -> int | None:
+    """`configured` (`params.dense_batch_size`/`sparse_batch_size`) is fine
+    as-is whenever it's unset or already at/above `k_floor` (the largest `k`
+    among EVERY search of this vector_type) — a batch that size can already
+    fill any of these searches' own top-K in one pass. Below that, never
+    raise it: every search of the vector_type shares one batch grid
+    regardless of filter (see `run_compute`'s `has_baseline` and
+    `_union_keep`), so raising `configured` for one search's large `k` would
+    silently blow past a DIFFERENT, unrelated search's own memory bound —
+    exactly the OOM footgun `dense_batch_size`/`sparse_batch_size` exists to
+    prevent. Warn instead: the larger-`k` search just takes extra merge
+    rounds to fill its own top-K (more of them the further `configured` sits
+    below `k_floor`), at no extra GPU memory cost to anyone."""
     if configured is None or configured >= k_floor:
         return configured
-    if raise_to_floor:
-        logger.warning(
-            "params.%s_batch_size=%d is below k=%d; raising to k (a smaller "
-            "batch can't fill a search's top-K and gives no memory benefit).",
-            vt, configured, k_floor,
-        )
-        return k_floor
     logger.warning(
         "params.%s_batch_size=%d is below k=%d, the largest among searches "
         "sharing this vector_type's batch pass — keeping your configured "
@@ -591,66 +577,53 @@ def _resolve_vt_batch_size(configured: int | None, k_floor: int, vt: str, raise_
     return configured
 
 
-def _path_b_group_batch_size(configured: int | None, k_floor: int, vt: str) -> int | None:
-    return _resolve_vt_batch_size(configured, k_floor, vt, raise_to_floor=True)
-
-
-def _path_a_batch_size(configured: int | None, k_floor: int, vt: str) -> int | None:
-    return _resolve_vt_batch_size(configured, k_floor, vt, raise_to_floor=False)
-
-
-def _build_filter_groups(
-    idxs: list[int], specs: list[SearchSpec], spec_filter: list[Filter | None],
-    batch_size_cfg: int | None, vt: str,
-) -> list[FilterGroup]:
-    """Group `idxs` (every spec of one vector_type, Path B only — none of
-    them unfiltered) by exact filter equality (`Filter`'s own hash/eq), so
-    specs sharing an identical filter compact/transfer/score together once
-    instead of each redoing it."""
-    by_filter: dict[Filter | None, list[int]] = {}
-    for i in idxs:
-        by_filter.setdefault(spec_filter[i], []).append(i)
-    groups = []
-    for filt, members in by_filter.items():
-        k_floor = max(specs[m].k for m in members)
-        groups.append(FilterGroup(
-            filter=filt,
-            member_idxs=members,
-            batch_size=_path_b_group_batch_size(batch_size_cfg, k_floor, vt),
-        ))
-    return groups
+def _union_keep(filters: list[Filter], keeps: dict[Filter | None, np.ndarray | None]) -> np.ndarray:
+    """OR-reduce of every DISTINCT active filter's keep-mask in `filters` —
+    the shared row-set for a vector_type where no search is unfiltered (see
+    `run_compute`). Never called with `None` in `filters` (that's the
+    `has_baseline` case, handled by leaving the whole file uncompacted
+    instead), so every `keeps[f]` here is a real per-row `np.ndarray`, not
+    `None`. `filters` is never empty (a vt only reaches this function once
+    `vt_spec_idxs` has established it has at least one spec, each with a
+    real filter)."""
+    return np.logical_or.reduce([keeps[f] for f in filters])
 
 
 def _process_batch_group(
     batch, member_idxs: list[int], specs: list[SearchSpec], spec_Q, spec_top_scores, spec_top_enc,
     batch_size: int | None, gidx: int, device: str, orig_rows: np.ndarray | None, select,
 ) -> float:
-    """Shared Path A / Path B primitive: iterate `batch` in `batch_size`-row
-    slices, transfer each slice once (`batch.transfer`), score it once per
+    """The shared per-vector_type primitive behind `_process_shared_batch`:
+    iterate `batch` in `batch_size`-row slices, transfer each slice once
+    (`batch.transfer`), score it once per
     DISTINCT metric among `member_idxs` (`score_cache` — every member needing
     that metric reads the same tensor), and merge each member's own top-k
     from those shared columns via `_merge_topk`.
 
     `orig_rows` maps a slice position to its TRUE file-row number: `None`
-    means position IS the true row (Path A, `_process_shared_batch` below —
-    it never compacts, so `batch` is the raw, whole file); an array means
-    `batch` was already compacted by the caller (Path B,
-    `_process_filter_group` below) and this maps back to true rows for
-    `_merge_topk`'s encoding.
+    means position IS the true row — `batch` is the raw, whole file, because
+    some search of this vector_type is unfiltered and needs every row; an
+    array means `batch` was already compacted by the caller (to the union of
+    every active filter's surviving rows — see `run_compute`'s `has_baseline`
+    and `_union_keep`) and this maps back to true rows for `_merge_topk`'s
+    encoding.
 
-    `select(m, r0, r1, rows, cache) -> (sel_rows, sel_cols)` is the per-member
-    filtering strategy: `sel_rows is None` skips the merge entirely for this
-    member/slice (e.g. a filter keeping zero rows here); otherwise `sel_cols`
-    is either `None` (use the slice's columns/rows unchanged — Path B, whose
-    members already share one filter via compaction) or a column-index tensor
-    used to mask both the score matrix and `rows` down to a per-member
-    filter's surviving columns (Path A). `cache` is a fresh dict per r0-slice
-    for `select` to memoize per-filter lookups shared across members (see
-    `_path_a_select`) — it does not persist across slices, since the mask is
-    slice-relative.
+    `select(m, rows, true_rows, cache) -> (sel_rows, sel_cols)` is the
+    per-member filtering strategy (see `_process_shared_batch`): `sel_rows
+    is None` skips the merge entirely for this member/slice (e.g. a filter
+    keeping zero rows here); otherwise `sel_cols` is either `None` (member is
+    unfiltered, use the slice's rows unchanged) or a column-index tensor used
+    to mask both the score matrix and `rows` down to that member's own
+    filter's surviving columns. `true_rows` indexes a filter's keep-mask
+    (sized to the whole file, not to this possibly-already-compacted batch):
+    a plain `slice(r0, r1)` when `orig_rows is None` (position IS the true
+    row — a cheap view, no copy), or `orig_rows`'s corresponding array slice
+    otherwise. `cache` is a fresh dict per r0-slice for `select` to memoize
+    per-filter lookups shared across members — it does not persist across
+    slices, since the mask is slice-relative.
 
     Returns elapsed wall-clock seconds spent in this loop (folded into the
-    caller's `gpu_secs`). Callers that pre-compact (Path B) must compact
+    caller's `gpu_secs`). A caller that pre-compacts `batch` must do so
     BEFORE calling this function — its own timer starts only once this loop
     begins, so CPU-side compaction time never counts as GPU time (see the
     `io_wait`/`gpu_secs` split docs at the top of this module)."""
@@ -665,9 +638,15 @@ def _process_batch_group(
         r1 = min(r0 + step, n_rows)
         sl = batch.transfer(r0, r1, device)
         if orig_rows is None:
+            # No CPU round-trip: build the row-index tensor directly on
+            # device, and use a plain slice (a view, not a gather-copy) to
+            # index a filter's keep-mask below — position already IS the
+            # true row here, so there's nothing to remap.
             rows = torch.arange(r0, r0 + sl.n_rows, dtype=torch.int64, device=device)
+            true_rows = slice(r0, r0 + sl.n_rows)
         else:
-            rows = torch.from_numpy(orig_rows[r0 : r0 + sl.n_rows]).to(device, non_blocking=True)
+            true_rows = orig_rows[r0 : r0 + sl.n_rows]
+            rows = torch.from_numpy(true_rows).to(device, non_blocking=True)
 
         score_cache: dict[str, object] = {}
         cache: dict[object, object] = {}  # keyed by whatever select() memoizes on (e.g. Filter)
@@ -677,7 +656,7 @@ def _process_batch_group(
                 score_cache[s.metric] = sl.score(spec_Q[m], s.metric)
             scores = score_cache[s.metric]
 
-            sel_rows, sel_cols = select(m, r0, r1, rows, cache)
+            sel_rows, sel_cols = select(m, rows, true_rows, cache)
             if sel_rows is None:
                 continue
             sel_scores = scores if sel_cols is None else scores[:, sel_cols]
@@ -693,79 +672,47 @@ def _is_unfiltered(f: Filter | None) -> bool:
     (`Filter(must=(), should=(), must_not=())`) is semantically the same —
     `evaluate()` keeps every row either way — so both must be treated
     identically wherever "does this spec have an active filter" decides
-    Path A/B GPU-sharing (`has_baseline`) or per-member masking
-    (`_path_a_select`). `f.fields()` is empty iff every condition group is
-    empty, without duplicating that check against `Filter`'s own fields."""
+    `run_compute`'s `has_baseline` or `_process_shared_batch`'s per-member
+    masking. `f.fields()` is empty iff every condition group is empty,
+    without duplicating that check against `Filter`'s own fields."""
     return f is None or not f.fields()
 
 
-def _path_a_select(
-    specs: list[SearchSpec], keeps: dict[Filter | None, np.ndarray | None], device: str,
-):
-    """Path A's `select` for `_process_batch_group`: an unfiltered member uses
-    the shared slice as-is; a filtered member masks it down to its own
-    filter's surviving columns, via a `local_idx` cached per filter (in the
-    caller-provided per-slice `cache`) so two members sharing an identical
-    filter don't recompute `nonzero` twice."""
+def _process_shared_batch(
+    batch, member_idxs: list[int], specs: list[SearchSpec], spec_Q, spec_top_scores, spec_top_enc,
+    keeps: dict[Filter | None, np.ndarray | None], batch_size: int | None,
+    gidx: int, device: str, orig_rows: np.ndarray | None,
+) -> float:
+    """Every search of this vector_type shares one batch grid: `orig_rows`
+    is `None` when some search is unfiltered (`batch` is the raw, whole
+    file — see `run_compute`'s `has_baseline`), or the true-row map produced
+    by compacting `batch` to the union of every active filter otherwise (see
+    `_union_keep`). Either way, a filtered search masks the shared columns
+    down to its own filter's surviving rows, via a `local_idx` cached per
+    filter (in `_process_batch_group`'s per-slice `cache`) so two members
+    sharing an identical filter don't recompute `nonzero` twice — indexing
+    `keeps[s.filter]` by `true_rows` (each slice position's TRUE file row),
+    not by position, since the shared batch may already be a compacted
+    subset of the file. See `_process_batch_group` for the shared loop
+    body."""
     import torch
 
-    def select(m: int, r0: int, r1: int, rows, cache: dict[object, object]):
+    def select(m: int, rows, true_rows, cache: dict[object, object]):
         s = specs[m]
         if _is_unfiltered(s.filter):
             return rows, None
         local_idx = cache.get(s.filter)
         if local_idx is None:
-            local_np = np.nonzero(keeps[s.filter][r0:r1])[0]
+            local_np = np.nonzero(keeps[s.filter][true_rows])[0]
             local_idx = torch.from_numpy(local_np).to(device, non_blocking=True)
             cache[s.filter] = local_idx
         if local_idx.numel() == 0:
             return None, None
         return rows[local_idx], local_idx
 
-    return select
-
-
-def _path_b_select(m: int, r0: int, r1: int, rows, cache: dict[object, object]):
-    """Path B's `select` for `_process_batch_group`: every member of a
-    `FilterGroup` shares one identical filter, already applied via
-    `batch.compact()` before this loop runs — no further per-member masking
-    needed, so this is a no-op that always merges the slice unchanged."""
-    return rows, None
-
-
-def _process_shared_batch(
-    batch, member_idxs: list[int], specs: list[SearchSpec], spec_Q, spec_top_scores, spec_top_enc,
-    keeps: dict[Filter | None, np.ndarray | None], batch_size: int | None,
-    gidx: int, device: str,
-) -> float:
-    """Path A: every spec of this vector_type — filtered or not — shares one
-    full-file batch grid; a filtered spec masks the shared columns down to
-    its own filter's surviving rows (`_path_a_select`). See
-    `_process_batch_group` for the shared loop body."""
     return _process_batch_group(
         batch, member_idxs, specs, spec_Q, spec_top_scores, spec_top_enc,
-        batch_size, gidx, device, orig_rows=None,
-        select=_path_a_select(specs, keeps, device),
-    )
-
-
-def _process_filter_group(
-    batch, group: FilterGroup, specs: list[SearchSpec], spec_Q, spec_top_scores, spec_top_enc,
-    keep: np.ndarray, gidx: int, device: str,
-) -> float:
-    """Path B: no spec of this vector_type is unfiltered, so there's no
-    full-file score matrix to derive from — this group's rows are compacted
-    once (`batch.compact`), then run through the shared loop
-    (`_process_batch_group`) unmasked (`_path_b_select`), same as a single
-    spec running alone would. `batch.compact()` runs OUTSIDE (before)
-    `_process_batch_group`'s own timer, so its real but CPU-side cost (row
-    filtering, array copies — scales with corpus size, not GPU work) never
-    counts toward the `gpu_secs` signal (see the `io_wait`/`gpu_secs` split
-    docs at the top of this module)."""
-    compacted, orig_rows = batch.compact(keep)
-    return _process_batch_group(
-        compacted, group.member_idxs, specs, spec_Q, spec_top_scores, spec_top_enc,
-        group.batch_size, gidx, device, orig_rows=orig_rows, select=_path_b_select,
+        batch_size, gidx, device, orig_rows=orig_rows, select=select,
     )
 
 
@@ -781,11 +728,12 @@ def run_compute(
     filter combinations — against the corpus in ONE pass: each file is read
     and decoded once per vector_type actually needed (not once per spec), and
     every distinct filter is evaluated once per file regardless of how many
-    searches share it. Per vector_type, searches then share GPU work via
-    `_process_shared_batch` (Path A, when some search is unfiltered) or
-    `_process_filter_group` (Path B, otherwise) — see this module's
-    docstring. Only each search's own scoring and top-K accumulation stay
-    independent. Returns `{spec.name: output_path}`.
+    searches share it. Per vector_type, every search then shares one GPU
+    batch grid via `_process_shared_batch` — the whole file when some search
+    is unfiltered, otherwise the union of every active filter's surviving
+    rows (`_union_keep`) — see this module's docstring. Only each search's
+    own scoring and top-K accumulation stay independent. Returns
+    `{spec.name: output_path}`.
     """
     try:
         import torch
@@ -894,10 +842,10 @@ def run_compute(
 
     # Per vector_type: does any spec have no filter (or an explicit-but-empty
     # one — see `_is_unfiltered`)? If so every spec of that vector_type shares
-    # one full-file batch grid (Path A, `_process_shared_batch`); otherwise
-    # specs are grouped by exact filter equality instead (Path B,
-    # `_process_filter_group`) since there's no full-file computation to
-    # derive from. See this module's docstring for the full rationale.
+    # the whole file, uncompacted (`has_baseline`); otherwise every spec has
+    # an active filter, so the shared grid is instead the UNION of those
+    # filters' surviving rows (`_union_keep`, computed fresh per file below).
+    # See this module's docstring for the full rationale.
     spec_filter = [s.filter for s in specs]
     distinct_filters: list[Filter | None] = list(dict.fromkeys(spec_filter))
 
@@ -907,25 +855,26 @@ def run_compute(
 
     vt_configured_batch = {"dense": cfg.params.dense_batch_size, "sparse": cfg.params.sparse_batch_size}
     has_baseline: dict[str, bool] = {}
-    path_a_batch_size: dict[str, int | None] = {}
-    path_b_groups: dict[str, list[FilterGroup]] = {}
+    vt_batch_size: dict[str, int | None] = {}
+    vt_union_filters: dict[str, list[Filter]] = {}
     for vt, idxs in vt_spec_idxs.items():
         has_baseline[vt] = any(_is_unfiltered(specs[i].filter) for i in idxs)
+        # Every search of this vector_type shares one batch grid regardless of
+        # which branch below applies, so k_floor spans ALL of them, not just a
+        # same-filter subset — see _resolve_vt_batch_size's docstring.
+        k_floor = max(specs[i].k for i in idxs)
+        vt_batch_size[vt] = _resolve_vt_batch_size(vt_configured_batch[vt], k_floor, vt)
         if has_baseline[vt]:
-            k_floor = max(specs[i].k for i in idxs)
-            path_a_batch_size[vt] = _path_a_batch_size(vt_configured_batch[vt], k_floor, vt)
             logger.info(
                 "vector_type=%r: %d search(es) share one full-file batch pass (batch_size=%s)",
-                vt, len(idxs), path_a_batch_size[vt],
+                vt, len(idxs), vt_batch_size[vt],
             )
         else:
-            path_b_groups[vt] = _build_filter_groups(
-                idxs, specs, spec_filter, vt_configured_batch[vt], vt,
-            )
+            vt_union_filters[vt] = list(dict.fromkeys(spec_filter[i] for i in idxs))
             logger.info(
-                "vector_type=%r: no unfiltered search — %d distinct filter group(s), "
-                "each compacting its own rows independently",
-                vt, len(path_b_groups[vt]),
+                "vector_type=%r: no unfiltered search — %d search(es) share one batch pass "
+                "over the union of %d distinct filter(s) (batch_size=%s)",
+                vt, len(idxs), len(vt_union_filters[vt]), vt_batch_size[vt],
             )
 
     # Prefetch corpus files with a POOL of reader threads so many S3 GETs are in
@@ -986,8 +935,8 @@ def run_compute(
                 table = cstore.read_columns(f.read_path, read_cols)
                 # Decode each vector_type at most ONCE per file, regardless of how many
                 # specs need it — wrapped in the batch abstraction (`DenseCorpusBatch`/
-                # `SparseCorpusBatch`) in the consumer loop below, where every spec (Path
-                # A) or filter group (Path B) of that vector_type shares it.
+                # `SparseCorpusBatch`) in the consumer loop below, where every spec of
+                # that vector_type shares it (see `run_compute`'s `has_baseline`).
                 arrs: dict[str, object] = {}
                 if "dense" in vts_needed:
                     arrs["dense"] = dense_to_2d(table[dense_col])
@@ -1055,9 +1004,9 @@ def run_compute(
             bar.update(1)
 
             # Wrap this file's decoded arrays in the vector_type-agnostic batch
-            # abstraction ONCE — every spec of a vector_type (Path A) or every
-            # filter group of it (Path B) shares the same wrapper below, never
-            # rebuilding or mutating the underlying decoded arrays.
+            # abstraction ONCE — every spec of a vector_type shares the same
+            # wrapper below, never rebuilding or mutating the underlying
+            # decoded arrays.
             batches: dict[str, object] = {}
             if "dense" in vts_needed:
                 batches["dense"] = DenseCorpusBatch(arrs["dense"])
@@ -1090,16 +1039,19 @@ def run_compute(
             for vt in vts_needed:
                 b = batches[vt]
                 if has_baseline[vt]:
-                    gpu_secs += _process_shared_batch(
-                        b, vt_spec_idxs[vt], specs, spec_Q, spec_top_scores, spec_top_enc,
-                        keeps, path_a_batch_size[vt], gidx, device,
-                    )
+                    batch, orig_rows = b, None
                 else:
-                    for group in path_b_groups[vt]:
-                        keep = keeps[group.filter]
-                        gpu_secs += _process_filter_group(
-                            b, group, specs, spec_Q, spec_top_scores, spec_top_enc, keep, gidx, device,
-                        )
+                    # Compact to the union OUTSIDE _process_shared_batch's own
+                    # timer, same as the old per-filter-group compaction did —
+                    # this CPU-side cost (row filtering, array copies — scales
+                    # with corpus size, not GPU work) never counts toward the
+                    # gpu_secs signal (see the io_wait/gpu_secs split docs at
+                    # the top of this module).
+                    batch, orig_rows = b.compact(_union_keep(vt_union_filters[vt], keeps))
+                gpu_secs += _process_shared_batch(
+                    batch, vt_spec_idxs[vt], specs, spec_Q, spec_top_scores, spec_top_enc,
+                    keeps, vt_batch_size[vt], gidx, device, orig_rows=orig_rows,
+                )
 
             if bar.n % 200 == 0:
                 postfix = f"io_wait={io_wait:.0f}s gpu={gpu_secs:.0f}s"

--- a/python/nova-bf/src/nova_bf/config.py
+++ b/python/nova-bf/src/nova_bf/config.py
@@ -119,14 +119,24 @@ class ParamsConfig(BaseModel):
     # Bounds the per-file score matrix (`queries × rows`) for dense/sparse
     # searches respectively — a big file (or large query set) can otherwise
     # OOM the GPU; set this to score in row-batches instead of the whole file
-    # at once. None (default) = whole file in one matmul. Lives here (one
-    # value per vector_type, run-wide) rather than per-search: every search of
-    # a given vector_type ends up sharing one GPU pass over the corpus anyway
+    # at once. None (default) = whole file (or, if every search of that
+    # vector_type has an active filter, the UNION of their surviving rows —
+    # see compute.py's `_union_keep`) in one matmul. Lives here (one value
+    # per vector_type, run-wide) rather than per-search: every search of a
+    # given vector_type ends up sharing one GPU pass over the corpus anyway
     # (see compute.py), so a per-search value would just be resolved down to
-    # this same shared number regardless — this makes that explicit instead of
-    # implicit. Values below a search's own `k` are raised to `k` (a batch
-    # smaller than `k` can't fill that search's top-K and gives no memory
-    # benefit).
+    # this same shared number regardless — this makes that explicit instead
+    # of implicit. A value below some search's own `k` is never raised —
+    # only warned about (that search just needs extra merge rounds to fill
+    # its own top-K, at no extra memory cost to anyone).
+    #
+    # When every search of a vector_type has an active filter, this is now
+    # the ONLY memory bound on that vector_type's shared pass: the union of
+    # several large, mostly-disjoint filters can be nearly as big as the
+    # whole file, transferred/scored in one shot if this is left at its
+    # None default — set it explicitly if you have several such filters and
+    # relied on each one's own (typically much smaller) surviving-row count
+    # bounding memory implicitly.
     # `gt=0`: a batch size of 0 or negative isn't just useless, it's actively
     # wrong — `range(0, n_rows, step)` with a non-positive `step` is EMPTY, so
     # every file's batch loop would silently skip all rows, no exception, no
@@ -236,7 +246,7 @@ class Filter(BaseModel):
 
     Frozen and hashable (see `RangeCondition`'s docstring) — usable directly
     as a dict key wherever specs need grouping/deduping by identical filter
-    (see compute.py's `spec_filter`/`FilterGroup.filter`/`keeps`), via
+    (see compute.py's `spec_filter`/`_union_keep`/`keeps`), via
     pydantic's own `__eq__`/`__hash__`, with no separate canonicalization
     scheme needed: two `Filter`s are "the same" iff Python's own `==` says so,
     which for `int`/`float`/`nan`/`inf` `match` values already has exactly the

--- a/python/nova-bf/tests/test_compute_multi.py
+++ b/python/nova-bf/tests/test_compute_multi.py
@@ -1,16 +1,17 @@
 """Correctness tests for `BruteForceConfig.searches` — running several
 independent top-K searches (dense/sparse x filtered/unfiltered) against the
 SAME corpus in one `run_compute`/`run_merge` call, sharing corpus file IO and
-per-vector-type decode across specs. Per vector_type, searches additionally
-share GPU work one of two ways (see compute.py's module docstring):
+per-vector-type decode across specs. Per vector_type, every search sharing
+that vector_type shares ONE GPU batch grid via `_process_shared_batch` (see
+compute.py's module docstring):
 
-- Path A (`_process_shared_batch`): if ANY search of that vector_type is
-  unfiltered, every search of that vector_type shares one full-file batch
-  pass — a filtered search's own `metric` never needs to match anyone
-  else's, since scoring one more metric on an already-resident batch is
-  cheap.
-- Path B (`_process_filter_group`): otherwise, searches are grouped by exact
-  filter equality and each such group compacts its own rows independently.
+- If ANY search of that vector_type is unfiltered, the shared grid is the
+  whole file, uncompacted — a filtered search's own `metric` never needs to
+  match anyone else's, since scoring one more metric on an already-resident
+  batch is cheap.
+- Otherwise, the shared grid is the UNION of every distinct active filter's
+  surviving rows (`_union_keep`), compacted/transferred/scored once, with
+  each search then masking down further to its own filter's subset.
 
 Only each search's own scoring and top-K stay independent either way.
 
@@ -179,18 +180,19 @@ def test_grouped_matches_ungrouped_per_search(ds):
     searches together must produce results BIT-IDENTICAL to running each of
     those same searches alone, one per `run_compute` call. Covers dense+
     sparse, all three dense metrics (cosine/dot/euclidean) sharing the SAME
-    unfiltered pass (Path A — see `_scores`), and a filtered dense search
-    (`dense_eng`) riding that same pass alongside them."""
+    unfiltered pass (see `_scores`), and a filtered dense search (`dense_eng`)
+    riding that same pass alongside them."""
     eng_filter = Filter(must=[FilterCondition(field="language", match="eng")])
     specs = [
-        # dense: 3 unfiltered members (all 3 metrics) -> Path A baseline
+        # dense: 3 unfiltered members (all 3 metrics) -> whole-file baseline
         SearchSpec(name="dense_dot", vector_type="dense", metric="dot", k=3),
         SearchSpec(name="dense_cos", vector_type="dense", metric="cosine", k=2),
         SearchSpec(name="dense_euclid", vector_type="dense", metric="euclidean", k=2),
         # dense: filtered, but an unfiltered dense sibling exists above -> also
-        # rides Path A (masked down to its own filter), not processed alone
+        # rides the shared batch (masked down to its own filter), not
+        # processed alone
         SearchSpec(name="dense_eng", vector_type="dense", metric="dot", k=2, filter=eng_filter),
-        # sparse: 2 unfiltered members, mixed metrics — Path A again (the
+        # sparse: 2 unfiltered members, mixed metrics — shared again (the
         # shared-metric-cache path; see test_three_member_group_mixed_metrics
         # for a 3-member version with independently-verified ground truth)
         SearchSpec(name="sparse_dot", vector_type="sparse", metric="dot", k=3),
@@ -222,7 +224,7 @@ def test_grouped_matches_ungrouped_per_search(ds):
 
 
 def test_three_member_group_mixed_metrics(tmp_path):
-    """One Path A shared batch (vector_type=sparse, all three unfiltered) with
+    """One shared batch (vector_type=sparse, all three unfiltered) with
     THREE members: two `cosine`, one `dot` — directly targets the two riskiest
     bug classes from grouping sparse searches: double-normalization (a cosine
     member's score divided by row_norms twice) and cross-member contamination
@@ -277,35 +279,182 @@ def test_three_member_group_mixed_metrics(tmp_path):
             assert cos[cid] == pytest.approx(expected, abs=1e-4), f"search={name} id={cid}"
 
 
-def test_path_b_group_batch_size_raises_to_k_floor():
-    """Unit test for `_path_b_group_batch_size` — `k_floor` is scoped to one
-    `FilterGroup`'s own (related) members: a configured batch below that
-    floor is raised to it, never left below — the extra merge rounds below
-    `k` buy nothing since the group's own memory footprint is unaffected
-    either way."""
-    assert compute_mod._path_b_group_batch_size(10, k_floor=100, vt="dense") == 100
-    assert compute_mod._path_b_group_batch_size(500, k_floor=100, vt="dense") == 500
-    assert compute_mod._path_b_group_batch_size(None, k_floor=100, vt="dense") is None
+def test_resolve_vt_batch_size_never_raises():
+    """Unit test for `_resolve_vt_batch_size` — `k_floor` spans EVERY search
+    of a vector_type, since they all now share one batch grid regardless of
+    filter (see `_union_keep`). Raising a configured value here would let one
+    search's large `k` silently blow past a DIFFERENT, unrelated search's own
+    memory bound, so it's never overridden — only warned about — even when
+    it's below `k_floor`. (Unlike the old per-identical-filter-group
+    behavior this replaced: that raised freely, since only THAT group's own
+    members shared the grid back then — see
+    test_identical_filter_specs_no_longer_raise_batch_size.)"""
+    assert compute_mod._resolve_vt_batch_size(10, k_floor=100, vt="dense") == 10
+    assert compute_mod._resolve_vt_batch_size(500, k_floor=100, vt="dense") == 500
+    assert compute_mod._resolve_vt_batch_size(None, k_floor=100, vt="dense") is None
 
 
-def test_path_a_batch_size_respects_configured_value():
-    """Unit test for `_path_a_batch_size` — `k_floor` spans EVERY search of a
-    vector_type, related or not. Raising it here would let one search's
-    large `k` silently blow past a DIFFERENT search's own memory bound, so a
-    configured value is never overridden — only warned about — even when
-    it's below `k_floor`."""
-    assert compute_mod._path_a_batch_size(10, k_floor=100, vt="dense") == 10
-    assert compute_mod._path_a_batch_size(500, k_floor=100, vt="dense") == 500
-    assert compute_mod._path_a_batch_size(None, k_floor=100, vt="dense") is None
+def test_union_keep_ors_every_distinct_filter():
+    """Unit test for `_union_keep`: the shared row-set for a vector_type with
+    no unfiltered search is the OR of every distinct filter's own mask, not
+    just one of them — this is what lets fully disjoint filters still share
+    ONE transfer/score pass instead of one each."""
+    keeps = {
+        "a": np.array([True, False, False, True]),
+        "b": np.array([False, True, False, False]),
+    }
+    union = compute_mod._union_keep(["a", "b"], keeps)
+    assert union.tolist() == [True, True, False, True]
+    # a single filter's union is just its own mask, copied (not aliased —
+    # mutating the result must never corrupt `keeps`).
+    solo = compute_mod._union_keep(["a"], keeps)
+    solo[0] = False
+    assert keeps["a"][0]
+
+
+def test_no_baseline_distinct_filters_match_independent_ground_truth(ds):
+    """The core regression guard for the union-of-filters mechanism
+    (`_union_keep`): when NO search of a vector_type is unfiltered, but two
+    searches have genuinely DIFFERENT (here, disjoint — eng vs fra) filters,
+    each must still get its own correct top-K — the shared union batch must
+    never let one search's filter leak into another's results. `lang_by_g`
+    alternates eng/fra across the WHOLE corpus, so the union here covers
+    every row, the same as an unfiltered baseline would — a good edge case
+    for the union path specifically."""
+    eng_filter = Filter(must=[FilterCondition(field="language", match="eng")])
+    fra_filter = Filter(must=[FilterCondition(field="language", match="fra")])
+    specs = [
+        SearchSpec(name="dense_eng", vector_type="dense", metric="dot", k=3, filter=eng_filter),
+        SearchSpec(name="dense_fra", vector_type="dense", metric="dot", k=3, filter=fra_filter),
+    ]
+    cfg = BruteForceConfig(
+        corpus=CorpusConfig(path=ds["cdir"], id_column="id"),
+        queries=QueriesConfig(path=ds["qpath"], id_column="qid"),
+        output=OutputConfig(path=_out(ds, "no_baseline_union_out")),
+        searches=specs,
+    )
+    paths = run_compute(cfg)
+
+    eng_globals = [g for g, lang in enumerate(ds["lang_by_g"]) if lang == "eng"]
+    fra_globals = [g for g, lang in enumerate(ds["lang_by_g"]) if lang == "fra"]
+    expectations = {
+        "dense_eng": ds["ground_truth"]("dense", 3, allowed=eng_globals),
+        "dense_fra": ds["ground_truth"]("dense", 3, allowed=fra_globals),
+    }
+    for name, expected in expectations.items():
+        t = pq.read_table(paths[name]).to_pydict()
+        got = {q: hi for q, hi in zip(t["query_id"], t["hit_ids"])}
+        for q in ds["qids"]:
+            assert got[q] == expected[q], f"search={name} query={q}"
+
+
+def test_no_baseline_distinct_filters_match_solo_runs_bit_identical(ds):
+    """Companion to `test_grouped_matches_ungrouped_per_search`, specifically
+    for the no-baseline union path: two searches with different (eng/fra)
+    filters and no unfiltered sibling must produce results BIT-IDENTICAL to
+    running each alone — each solo run's own union is just its single
+    filter, so this also proves the union path degenerates correctly to the
+    single-filter case."""
+    eng_filter = Filter(must=[FilterCondition(field="language", match="eng")])
+    fra_filter = Filter(must=[FilterCondition(field="language", match="fra")])
+    specs = [
+        SearchSpec(name="dense_eng", vector_type="dense", metric="dot", k=3, filter=eng_filter),
+        SearchSpec(name="dense_fra", vector_type="dense", metric="dot", k=3, filter=fra_filter),
+    ]
+    combined_cfg = BruteForceConfig(
+        corpus=CorpusConfig(path=ds["cdir"], id_column="id"),
+        queries=QueriesConfig(path=ds["qpath"], id_column="qid"),
+        output=OutputConfig(path=_out(ds, "no_baseline_union_combined")),
+        searches=specs,
+    )
+    combined_paths = run_compute(combined_cfg)
+
+    for spec in specs:
+        solo_cfg = BruteForceConfig(
+            corpus=CorpusConfig(path=ds["cdir"], id_column="id"),
+            queries=QueriesConfig(path=ds["qpath"], id_column="qid"),
+            output=OutputConfig(path=_out(ds, f"no_baseline_union_solo_{spec.name}")),
+            searches=[spec],
+        )
+        solo_path = run_compute(solo_cfg)[spec.name]
+
+        combined_t = pq.read_table(combined_paths[spec.name]).to_pydict()
+        solo_t = pq.read_table(solo_path).to_pydict()
+        assert combined_t["hit_ids"] == solo_t["hit_ids"], f"search={spec.name}"
+        for combined_scores, solo_scores in zip(combined_t["hit_scores"], solo_t["hit_scores"]):
+            assert np.allclose(combined_scores, solo_scores, atol=1e-5), f"search={spec.name}"
+
+
+def test_no_baseline_log_reports_union_of_distinct_filters(ds, caplog):
+    """Regression test for the log wording itself: with no unfiltered search
+    sharing a vector_type, the log must report the union path (distinct
+    filter count), not the old per-group wording."""
+    eng_filter = Filter(must=[FilterCondition(field="language", match="eng")])
+    fra_filter = Filter(must=[FilterCondition(field="language", match="fra")])
+    specs = [
+        SearchSpec(name="dense_eng", vector_type="dense", metric="dot", k=3, filter=eng_filter),
+        SearchSpec(name="dense_fra", vector_type="dense", metric="dot", k=3, filter=fra_filter),
+    ]
+    cfg = BruteForceConfig(
+        corpus=CorpusConfig(path=ds["cdir"], id_column="id"),
+        queries=QueriesConfig(path=ds["qpath"], id_column="qid"),
+        output=OutputConfig(path=_out(ds, "no_baseline_union_log_out")),
+        searches=specs,
+    )
+    with caplog.at_level(logging.INFO, logger="nova_bf.compute"):
+        run_compute(cfg)
+    assert any(
+        "no unfiltered search" in r.message and "union of 2 distinct filter(s)" in r.message
+        for r in caplog.records
+    )
+
+
+def test_identical_filter_specs_no_longer_raise_batch_size(ds, caplog):
+    """Deliberate behavior change from the old per-identical-filter-group
+    path: specs sharing an IDENTICAL filter used to have their batch size
+    raised to their own group's k_floor (safe when only THAT group shared
+    the grid). Now every search of the vector_type shares ONE grid regardless
+    of filter — even when they're all the same filter — so raising is no
+    longer safe in general and `_resolve_vt_batch_size` never does it; a
+    small configured batch just costs the larger-k search extra merge
+    rounds instead of a wrong answer."""
+    eng_filter = Filter(must=[FilterCondition(field="language", match="eng")])
+    specs = [
+        SearchSpec(name="eng_smallk", vector_type="dense", metric="dot", k=2, filter=eng_filter),
+        SearchSpec(name="eng_bigk", vector_type="dense", metric="dot", k=1000, filter=eng_filter),
+    ]
+    cfg = BruteForceConfig(
+        corpus=CorpusConfig(path=ds["cdir"], id_column="id"),
+        queries=QueriesConfig(path=ds["qpath"], id_column="qid"),
+        output=OutputConfig(path=_out(ds, "identical_filter_no_raise_out")),
+        params=ParamsConfig(dense_batch_size=1),
+        searches=specs,
+    )
+    with caplog.at_level(logging.INFO, logger="nova_bf.compute"):
+        paths = run_compute(cfg)
+    assert any("batch_size=1)" in r.message for r in caplog.records), \
+        "batch size must stay at the configured 1, not be raised to k=1000 (old Path B behavior)"
+    assert not any("raising to k" in r.message for r in caplog.records)
+
+    eng_globals = [g for g, lang in enumerate(ds["lang_by_g"]) if lang == "eng"]
+    expectations = {
+        "eng_smallk": ds["ground_truth"]("dense", 2, allowed=eng_globals),
+        "eng_bigk": ds["ground_truth"]("dense", 1000, allowed=eng_globals),
+    }
+    for name, expected in expectations.items():
+        t = pq.read_table(paths[name]).to_pydict()
+        got = {q: hi for q, hi in zip(t["query_id"], t["hit_ids"])}
+        for q in ds["qids"]:
+            assert got[q] == expected[q], f"search={name} query={q}"
 
 
 def test_batch_size_floor_end_to_end_still_correct(ds):
-    """End-to-end companion to the unit tests above: a tiny `params.
-    dense_batch_size` shared by a low-k and a high-k search (both unfiltered
-    -> Path A, so the configured value is kept rather than raised — see
-    test_path_a_batch_size_respects_configured_value) must still produce
-    correct, ground-truth-matching results for BOTH — an under-filled batch
-    means more merge rounds, never a wrong answer."""
+    """End-to-end companion to the unit test above: a tiny `params.
+    dense_batch_size` shared by a low-k and a high-k search (both unfiltered,
+    so the configured value is kept rather than raised — see
+    test_resolve_vt_batch_size_never_raises) must still produce correct,
+    ground-truth-matching results for BOTH — an under-filled batch means
+    more merge rounds, never a wrong answer."""
     specs = [
         SearchSpec(name="low_k", vector_type="dense", metric="dot", k=2),
         SearchSpec(name="high_k", vector_type="dense", metric="dot", k=5),
@@ -314,7 +463,7 @@ def test_batch_size_floor_end_to_end_still_correct(ds):
         corpus=CorpusConfig(path=ds["cdir"], id_column="id"),
         queries=QueriesConfig(path=ds["qpath"], id_column="qid"),
         output=OutputConfig(path=_out(ds, "batch_floor_out")),
-        params=ParamsConfig(dense_batch_size=1),  # NOT raised to 5 — Path A keeps it at 1
+        params=ParamsConfig(dense_batch_size=1),  # NOT raised to 5 — kept at 1
         searches=specs,
     )
     paths = run_compute(cfg)
@@ -329,13 +478,13 @@ def test_batch_size_floor_end_to_end_still_correct(ds):
             assert got[q] == expected[q], f"search={name} query={q}"
 
 
-def test_unrelated_large_k_filtered_spec_does_not_inflate_shared_path_a_batch(ds, caplog):
-    """Regression test: under Path A, an unfiltered spec's own configured
-    `dense_batch_size` must not be silently widened just because a DIFFERENT,
-    filtered spec sharing the same vector_type has a much larger `k` — that
-    would defeat the memory bound the batch size exists to enforce. Both
-    specs must still produce correct results; only the log should note the
-    larger-k search needs extra merge rounds, not raise the resolved batch."""
+def test_unrelated_large_k_filtered_spec_does_not_inflate_shared_batch(ds, caplog):
+    """Regression test: an unfiltered spec's own configured `dense_batch_size`
+    must not be silently widened just because a DIFFERENT, filtered spec
+    sharing the same vector_type has a much larger `k` — that would defeat
+    the memory bound the batch size exists to enforce. Both specs must still
+    produce correct results; only the log should note the larger-k search
+    needs extra merge rounds, not raise the resolved batch."""
     eng_filter = Filter(must=[FilterCondition(field="language", match="eng")])
     specs = [
         SearchSpec(name="dense_all_smallk", vector_type="dense", metric="dot", k=2),
@@ -351,7 +500,7 @@ def test_unrelated_large_k_filtered_spec_does_not_inflate_shared_path_a_batch(ds
     with caplog.at_level(logging.INFO, logger="nova_bf.compute"):
         paths = run_compute(cfg)
     assert any("batch_size=1)" in r.message for r in caplog.records), "batch size must stay at the configured 1, not be raised to k=1000"
-    assert not any("raising to k" in r.message for r in caplog.records), "Path A must never force-raise a configured batch size"
+    assert not any("raising to k" in r.message for r in caplog.records), "the shared batch grid must never be force-raised for one unrelated search's large k"
 
     eng_globals = [g for g, lang in enumerate(ds["lang_by_g"]) if lang == "eng"]
     expectations = {
@@ -365,13 +514,13 @@ def test_unrelated_large_k_filtered_spec_does_not_inflate_shared_path_a_batch(ds
             assert got[q] == expected[q], f"search={name} query={q}"
 
 
-def test_explicit_empty_filter_still_rides_path_a(ds, caplog):
+def test_explicit_empty_filter_still_shares_full_file_batch(ds, caplog):
     """Regression test: an explicit-but-empty `filter: {}` (`Filter()`) is
     semantically identical to no filter at all — `evaluate()` keeps every
     row either way — so a vector_type where every spec sets one must still
-    take Path A's zero-copy full-file batch grid, not Path B's per-group row
-    compaction (which `has_baseline`'s `is None` check alone would have
-    mistakenly ruled out, since `Filter()` is not `None`)."""
+    take the zero-copy, whole-file shared batch grid, not the union-of-
+    filters compaction path (which `has_baseline`'s `is None` check alone
+    would have mistakenly ruled out, since `Filter()` is not `None`)."""
     specs = [
         SearchSpec(name="dense_a", vector_type="dense", metric="dot", k=3, filter=Filter()),
         SearchSpec(name="dense_b", vector_type="dense", metric="dot", k=3, filter=Filter()),
@@ -385,7 +534,7 @@ def test_explicit_empty_filter_still_rides_path_a(ds, caplog):
     with caplog.at_level(logging.INFO, logger="nova_bf.compute"):
         paths = run_compute(cfg)
     assert any("share one full-file batch pass" in r.message for r in caplog.records), \
-        "an explicit-but-empty filter must still route to Path A, not Path B's row compaction"
+        "an explicit-but-empty filter must still route to the whole-file shared batch, not union compaction"
     assert not any("no unfiltered search" in r.message for r in caplog.records)
 
     expected = ds["ground_truth"]("dense", 3)
@@ -450,7 +599,7 @@ def test_filtered_spec_metric_not_used_by_baseline_still_shares_batch(ds):
     the only unfiltered dense sibling (`dense_all`) is `dot` — under the old
     SpecGroup/borrower model this metric mismatch would have forced
     `dense_eng` into fully independent processing; now it still rides the
-    shared Path A batch (computing one more metric — `cosine` — on the
+    shared batch (computing one more metric — `cosine` — on the
     already-resident batch is cheap), and must produce results BIT-IDENTICAL
     to running it alone."""
     eng_filter = Filter(must=[FilterCondition(field="language", match="eng")])
@@ -474,10 +623,11 @@ def test_filtered_spec_metric_not_used_by_baseline_still_shares_batch(ds):
     )
     solo_path = run_compute(solo_cfg)["dense_eng"]
 
-    # Crucially, the solo run here has NO unfiltered dense sibling, so it takes
-    # Path B (independent compaction) — a different code path than the
-    # combined run's Path A. Matching bit-for-bit across both paths is a
-    # stronger proof than comparing either one to itself.
+    # Crucially, the solo run here has NO unfiltered dense sibling, so its
+    # shared batch is the union of its own (single) filter — batch.compact()
+    # runs, unlike the combined run's whole-file pass above. Matching
+    # bit-for-bit across both is a stronger proof than comparing either one
+    # to itself.
     combined_t = pq.read_table(combined_paths["dense_eng"]).to_pydict()
     solo_t = pq.read_table(solo_path).to_pydict()
     assert combined_t["hit_ids"] == solo_t["hit_ids"]
@@ -530,10 +680,10 @@ def test_sparse_cosine_filtered_spec_riding_dot_baseline_not_double_normalized(t
 
 
 def test_multi_batch_filtered_spec_riding_shared_batch_correct(ds):
-    """A filtered dense search sharing Path A's batch grid with an unfiltered
-    sibling must still accumulate the correct top-K across MULTIPLE batch
-    boundaries (`params.dense_batch_size` forces several batches per file) —
-    not just when the whole file fits in one batch."""
+    """A filtered dense search sharing the whole-file batch grid with an
+    unfiltered sibling must still accumulate the correct top-K across
+    MULTIPLE batch boundaries (`params.dense_batch_size` forces several
+    batches per file) — not just when the whole file fits in one batch."""
     eng_filter = Filter(must=[FilterCondition(field="language", match="eng")])
     specs = [
         SearchSpec(name="dense_all", vector_type="dense", metric="dot", k=3),
@@ -561,7 +711,7 @@ def test_multi_batch_filtered_spec_riding_shared_batch_correct(ds):
 
 
 def test_filtered_spec_zero_surviving_rows_in_a_middle_batch(tmp_path):
-    """A filtered search riding Path A's shared batch grid must handle a
+    """A filtered search riding the whole-file shared batch grid must handle a
     batch where NONE of its rows survive its filter — not just an all-or-
     nothing whole-file case (see `test_corpus_ids_resolved_even_when_a_
     different_specs_filter_drops_the_file` for the whole-file version). Rows


### PR DESCRIPTION
## Summary

This branch (`single-pass-bf`) reworks nova-bf's brute-force compute path from "one search, one corpus pass" into a single-pass, multi-search engine: any number of independent searches (vector_type × metric × k × filter combinations) now run against one read-through of the corpus, sharing IO, decode, and GPU batching wherever their underlying data/filters allow it. On top of that architecture, it adds a new **per-query filter** feature (filter values sourced from the queries file, not a fixed YAML literal), a long series of performance optimizations for both the shared architecture and the per-query filter case specifically, and a set of correctness fixes discovered while building and stress-testing all of it.

## Core capability: single-pass multi-search

- **Initial implementation**: `BruteForceConfig.searches` — a list of independent `SearchSpec`s (vector_type/metric/k/filter) — replaces the old one-search-per-run config. Each corpus file is read and decoded **once per vector_type actually needed**, not once per search, and `run_merge` was generalized from producing one top-K parquet to one per search.
- **GPU batch sharing** was built up in stages and then unified:
  - Query matrices are deduped and cached per vector_type (a cosine-normalized copy was previously re-computed and held once per spec, even when N specs shared the same vector_type).
  - Two separate sharing strategies ("Path A": whole-file shared batch when some search of a vector_type is unfiltered; "Path B": per-identical-filter grouped compaction otherwise) were eventually **collapsed into one mechanism**: every search of a vector_type always shares one batch grid — either the whole file (unfiltered case) or the **union of every distinct active filter's surviving rows** (`_union_keep`), compacted/transferred/scored once regardless of how many distinct filters share it. This never scores more rows than treating each filter independently would, and is strictly less whenever filters' surviving rows overlap.
  - `Filter`/`FilterCondition`/`RangeCondition` were made frozen, hashable pydantic models, retiring a ~110-line hand-rolled `filter_key()`/canonicalization scheme in favor of native `==`/`hash()` — used to dedup identical filters across specs and key per-file mask caches. (An intermediate int-index-based scheme was tried to avoid re-hashing on hot paths, then reverted once measurement showed the hash cost was immaterial next to corpus IO/GPU work — keying directly by the `Filter` object was simpler with no behavioral change.)
  - An explicit-but-empty filter (`filter: {}`) is now treated identically to an omitted filter for routing purposes — previously it was semantically unfiltered but still routed through per-group compaction, with no effect on results but wasted work.

## Per-query filters

Three new filter condition variants — `match_from_query`, `range_from_query`, `match_text_from_query` — pull their comparison value(s) from a column in the **queries** file instead of a fixed YAML literal, so different queries in the same search can be restricted to different corpus subsets (tenant/user scoping, a per-query budget, a per-query free-text search phrase). Usable in any of `must`/`should`/`must_not`, freely combinable with static conditions.

- `filters.evaluate()` takes an optional `query_values` dict; a filter with no per-query condition still returns `(rows,)` at unchanged cost, and the moment any condition anywhere is per-query, the result promotes to `(n_queries, rows)`.
- A per-query-filtered spec is masked via a `(n_queries, rows)` cell mask + `masked_fill` instead of a column gather — no changes needed to the id-encoding scheme, since no column is ever dropped. `merge.py` needed no changes at all: each shard already sees the full query set, so per-query filtering resolves entirely within one `run_compute` call.

### Performance optimizations for the per-query filter case

- **GPU-native evaluation**: `match_from_query`/`range_from_query` evaluate directly on GPU from small per-query vocab/membership/bound tensors built once at setup, plus per-file corpus arrays transferred once — no `(n_queries, rows)` mask is ever materialized on the CPU or shipped over PCIe for these two condition types.
- **Union-compaction**: a per-query filter no longer unconditionally forces its whole vector_type onto the whole-file grid — it contributes a cheap, safe row-level over-approximation to the same union-compaction a uniform filter's exact row-subset already benefits from.
- **Word-level dedup**: `match_text_from_query` (the one case that can't move to GPU — no string tensor type) caches each distinct **word's** regex mask across all query phrases in a file, instead of each distinct phrase, so two phrases sharing a word reuse that word's regex pass.
- **Bit-packed CPU-fallback mask**: the one case that still holds a dense `(n_queries, rows)` boolean mask on the CPU for a whole file's batch loop (any filter with a `match_text`/`match_text_from_query` leaf) bit-packs that mask along the query axis (8 queries/byte), cutting its footprint 8x. Row-slicing stays a plain column slice (rows aren't the packed axis), and the union-compaction reduction works unchanged on the packed bytes; each batch slice unpacks only its own row-slice back to real booleans, right before use.
- **Literal-substring prefilter**: `match_text_from_query`'s per-word regex computation now runs a cheap literal (non-regex) substring pass first to narrow to rows that could possibly match — a `\b`-bounded match always implies plain substring presence — before the pricier `\b`-bounded regex re-verifies just that (usually much smaller) subset. Skips the regex pass entirely when nothing survives the literal prefilter.
- Measured ~3x wall-clock improvement on a 20k-query × 20k-row synthetic scenario with forced multi-slice batching (GPU-native + union-compaction); ~2.4x faster per-word / ~7% faster end-to-end on the literal-prefilter change; no measurable slowdown from bit-packing. All verified bit-identical against the pre-optimization code on real FIQA data and against a real Qdrant instance's per-query exact search.

## Further parallelization of the shared architecture

Three more optimizations, chosen after empirically measuring each candidate's potential impact (2.6-9x speedups on the specific bottlenecks targeted) before implementing:

- **Reader-side compaction**: union-compaction (`_union_keep` + `.compact()`) moved from the single consumer thread into the `io_workers` reader threads, so this CPU-bound fancy-index copy runs concurrently across readers instead of serializing behind GPU enqueue on one thread.
- **Parallel CPU-fallback filter evaluation**: distinct filters with a `match_text`/`match_text_from_query` leaf are now evaluated concurrently via a per-file thread pool (pyarrow's regex kernels release the GIL, giving real thread-level speedup). The GPU-eligible branch stays sequential (its cross-filter leaf-array dedup isn't safe to parallelize without a lock, and it's the cheap branch anyway).
- **Cross-file batch coalescing**: when a vector_type has no unfiltered baseline and every filter it shares is uniform (non-per-query), several files' small, already-compacted batches now get combined into one larger GPU call instead of one call per file — amortizing per-file, per-spec fixed overhead. Required decoupling the running top-K merge's output-id encoding from the existing keep-mask-indexing role of `orig_rows` (they always coincided for a single file; a coalesced batch needs identity keep-mask indexing against rebuilt, per-flush-group keep masks, but non-identity per-source-file id encoding). Correctness bar here is numeric tolerance, not bit-identical — concatenating files changes the floating-point summation order inside the score matmul, the same category of imprecision changing the batch-size config already introduces today, just applied across files instead of only within one file.

## Bugs found and fixed along the way

Multi-angle code review (independent review agents, several rounds) plus live testing against the real FIQA corpus and a real Qdrant instance surfaced and fixed:
- A blank/whitespace-only per-query phrase crashed `match_text_from_query` (zero words to match). Now treated as never-matches, same as null.
- A per-query MatchAny column with query 0's value null but later queries holding real lists crashed with a numpy "inhomogeneous shape" error (classification was based on the first value only). Now scans every value.
- A nullable corpus column crashed `np.unique`'s internal sort when factorizing MatchAny values (can't compare `None` to `str`). Now excludes nulls before factorizing.
- An empty/all-null MatchAny vocabulary caused an out-of-bounds GPU gather. Now guarded explicitly.

## Correctness fixes and hardening (core architecture)

- Reader thread failures (e.g. a filter referencing a column missing from a shard's schema) previously died silently, hanging the consumer forever waiting for a file that would never arrive — now caught and re-raised in the main thread with a clear message.
- `run_merge` now detects and raises on mismatched partial counts across searches (previously, a rank dying partway through a run could silently produce an incomplete merge for one search with no warning).
- Corpus file processing order is now deterministic (files are folded into the top-K merge in a fixed, not IO-arrival, order) — fixes nondeterministic tie-breaking for exactly-tied top-K candidates, confirmed via a real, previously-flipping tie in the FIQA corpus.
- A stale docs typo (sparse vector default column name) and stale CLI docstrings (still describing merge as single-search) were fixed in passing.

## Config/CLI ergonomics

- `SearchSpec.name` is now optional — auto-derived from vector_type/metric (+ `_filtered` when a filter is set), with collision disambiguation, so naming every search isn't required for the common case of one or a couple of obviously-distinct ones.

## Testing

Test count grew from the original single-search suite to 159+ tests across `test_config_searches.py`, `test_filters.py`, `test_compute.py`/`test_compute_sparse.py`, and `test_compute_multi.py` (the largest and fastest-growing file), covering: solo vs. combined vs. sharded+merge consistency, every filter-routing interaction (unfiltered/uniform/per-query siblings sharing a vector_type), cross-file batch coalescing (dense, sparse, single- and multi-distinct-filter cases, each instrumented to confirm a genuine multi-file flush occurs, not just a same-result no-op), and regression cases for each bug found above. Verified independently against real FIQA corpus data at every stage and, for both per-query filters and the coalescing optimization, against a real Qdrant instance's exact search.
