### PR TITLE
bf compute: bound the prefetch lookahead with a window semaphore

### DIFF
--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -123,7 +123,7 @@ from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from queue import Empty, Queue
-from threading import Thread
+from threading import Semaphore, Thread
 
 import numpy as np
 
@@ -1585,13 +1585,31 @@ def run_compute(
     work: Queue = Queue()
     for item in mine:
         work.put(item)
-    fq: Queue = Queue(maxsize=io_workers * 2)  # bounded → backpressure on readers
+    fq: Queue = Queue(maxsize=io_workers * 2)
+    # `fq`'s bound alone is NOT the memory ceiling it looks like: the consumer
+    # must fold files in ascending `gidx` order, so while it waits for a slow
+    # file inside `_next_in_order` it keeps draining `fq` into the unbounded
+    # `pending` dict below — every drain frees a queue slot, readers never
+    # block, and one pathologically slow early file (a hung S3 read) would let
+    # the ENTIRE remaining corpus accumulate decoded in host RAM. `window` is
+    # the real end-to-end bound: a permit is held from the moment a reader
+    # STARTS a file until the consumer CONSUMES it, so at most `io_workers*2`
+    # files ever exist anywhere in the pipeline (being read + in `fq` + in
+    # `pending`). Deadlock-free: readers start files in ascending `gidx`
+    # order (`work` is FIFO), so the oldest unconsumed file — exactly the one
+    # the consumer is waiting for — is always inside the window, and consuming
+    # it releases the permit that slides the window forward. In a healthy run
+    # the consumer keeps up and no reader ever blocks here; the permit only
+    # binds in the stall scenario it exists for.
+    window = Semaphore(io_workers * 2)
 
     def reader():
         while True:
+            window.acquire()
             try:
                 gidx, f = work.get_nowait()
             except Empty:
+                window.release()
                 return
             # Wrapped in try/except so a bad read/decode/filter (e.g. a filter
             # field missing from this file's schema, or a type pyarrow can't
@@ -1737,6 +1755,9 @@ def run_compute(
                 t2 = time.perf_counter()
                 fq.put((gidx, batches, batch_orig_rows, raw_stats, ids, keeps, leaf_arrays, t1 - t0, t2 - t1))
             except Exception as exc:
+                # Permit deliberately NOT released: the consumer re-raises on
+                # fetching this, killing the run — holding it just stops the
+                # surviving readers from racing further ahead in the meantime.
                 fq.put(exc)
                 return
 
@@ -1768,10 +1789,12 @@ def run_compute(
 
     # `mine` already lists this worker's files in a fixed, deterministic
     # order (ascending `gidx`); `_next_in_order` reorders reader threads'
-    # arbitrary-arrival-order output back into that order (bounded by
-    # `io_workers`-many buffered items, since `fq`'s own bound already caps
-    # how far readers can race ahead) — see its docstring for why this
-    # matters for reproducibility, not just correctness.
+    # arbitrary-arrival-order output back into that order — see its docstring
+    # for why this matters for reproducibility, not just correctness.
+    # `pending`'s size is bounded by the `window` semaphore above (at most
+    # `io_workers * 2` files in flight end-to-end), NOT by `fq`'s maxsize:
+    # the wait loop inside `_next_in_order` drains `fq` while blocked, so the
+    # queue's own bound caps nothing on its own.
     pending: dict[int, tuple] = {}
 
     # Idea #2: per-vt accumulation buffer for coalescing several files'
@@ -1822,6 +1845,7 @@ def run_compute(
             gidx, batches, batch_orig_rows, raw_stats, ids, keeps, leaf_arrays, rsec, fsec = _next_in_order(
                 want_gidx, pending, _fetch_or_raise
             )
+            window.release()  # file consumed — a reader may start another
             io_wait += time.perf_counter() - w0
             read_secs += rsec
             filter_secs += fsec

--- a/python/nova-bf/tests/test_compute.py
+++ b/python/nova-bf/tests/test_compute.py
@@ -262,3 +262,71 @@ def test_next_in_order_reraises_from_fetch():
 
     with pytest.raises(RuntimeError, match="boom"):
         _next_in_order(0, {}, fetch)
+
+
+def test_slow_first_file_cannot_flood_host_memory(tmp_path, monkeypatch):
+    """Regression test for the lookahead `window` semaphore in `run_compute`:
+    the consumer folds files in ascending `gidx` order, so while it waits for
+    a slow file 0 it drains `fq` into the unbounded `pending` dict — every
+    drain frees a queue slot, so `fq`'s own bound provides NO backpressure and
+    (before the window) readers could stream the ENTIRE remaining corpus,
+    decoded, into host RAM during one stalled read. The window holds a permit
+    per file from read-start until the consumer consumes it, so no more than
+    `io_workers * 2` reads may even START while file 0 stalls.
+
+    Also checks the stalled run's results are bit-identical to an unstalled
+    one: the window changes memory behavior, never consumption order."""
+    import threading
+    import time
+
+    rng = np.random.default_rng(7)
+    n_files, rows, n_q, io_workers = 24, 3, 2, 4
+    cdir = tmp_path / "corpus"
+    cdir.mkdir()
+    for fi in range(n_files):
+        _write_vectors(cdir / f"f{fi:03d}.parquet", rng.standard_normal((rows, DIM)).astype(np.float32))
+    qpath = tmp_path / "queries.parquet"
+    _write_vectors(qpath, rng.standard_normal((n_q, DIM)).astype(np.float32), qid=[f"q{i}" for i in range(n_q)])
+
+    def _cfg(out_name):
+        out = tmp_path / out_name
+        out.mkdir()
+        return BruteForceConfig(
+            corpus=CorpusConfig(path=str(cdir), dense_column="dense_embedding"),
+            queries=QueriesConfig(path=str(qpath), dense_column="dense_embedding", id_column="qid"),
+            output=OutputConfig(path=str(out)),
+            params=ParamsConfig(io_workers=io_workers),
+            searches=[SearchSpec(name="test", k=K, metric="dot")],
+        )
+
+    control = pq.read_table(run_compute(_cfg("out_control"))["test"]).to_pydict()
+
+    first_path = Store(str(cdir)).list_parquets()[0].read_path
+    lock = threading.Lock()
+    corpus_reads_started: list[str] = []
+    started_during_stall: list[int] = []
+    real_read = Store.read_columns
+
+    def stalling_read(self, read_path, columns):
+        if str(cdir) in str(read_path):
+            with lock:
+                corpus_reads_started.append(read_path)
+        if read_path == first_path:
+            time.sleep(1.0)  # ample for 23 tiny local reads — without the
+            # window, every other file would start (and finish) in here
+            result = real_read(self, read_path, columns)
+            with lock:
+                started_during_stall.append(len(corpus_reads_started) - 1)
+            return result
+        return real_read(self, read_path, columns)
+
+    monkeypatch.setattr(Store, "read_columns", stalling_read)
+    stalled = pq.read_table(run_compute(_cfg("out_stalled"))["test"]).to_pydict()
+
+    # Structural bound: file 0 holds 1 of the io_workers*2 permits for the
+    # whole stall, so at most io_workers*2 - 1 OTHER reads can have started.
+    assert started_during_stall[0] <= io_workers * 2 - 1, (
+        f"{started_during_stall[0]} reads started while file 0 stalled — "
+        f"the lookahead window (io_workers*2 = {io_workers * 2}) is not binding"
+    )
+    assert stalled == control


### PR DESCRIPTION
Fixes the unbounded `pending` reorder buffer (finding #1 from the external compute.py review).

## Problem

`fq`'s `maxsize` looked like the reader-backpressure bound, but the consumer must fold files in ascending `gidx` order — while it waits for a slow file inside `_next_in_order`, it drains `fq` into the unbounded `pending` dict, freeing a queue slot per drain, so readers never block. One pathologically slow early file (e.g. a hung S3 read) lets the readers stream the **entire remaining corpus, decoded, into host RAM** — worst with `has_baseline`, where batches are whole uncompacted files. Measured pre-fix: **23/23** remaining files started during a 1s stall on file 0. The comment claiming `pending` was bounded by `io_workers`-many items was wrong for exactly this reason.

## Fix

A `Semaphore(io_workers * 2)`: a permit is held per file from read-start until the consumer consumes it, capping end-to-end in-flight files (being read + in `fq` + in `pending`) at the window size. Deadlock-free because readers start files in ascending `gidx` order (`work` is FIFO), so the oldest unconsumed file — exactly the one the consumer waits for — is always inside the window; consuming it releases the permit that slides the window forward. Zero effect on healthy runs (the permit only binds when readers are a full window ahead, i.e. the stall scenario itself) and zero effect on results (consumption order untouched).

Post-fix, the same 1s stall admits exactly `io_workers*2 - 1 = 7` other read starts — the structural bound.

## Verification

- New regression test `test_slow_first_file_cannot_flood_host_memory`: 24-file corpus, monkeypatched 1s stall on file 0, asserts ≤ `io_workers*2 - 1` reads start during the stall **and** that the stalled run's results are bit-identical to an unstalled control run.
- A/B via standalone repro (pytest's `pythonpath = ["src"]` pins tests to this branch's code, so the pre-fix side was run as a plain script against the old module): pre-fix 23/23 starts, post-fix 7.
- Full suite: **165 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)