### PR TITLE
nova storm: add filtered-search support

### DIFF
--- a/crates/nova-storm/src/config.rs
+++ b/crates/nova-storm/src/config.rs
@@ -203,6 +203,8 @@ pub enum ConfigError {
     FilterConditionBlankMatchText { field: String },
     #[error("filter condition on `{field}` range needs at least one of gt/gte/lt/lte")]
     FilterConditionEmptyRange { field: String },
+    #[error("filter condition on `{field}` has an empty `match: []` list — it would never match anything")]
+    FilterConditionEmptyMatchAny { field: String },
 }
 
 /// Expand `${VAR}` references in `input` from the process environment.

--- a/crates/nova-storm/src/config.rs
+++ b/crates/nova-storm/src/config.rs
@@ -11,6 +11,7 @@ use std::env;
 
 use serde::Deserialize;
 
+use crate::filter::Filter;
 use crate::targets::TargetConfig;
 
 /// The full parsed storm config.
@@ -36,6 +37,9 @@ impl StormConfig {
         }
         if cfg.load.batch_size == 0 {
             return Err(ConfigError::ZeroBatchSize);
+        }
+        if let Some(filter) = &cfg.query.filter {
+            filter.validate()?;
         }
         Ok(cfg)
     }
@@ -65,6 +69,10 @@ pub struct QueryConfig {
     /// leaves every one of these at the collection's own defaults.
     #[serde(default)]
     pub search_params: Option<SearchParamsConfig>,
+    /// Payload/metadata filter applied to every query in the run — see
+    /// [`crate::filter::Filter`]. `None` (default) is an unfiltered search.
+    #[serde(default)]
+    pub filter: Option<Filter>,
 }
 
 /// Server-side search-time tuning, passed straight through to Qdrant's
@@ -186,6 +194,15 @@ pub enum ConfigError {
     ZeroTopK,
     #[error("load.batch_size must be greater than 0")]
     ZeroBatchSize,
+    #[error(
+        "filter condition on `{field}` must set exactly one of `match`, `range`, `match_text`, \
+         `match_from_query`, `range_from_query`, or `match_text_from_query`"
+    )]
+    FilterConditionNotExactlyOne { field: String },
+    #[error("filter condition on `{field}` has a blank `match_text` — it needs at least one word")]
+    FilterConditionBlankMatchText { field: String },
+    #[error("filter condition on `{field}` range needs at least one of gt/gte/lt/lte")]
+    FilterConditionEmptyRange { field: String },
 }
 
 /// Expand `${VAR}` references in `input` from the process environment.

--- a/crates/nova-storm/src/filter.rs
+++ b/crates/nova-storm/src/filter.rs
@@ -136,6 +136,15 @@ impl FilterCondition {
         {
             return Err(ConfigError::FilterConditionBlankMatchText { field: self.field.clone() });
         }
+        // An empty `match: []` is vacuously "matches nothing" (Qdrant's own
+        // MatchAny with zero values never matches) — silently accepting it
+        // would make a load test return zero results forever with no config
+        // or runtime error, so treat it the same as a blank `match_text`.
+        if let Some(MatchSpec::Any(values)) = &self.r#match
+            && values.is_empty()
+        {
+            return Err(ConfigError::FilterConditionEmptyMatchAny { field: self.field.clone() });
+        }
         if let Some(range) = &self.range
             && !range.has_bound()
         {
@@ -222,11 +231,19 @@ impl Filter {
 /// [`QueryVector`](crate::queries::QueryVector), then read at request-build
 /// time by a backend's translation (e.g.
 /// `targets::qdrant::to_qdrant_condition`).
+///
+/// `Int` is kept distinct from `Num` (rather than widening every integer
+/// column to `f64` at load time) specifically so an exact `match_from_query`
+/// equality check on a large id (e.g. a snowflake-style `tenant_id` above
+/// 2^53) doesn't silently lose precision round-tripping through `f64` — see
+/// `queries::int_value`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum FilterFieldValue {
     Text(String),
+    Int(i64),
     Num(f64),
     TextList(Vec<String>),
+    IntList(Vec<i64>),
     NumList(Vec<f64>),
 }
 
@@ -322,6 +339,15 @@ must:
         assert!(matches!(
             f.validate().unwrap_err(),
             ConfigError::FilterConditionEmptyRange { field } if field == "price"
+        ));
+    }
+
+    #[test]
+    fn rejects_empty_match_any_list() {
+        let f = de("must:\n  - field: tag\n    match: []\n");
+        assert!(matches!(
+            f.validate().unwrap_err(),
+            ConfigError::FilterConditionEmptyMatchAny { field } if field == "tag"
         ));
     }
 

--- a/crates/nova-storm/src/filter.rs
+++ b/crates/nova-storm/src/filter.rs
@@ -1,0 +1,344 @@
+//! Backend-agnostic payload/metadata filter — shaped like `nova-bf`'s own
+//! `Filter`/`FilterCondition` (`python/nova-bf/src/nova_bf/config.py`), so a
+//! filter authored for a `nova bf` ground-truth run and a `nova storm` load
+//! test read the same way. Translating this into an actual wire-level filter
+//! is backend-specific (see `targets::qdrant::to_qdrant_filter`) — this module
+//! only owns the config shape and its validation.
+//!
+//! `must` = AND, `should` = OR-at-least-one, `must_not` = AND-NOT, same as
+//! Qdrant's own filter and `nova-bf`'s.
+
+use std::collections::BTreeSet;
+
+use serde::Deserialize;
+
+use crate::config::ConfigError;
+
+/// A single scalar payload value, as it would appear in a corpus/collection
+/// field. `Float` is kept for parity with `nova-bf`'s `MatchValue = str | int
+/// | float | bool` even though Qdrant's own match condition has no float
+/// variant — a backend that can't honour it (Qdrant, today) rejects it at
+/// translation time with a clear error, not here at parse time, since this
+/// type isn't inherently bound to one backend.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum MatchValue {
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Str(String),
+}
+
+/// `match`'s value: a scalar (equality) or a list (matches any of them —
+/// Qdrant's `MatchAny`).
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum MatchSpec {
+    One(MatchValue),
+    Any(Vec<MatchValue>),
+}
+
+/// Numeric bounds, combinable (e.g. `gte` + `lt` together).
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RangeCondition {
+    #[serde(default)]
+    pub gt: Option<f64>,
+    #[serde(default)]
+    pub gte: Option<f64>,
+    #[serde(default)]
+    pub lt: Option<f64>,
+    #[serde(default)]
+    pub lte: Option<f64>,
+}
+
+impl RangeCondition {
+    fn has_bound(&self) -> bool {
+        self.gt.is_some() || self.gte.is_some() || self.lt.is_some() || self.lte.is_some()
+    }
+}
+
+/// Per-query numeric bounds — same shape as [`RangeCondition`], but each bound
+/// names a QUERIES column supplying that query's own value for the bound,
+/// instead of a literal number (e.g. `lt: max_budget` means "each query's own
+/// ceiling comes from its own `max_budget` column").
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RangeFromQuery {
+    #[serde(default)]
+    pub gt: Option<String>,
+    #[serde(default)]
+    pub gte: Option<String>,
+    #[serde(default)]
+    pub lt: Option<String>,
+    #[serde(default)]
+    pub lte: Option<String>,
+}
+
+impl RangeFromQuery {
+    fn has_bound(&self) -> bool {
+        self.gt.is_some() || self.gte.is_some() || self.lt.is_some() || self.lte.is_some()
+    }
+
+    /// Every queries column named by a bound on this condition.
+    fn columns(&self) -> impl Iterator<Item = &str> {
+        [&self.gt, &self.gte, &self.lt, &self.lte].into_iter().filter_map(|c| c.as_deref())
+    }
+}
+
+/// One field predicate: keyword-style equality (`match`), numeric bounds
+/// (`range`), full-text (`match_text`), or a per-query variant of any of the
+/// three (`match_from_query`/`range_from_query`/`match_text_from_query`),
+/// which pulls its comparison value(s) from a column in the queries file
+/// instead of a literal in this config — so two different queries in the same
+/// run can each be restricted to a different subset (e.g. each scoped to its
+/// own tenant, budget, or search phrase). Exactly one of the six must be set.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FilterCondition {
+    /// The collection field this condition reads and matches against.
+    pub field: String,
+    #[serde(default, rename = "match")]
+    pub r#match: Option<MatchSpec>,
+    #[serde(default)]
+    pub range: Option<RangeCondition>,
+    #[serde(default)]
+    pub match_text: Option<String>,
+    /// Per-query variants — see this struct's docstring. Each names a QUERIES
+    /// column (not a collection field); `field` above still names the
+    /// collection field every one of these compares against.
+    #[serde(default)]
+    pub match_from_query: Option<String>,
+    #[serde(default)]
+    pub range_from_query: Option<RangeFromQuery>,
+    #[serde(default)]
+    pub match_text_from_query: Option<String>,
+}
+
+impl FilterCondition {
+    fn validate(&self) -> Result<(), ConfigError> {
+        let set_count = [
+            self.r#match.is_some(),
+            self.range.is_some(),
+            self.match_text.is_some(),
+            self.match_from_query.is_some(),
+            self.range_from_query.is_some(),
+            self.match_text_from_query.is_some(),
+        ]
+        .into_iter()
+        .filter(|&s| s)
+        .count();
+        if set_count != 1 {
+            return Err(ConfigError::FilterConditionNotExactlyOne { field: self.field.clone() });
+        }
+        if let Some(text) = &self.match_text
+            && text.trim().is_empty()
+        {
+            return Err(ConfigError::FilterConditionBlankMatchText { field: self.field.clone() });
+        }
+        if let Some(range) = &self.range
+            && !range.has_bound()
+        {
+            return Err(ConfigError::FilterConditionEmptyRange { field: self.field.clone() });
+        }
+        if let Some(range) = &self.range_from_query
+            && !range.has_bound()
+        {
+            return Err(ConfigError::FilterConditionEmptyRange { field: self.field.clone() });
+        }
+        Ok(())
+    }
+
+    /// Does this ONE condition vary per query?
+    pub fn is_per_query(&self) -> bool {
+        self.match_from_query.is_some()
+            || self.range_from_query.is_some()
+            || self.match_text_from_query.is_some()
+    }
+
+    /// Every queries column this condition (if per-query) reads a comparison
+    /// value from.
+    fn query_columns(&self) -> Vec<&str> {
+        let mut cols = Vec::new();
+        if let Some(c) = &self.match_from_query {
+            cols.push(c.as_str());
+        }
+        if let Some(r) = &self.range_from_query {
+            cols.extend(r.columns());
+        }
+        if let Some(c) = &self.match_text_from_query {
+            cols.push(c.as_str());
+        }
+        cols
+    }
+}
+
+/// A payload filter, shaped like Qdrant's own filter (must/should/must_not).
+/// Restricts which points are eligible neighbours for every query in the run
+/// — it does not touch queries themselves, same as a Qdrant search filter.
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Filter {
+    #[serde(default)]
+    pub must: Vec<FilterCondition>,
+    #[serde(default)]
+    pub should: Vec<FilterCondition>,
+    #[serde(default)]
+    pub must_not: Vec<FilterCondition>,
+}
+
+impl Filter {
+    /// Validate every condition in this filter. Called once at config-load
+    /// time (`StormConfig::from_yaml`), the same place `top_k`/`batch_size`
+    /// are checked — serde has no post-parse validator hook of its own, so
+    /// this stands in for what `pydantic`'s `@model_validator` does for
+    /// `nova-bf`'s equivalent config.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        self.all_conditions().try_for_each(FilterCondition::validate)
+    }
+
+    /// Every condition in this filter, across all three groups.
+    fn all_conditions(&self) -> impl Iterator<Item = &FilterCondition> {
+        self.must.iter().chain(self.should.iter()).chain(self.must_not.iter())
+    }
+
+    /// Every QUERIES column referenced by a per-query condition anywhere in
+    /// this filter — `nova storm` reads exactly (and only) the queries
+    /// columns some per-query condition actually references (see
+    /// `queries::load_query_vectors`).
+    pub fn query_fields(&self) -> BTreeSet<&str> {
+        self.all_conditions().flat_map(FilterCondition::query_columns).collect()
+    }
+
+    /// Does any condition in this filter vary per query?
+    pub fn is_per_query(&self) -> bool {
+        !self.query_fields().is_empty()
+    }
+}
+
+/// One `_from_query` column's resolved value for a single query — the
+/// per-query analog of a literal in [`FilterCondition`]. Populated once at
+/// query-load time (`queries::load_query_vectors`) alongside each
+/// [`QueryVector`](crate::queries::QueryVector), then read at request-build
+/// time by a backend's translation (e.g.
+/// `targets::qdrant::to_qdrant_condition`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum FilterFieldValue {
+    Text(String),
+    Num(f64),
+    TextList(Vec<String>),
+    NumList(Vec<f64>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn de(yaml: &str) -> Filter {
+        serde_yaml::from_str(yaml).expect("parses")
+    }
+
+    #[test]
+    fn parses_static_match_range_and_text() {
+        let f = de(
+            r#"
+must:
+  - field: category
+    match: shoes
+  - field: price
+    range:
+      gte: 10.0
+      lt: 100.0
+should:
+  - field: description
+    match_text: "waterproof hiking"
+must_not:
+  - field: tag
+    match: [discontinued, recalled]
+"#,
+        );
+        assert_eq!(f.must.len(), 2);
+        assert_eq!(f.should.len(), 1);
+        assert_eq!(f.must_not.len(), 1);
+        assert_eq!(f.must[0].r#match, Some(MatchSpec::One(MatchValue::Str("shoes".into()))));
+        assert!(!f.is_per_query());
+        assert!(f.query_fields().is_empty());
+        f.validate().expect("valid");
+    }
+
+    #[test]
+    fn parses_per_query_variants_and_collects_query_fields() {
+        let f = de(
+            r#"
+must:
+  - field: text
+    match_text_from_query: keyword_phrase
+  - field: tenant_id
+    match_from_query: tenant_column
+  - field: budget
+    range_from_query:
+      lt: max_budget
+      gte: min_budget
+"#,
+        );
+        assert!(f.is_per_query());
+        assert_eq!(
+            f.query_fields(),
+            BTreeSet::from(["keyword_phrase", "tenant_column", "max_budget", "min_budget"])
+        );
+        f.validate().expect("valid");
+    }
+
+    #[test]
+    fn rejects_condition_with_zero_kinds_set() {
+        let f = de("must:\n  - field: category\n");
+        assert!(matches!(
+            f.validate().unwrap_err(),
+            ConfigError::FilterConditionNotExactlyOne { field } if field == "category"
+        ));
+    }
+
+    #[test]
+    fn rejects_condition_with_multiple_kinds_set() {
+        let f = de("must:\n  - field: category\n    match: shoes\n    match_text: shoes\n");
+        assert!(matches!(
+            f.validate().unwrap_err(),
+            ConfigError::FilterConditionNotExactlyOne { field } if field == "category"
+        ));
+    }
+
+    #[test]
+    fn rejects_blank_match_text() {
+        let f = de("must:\n  - field: description\n    match_text: \"   \"\n");
+        assert!(matches!(
+            f.validate().unwrap_err(),
+            ConfigError::FilterConditionBlankMatchText { field } if field == "description"
+        ));
+    }
+
+    #[test]
+    fn rejects_range_with_no_bounds() {
+        let f = de("must:\n  - field: price\n    range: {}\n");
+        assert!(matches!(
+            f.validate().unwrap_err(),
+            ConfigError::FilterConditionEmptyRange { field } if field == "price"
+        ));
+    }
+
+    #[test]
+    fn rejects_range_from_query_with_no_bounds() {
+        let f = de("must:\n  - field: price\n    range_from_query: {}\n");
+        assert!(matches!(
+            f.validate().unwrap_err(),
+            ConfigError::FilterConditionEmptyRange { field } if field == "price"
+        ));
+    }
+
+    #[test]
+    fn deny_unknown_fields_rejects_typos() {
+        let result: Result<Filter, _> = serde_yaml::from_str(
+            "must:\n  - field: category\n    matches: shoes\n", // typo: "matches"
+        );
+        assert!(result.is_err());
+    }
+}

--- a/crates/nova-storm/src/lib.rs
+++ b/crates/nova-storm/src/lib.rs
@@ -13,6 +13,7 @@
 
 pub mod config;
 pub mod errors;
+pub mod filter;
 pub mod queries;
 pub mod runner;
 pub mod targets;
@@ -32,7 +33,7 @@ use runner::Summary;
 pub async fn run(config: StormConfig) -> Result<Summary, StormError> {
     let StormConfig { target, query, load } = config;
 
-    let vectors = load_query_vectors(&query.source)?;
+    let vectors = load_query_vectors(&query.source, query.filter.as_ref())?;
     if vectors.is_empty() {
         return Err(StormError::Other(format!(
             "no query vectors loaded from {:?} (column {:?})",

--- a/crates/nova-storm/src/queries.rs
+++ b/crates/nova-storm/src/queries.rs
@@ -15,13 +15,14 @@
 //! files by an independently-derived query id: the vector and its ground truth
 //! arrive already paired, by construction.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use duckdb::Connection;
 use duckdb::types::Value;
 
 use crate::config::QuerySource;
 use crate::errors::QueryLoadError;
+use crate::filter::{Filter, FilterFieldValue};
 
 /// One query vector plus its ground truth, if configured. Bundled into one
 /// struct (rather than two parallel `Vec`s) so the two can never drift out of
@@ -37,24 +38,49 @@ pub struct QueryVector {
     /// value is SQL NULL — either way, just "no known-correct answer for this
     /// query," not an error: the query still runs and contributes latency.
     pub ground_truth: Option<HashSet<String>>,
+    /// This query's own resolved value for every queries column referenced by
+    /// a `_from_query` condition in `query.filter` (see
+    /// [`Filter::query_fields`]) — empty when no per-query filter is
+    /// configured. Keyed by queries-column name, so a backend's translation
+    /// (e.g. `targets::qdrant::to_qdrant_condition`) can look up exactly the
+    /// column a given `FilterCondition` names.
+    pub filter_values: HashMap<String, FilterFieldValue>,
 }
 
 /// Read up to `source.limit` query vectors (and, if configured, each one's
-/// ground truth) from `source.uri`. Rows whose vector column is NULL are
-/// skipped entirely (there's nothing to query with); a NULL ground-truth value
-/// on an otherwise-valid row just means that query has no known-correct answer.
-pub fn load_query_vectors(source: &QuerySource) -> Result<Vec<QueryVector>, QueryLoadError> {
+/// ground truth and/or per-query filter values) from `source.uri`. Rows whose
+/// vector column is NULL are skipped entirely (there's nothing to query
+/// with); a NULL ground-truth value on an otherwise-valid row just means that
+/// query has no known-correct answer.
+///
+/// `filter` is `query.filter`, if configured — when it has any `_from_query`
+/// condition, this also projects every queries column those conditions name
+/// (see [`Filter::query_fields`]) into each [`QueryVector::filter_values`].
+/// Unlike a NULL ground-truth value, a NULL in one of *these* columns is a
+/// hard error: nova-bf's own convention for "no filter value for this query"
+/// is a non-matching placeholder (e.g. its MS MARCO config's unused
+/// `domain_slot_N` columns hold `"zzznomatchzzz000"`), not NULL, so a NULL
+/// here means the queries file wasn't built for this filter.
+pub fn load_query_vectors(
+    source: &QuerySource,
+    filter: Option<&Filter>,
+) -> Result<Vec<QueryVector>, QueryLoadError> {
     let conn = Connection::open_in_memory()?;
     // httpfs lets DuckDB read `s3://` (and `http(s)://`); harmless for local paths.
     conn.execute_batch("INSTALL httpfs; LOAD httpfs;")?;
     configure_s3(&conn)?;
 
+    let filter_columns: Vec<&str> =
+        filter.map(|f| f.query_fields().into_iter().collect()).unwrap_or_default();
+
     // Config is operator-authored (trusted). Columns are quoted so names with
     // odd characters survive. `cols` is the single source of truth for both the
-    // SQL projection and "how many columns to read per row" below — there's
-    // exactly one place that decides whether a ground-truth column is in play.
-    let cols: Vec<&str> =
-        std::iter::once(source.column.as_str()).chain(source.ground_truth_column.as_deref()).collect();
+    // SQL projection and "how many/which columns to read per row" below.
+    let mut cols: Vec<&str> = vec![source.column.as_str()];
+    cols.extend(source.ground_truth_column.as_deref());
+    let has_gt = source.ground_truth_column.is_some();
+    cols.extend(filter_columns.iter().copied());
+
     let projection = cols.iter().map(|c| format!("\"{c}\"")).collect::<Vec<_>>().join(", ");
     let sql = format!(
         "SELECT {projection} FROM read_parquet('{uri}') WHERE \"{col}\" IS NOT NULL LIMIT {limit}",
@@ -63,22 +89,36 @@ pub fn load_query_vectors(source: &QuerySource) -> Result<Vec<QueryVector>, Quer
         limit = source.limit,
     );
 
-    let has_gt = cols.len() > 1;
+    let n_cols = cols.len();
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map([], move |row| {
-        let vector = row.get::<_, Value>(0)?;
-        let ground_truth = if has_gt { Some(row.get::<_, Value>(1)?) } else { None };
-        Ok((vector, ground_truth))
+        (0..n_cols).map(|i| row.get::<_, Value>(i)).collect::<duckdb::Result<Vec<_>>>()
     })?;
 
     let mut out = Vec::new();
     for row in rows {
-        let (vector, ground_truth) = row?;
+        let mut values = row?.into_iter();
+        let vector = values.next().expect("vector column always present");
+        let ground_truth = if has_gt { values.next() } else { None };
         let ground_truth = match ground_truth {
             None | Some(Value::Null) => None,
             Some(v) => Some(string_list(v)?.into_iter().collect::<HashSet<_>>()),
         };
-        out.push(QueryVector { vector: float_list(vector)?, ground_truth });
+
+        // Everything remaining, in the same order as `filter_columns`.
+        let mut filter_values = HashMap::with_capacity(filter_columns.len());
+        for (name, value) in filter_columns.iter().zip(values) {
+            if matches!(value, Value::Null) {
+                return Err(QueryLoadError::Other(format!(
+                    "filter column `{name}` is NULL for a query row — `_from_query` columns must \
+                     never be NULL; use a non-matching placeholder value instead (e.g. nova-bf's \
+                     `domain_slot_N` convention)"
+                )));
+            }
+            filter_values.insert((*name).to_string(), filter_field_value(value)?);
+        }
+
+        out.push(QueryVector { vector: float_list(vector)?, ground_truth, filter_values });
     }
     Ok(out)
 }
@@ -124,6 +164,61 @@ fn float(v: &Value) -> Option<f32> {
         Value::Double(d) => Some(d as f32),
         _ => None,
     }
+}
+
+/// Coerce a DuckDB numeric value (any int width, signed or unsigned, or
+/// float/double) to `f64`. `None` for anything else.
+fn numeric(v: &Value) -> Option<f64> {
+    match *v {
+        Value::TinyInt(i) => Some(i as f64),
+        Value::SmallInt(i) => Some(i as f64),
+        Value::Int(i) => Some(i as f64),
+        Value::BigInt(i) => Some(i as f64),
+        Value::HugeInt(i) => Some(i as f64),
+        Value::UTinyInt(i) => Some(i as f64),
+        Value::USmallInt(i) => Some(i as f64),
+        Value::UInt(i) => Some(i as f64),
+        Value::UBigInt(i) => Some(i as f64),
+        Value::Float(f) => Some(f as f64),
+        Value::Double(d) => Some(d),
+        _ => None,
+    }
+}
+
+/// Coerce one `_from_query`-referenced column's value into a
+/// [`FilterFieldValue`] — text, numeric, or a homogeneous list of either.
+/// Callers already reject `Value::Null` before this is called (see the NULL
+/// check in [`load_query_vectors`]).
+fn filter_field_value(value: Value) -> Result<FilterFieldValue, QueryLoadError> {
+    match &value {
+        Value::Text(s) => return Ok(FilterFieldValue::Text(s.clone())),
+        Value::List(xs) | Value::Array(xs) => {
+            if xs.iter().all(|v| matches!(v, Value::Text(_))) {
+                return Ok(FilterFieldValue::TextList(
+                    xs.iter()
+                        .filter_map(|v| match v {
+                            Value::Text(s) => Some(s.clone()),
+                            _ => None,
+                        })
+                        .collect(),
+                ));
+            }
+            return xs
+                .iter()
+                .map(numeric)
+                .collect::<Option<Vec<_>>>()
+                .map(FilterFieldValue::NumList)
+                .ok_or_else(|| {
+                    QueryLoadError::Other(
+                        "filter column list is neither all-text nor all-numeric".into(),
+                    )
+                });
+        }
+        _ => {}
+    }
+    numeric(&value).map(FilterFieldValue::Num).ok_or_else(|| {
+        QueryLoadError::Other("filter column is not text, numeric, or a list of either".into())
+    })
 }
 
 /// Coerce a DuckDB `LIST`/`ARRAY` of ids into a `Vec<String>` — the same
@@ -208,7 +303,7 @@ mod tests {
         let file = dir.join("queries.parquet");
         write_parquet(&file, 100);
 
-        let vectors = load_query_vectors(&source(file.display().to_string(), None)).unwrap();
+        let vectors = load_query_vectors(&source(file.display().to_string(), None), None).unwrap();
 
         std::fs::remove_dir_all(&dir).ok();
 
@@ -225,7 +320,7 @@ mod tests {
         write_parquet_with_ground_truth(&file, 5);
 
         let vectors =
-            load_query_vectors(&source(file.display().to_string(), Some("hit_ids"))).unwrap();
+            load_query_vectors(&source(file.display().to_string(), Some("hit_ids")), None).unwrap();
 
         std::fs::remove_dir_all(&dir).ok();
 
@@ -256,7 +351,7 @@ mod tests {
         .unwrap();
 
         let vectors =
-            load_query_vectors(&source(file.display().to_string(), Some("hit_ids"))).unwrap();
+            load_query_vectors(&source(file.display().to_string(), Some("hit_ids")), None).unwrap();
 
         std::fs::remove_dir_all(&dir).ok();
 
@@ -280,7 +375,68 @@ mod tests {
         ))
         .unwrap();
 
-        let result = load_query_vectors(&source(file.display().to_string(), Some("hit_ids")));
+        let result = load_query_vectors(&source(file.display().to_string(), Some("hit_ids")), None);
+
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert!(result.is_err());
+    }
+
+    fn parse_filter(yaml: &str) -> Filter {
+        serde_yaml::from_str(yaml).expect("parses")
+    }
+
+    #[test]
+    fn loads_per_query_filter_columns_into_filter_values() {
+        let dir = std::env::temp_dir().join(format!("nova_storm_qf_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("queries.parquet");
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(&format!(
+            "COPY (SELECT [i::FLOAT, (i + 1)::FLOAT, (i + 2)::FLOAT] AS embedding, \
+             'tenant-' || i AS tenant_column, (i * 10)::DOUBLE AS max_budget \
+             FROM range(3) r(i)) TO '{}' (FORMAT PARQUET)",
+            file.display()
+        ))
+        .unwrap();
+
+        let filter = parse_filter(
+            "must:\n  - field: tenant_id\n    match_from_query: tenant_column\n  - field: budget\n    range_from_query:\n      lt: max_budget\n",
+        );
+        let vectors =
+            load_query_vectors(&source(file.display().to_string(), None), Some(&filter)).unwrap();
+
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(vectors.len(), 3);
+        assert_eq!(
+            vectors[1].filter_values.get("tenant_column"),
+            Some(&FilterFieldValue::Text("tenant-1".to_string()))
+        );
+        assert_eq!(
+            vectors[2].filter_values.get("max_budget"),
+            Some(&FilterFieldValue::Num(20.0))
+        );
+    }
+
+    #[test]
+    fn null_in_a_from_query_column_is_a_hard_error() {
+        let dir = std::env::temp_dir().join(format!("nova_storm_qfnull_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("queries.parquet");
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(&format!(
+            "COPY (SELECT [i::FLOAT, (i + 1)::FLOAT, (i + 2)::FLOAT] AS embedding, \
+             CASE WHEN i = 0 THEN NULL ELSE 'tenant-' || i END AS tenant_column \
+             FROM range(3) r(i)) TO '{}' (FORMAT PARQUET)",
+            file.display()
+        ))
+        .unwrap();
+
+        let filter =
+            parse_filter("must:\n  - field: tenant_id\n    match_from_query: tenant_column\n");
+        let result =
+            load_query_vectors(&source(file.display().to_string(), None), Some(&filter));
 
         std::fs::remove_dir_all(&dir).ok();
 

--- a/crates/nova-storm/src/queries.rs
+++ b/crates/nova-storm/src/queries.rs
@@ -167,57 +167,106 @@ fn float(v: &Value) -> Option<f32> {
 }
 
 /// Coerce a DuckDB numeric value (any int width, signed or unsigned, or
-/// float/double) to `f64`. `None` for anything else.
+/// float/double/decimal) to `f64`. `None` for anything else. Used for range
+/// bounds, which are `f64` regardless of the source column's exact type
+/// (`RangeCondition`/`RangeFromQuery` are `f64`-based like `nova-bf`'s own —
+/// see `crate::filter`), so widening an integer column here is fine even
+/// above `f64`'s 2^53 exact-integer limit.
 fn numeric(v: &Value) -> Option<f64> {
+    match v {
+        Value::Float(f) => Some(*f as f64),
+        Value::Double(d) => Some(*d),
+        // `rust_decimal::Decimal` isn't a direct dependency of this crate —
+        // going through its `Display` impl avoids needing one just for this.
+        Value::Decimal(d) => d.to_string().parse().ok(),
+        _ => int_value(v).map(|i| i as f64),
+    }
+}
+
+/// Every DuckDB integer-width variant, signed or unsigned.
+fn is_integer_value(v: &Value) -> bool {
+    matches!(
+        v,
+        Value::TinyInt(_)
+            | Value::SmallInt(_)
+            | Value::Int(_)
+            | Value::BigInt(_)
+            | Value::HugeInt(_)
+            | Value::UTinyInt(_)
+            | Value::USmallInt(_)
+            | Value::UInt(_)
+            | Value::UBigInt(_)
+    )
+}
+
+/// Coerce a DuckDB integer value to `i64` *exactly* — every int width,
+/// signed or unsigned, with no precision loss (unlike widening straight to
+/// `f64`, which silently loses precision above 2^53 — the bug this exists to
+/// avoid for an exact-equality `match_from_query` id). `None` for a value
+/// whose magnitude doesn't fit `i64` (an out-of-range `HugeInt`/`UBigInt`) or
+/// a non-integer `Value`.
+fn int_value(v: &Value) -> Option<i64> {
     match *v {
-        Value::TinyInt(i) => Some(i as f64),
-        Value::SmallInt(i) => Some(i as f64),
-        Value::Int(i) => Some(i as f64),
-        Value::BigInt(i) => Some(i as f64),
-        Value::HugeInt(i) => Some(i as f64),
-        Value::UTinyInt(i) => Some(i as f64),
-        Value::USmallInt(i) => Some(i as f64),
-        Value::UInt(i) => Some(i as f64),
-        Value::UBigInt(i) => Some(i as f64),
-        Value::Float(f) => Some(f as f64),
-        Value::Double(d) => Some(d),
+        Value::TinyInt(i) => Some(i as i64),
+        Value::SmallInt(i) => Some(i as i64),
+        Value::Int(i) => Some(i as i64),
+        Value::BigInt(i) => Some(i),
+        Value::HugeInt(i) => i64::try_from(i).ok(),
+        Value::UTinyInt(i) => Some(i as i64),
+        Value::USmallInt(i) => Some(i as i64),
+        Value::UInt(i) => Some(i as i64),
+        Value::UBigInt(i) => i64::try_from(i).ok(),
         _ => None,
     }
 }
 
 /// Coerce one `_from_query`-referenced column's value into a
-/// [`FilterFieldValue`] — text, numeric, or a homogeneous list of either.
-/// Callers already reject `Value::Null` before this is called (see the NULL
-/// check in [`load_query_vectors`]).
+/// [`FilterFieldValue`] — text, an exact integer, a float/decimal, or a
+/// homogeneous list of one of those. Callers already reject `Value::Null`
+/// before this is called (see the NULL check in [`load_query_vectors`]).
 fn filter_field_value(value: Value) -> Result<FilterFieldValue, QueryLoadError> {
-    match &value {
-        Value::Text(s) => return Ok(FilterFieldValue::Text(s.clone())),
-        Value::List(xs) | Value::Array(xs) => {
-            if xs.iter().all(|v| matches!(v, Value::Text(_))) {
-                return Ok(FilterFieldValue::TextList(
-                    xs.iter()
-                        .filter_map(|v| match v {
-                            Value::Text(s) => Some(s.clone()),
-                            _ => None,
-                        })
-                        .collect(),
-                ));
-            }
-            return xs
-                .iter()
-                .map(numeric)
-                .collect::<Option<Vec<_>>>()
-                .map(FilterFieldValue::NumList)
-                .ok_or_else(|| {
-                    QueryLoadError::Other(
-                        "filter column list is neither all-text nor all-numeric".into(),
-                    )
-                });
-        }
-        _ => {}
+    if let Value::Text(s) = &value {
+        return Ok(FilterFieldValue::Text(s.clone()));
+    }
+    if let Value::List(xs) | Value::Array(xs) = &value {
+        return filter_field_list_value(xs);
+    }
+    if is_integer_value(&value) {
+        return int_value(&value).map(FilterFieldValue::Int).ok_or_else(|| {
+            QueryLoadError::Other(format!(
+                "filter column value `{value:?}` is out of range for an exact integer match \
+                 (Qdrant match only supports i64)"
+            ))
+        });
     }
     numeric(&value).map(FilterFieldValue::Num).ok_or_else(|| {
         QueryLoadError::Other("filter column is not text, numeric, or a list of either".into())
+    })
+}
+
+/// [`filter_field_value`]'s list case: a `LIST`/`ARRAY` of all-text, all-
+/// integer (kept exact, same reasoning as [`int_value`]), or otherwise
+/// all-numeric (widened to `f64`, e.g. a mix of int and double columns —
+/// unusual but not actively wrong for `range_from_query`, which is `f64`
+/// anyway).
+fn filter_field_list_value(xs: &[Value]) -> Result<FilterFieldValue, QueryLoadError> {
+    if xs.iter().all(|v| matches!(v, Value::Text(_))) {
+        return Ok(FilterFieldValue::TextList(
+            xs.iter()
+                .filter_map(|v| match v {
+                    Value::Text(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .collect(),
+        ));
+    }
+    if xs.iter().all(is_integer_value) {
+        return xs.iter().map(int_value).collect::<Option<Vec<_>>>().map(FilterFieldValue::IntList).ok_or_else(
+            || QueryLoadError::Other("filter column list has an integer value out of range for i64".into()),
+        );
+    }
+    xs.iter().map(numeric).collect::<Option<Vec<_>>>().map(FilterFieldValue::NumList).ok_or_else(|| {
+        QueryLoadError::Other("filter column list is neither all-text nor all-numeric".into())
     })
 }
 
@@ -441,5 +490,56 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn large_bigint_filter_column_round_trips_exactly() {
+        // Above f64's 2^53 exact-integer limit (9007199254740992) -- widening
+        // straight to f64 before converting back to i64 would silently round
+        // this to 9007199254740992, submitting the WRONG tenant id to Qdrant
+        // with no error. `filter_field_value` must keep it exact via `Int`.
+        const BIG: i64 = 9_007_199_254_740_993;
+        let dir = std::env::temp_dir().join(format!("nova_storm_qfbig_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("queries.parquet");
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(&format!(
+            "COPY (SELECT [1.0::FLOAT] AS embedding, {BIG}::BIGINT AS tenant_column) \
+             TO '{}' (FORMAT PARQUET)",
+            file.display()
+        ))
+        .unwrap();
+
+        let filter =
+            parse_filter("must:\n  - field: tenant_id\n    match_from_query: tenant_column\n");
+        let vectors =
+            load_query_vectors(&source(file.display().to_string(), None), Some(&filter)).unwrap();
+
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(vectors[0].filter_values.get("tenant_column"), Some(&FilterFieldValue::Int(BIG)));
+    }
+
+    #[test]
+    fn decimal_filter_column_loads_as_numeric() {
+        let dir = std::env::temp_dir().join(format!("nova_storm_qfdec_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("queries.parquet");
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(&format!(
+            "COPY (SELECT [1.0::FLOAT] AS embedding, 42.5::DECIMAL(10,2) AS max_budget) \
+             TO '{}' (FORMAT PARQUET)",
+            file.display()
+        ))
+        .unwrap();
+
+        let filter =
+            parse_filter("must:\n  - field: budget\n    range_from_query:\n      lt: max_budget\n");
+        let vectors =
+            load_query_vectors(&source(file.display().to_string(), None), Some(&filter)).unwrap();
+
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(vectors[0].filter_values.get("max_budget"), Some(&FilterFieldValue::Num(42.5)));
     }
 }

--- a/crates/nova-storm/src/runner.rs
+++ b/crates/nova-storm/src/runner.rs
@@ -301,8 +301,8 @@ async fn run_closed_loop(
                 // fetch_add wraps far below usize::MAX over any real run.
                 let start = cursor.fetch_add(batch_size, Ordering::Relaxed) % n;
                 let idxs = batch_indices(start, batch_size, n);
-                let vecs: Vec<&[f32]> = idxs.iter().map(|&i| vectors[i].vector.as_slice()).collect();
-                let out = target.query_batch(&vecs).await;
+                let queries: Vec<&QueryVector> = idxs.iter().map(|&i| &vectors[i]).collect();
+                let out = target.query_batch(&queries).await;
                 let _ = tx.send(dispatch_sample(&out, &idxs, &vectors, top_k));
             }
         });
@@ -348,8 +348,8 @@ async fn run_paced(
         let vectors = vectors.clone();
         let tx = tx.clone();
         inflight.spawn(async move {
-            let vecs: Vec<&[f32]> = idxs.iter().map(|&i| vectors[i].vector.as_slice()).collect();
-            let out = target.query_batch(&vecs).await;
+            let queries: Vec<&QueryVector> = idxs.iter().map(|&i| &vectors[i]).collect();
+            let out = target.query_batch(&queries).await;
             let _ = tx.send(dispatch_sample(&out, &idxs, &vectors, top_k));
             drop(permit); // release the in-flight slot
         });
@@ -363,6 +363,8 @@ async fn run_paced(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
     use crate::targets::BatchOutcome;
     use async_trait::async_trait;
@@ -389,26 +391,32 @@ mod tests {
 
     #[async_trait]
     impl QueryTarget for MockTarget {
-        async fn query_batch(&self, vectors: &[&[f32]]) -> BatchOutcome {
+        async fn query_batch(&self, queries: &[&QueryVector]) -> BatchOutcome {
             if self.fail {
                 return BatchOutcome {
                     latency: Duration::from_micros(100),
                     ok: false,
-                    ids: vec![None; vectors.len()],
+                    ids: vec![None; queries.len()],
                     error: Some("mock failure".into()),
                 };
             }
             BatchOutcome {
                 latency: Duration::from_micros(100),
                 ok: true,
-                ids: vec![Some(self.ids.clone()); vectors.len()],
+                ids: vec![Some(self.ids.clone()); queries.len()],
                 error: None,
             }
         }
     }
 
     fn vectors() -> Vec<QueryVector> {
-        (0..16).map(|i| QueryVector { vector: vec![i as f32; 4], ground_truth: None }).collect()
+        (0..16)
+            .map(|i| QueryVector {
+                vector: vec![i as f32; 4],
+                ground_truth: None,
+                filter_values: HashMap::new(),
+            })
+            .collect()
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -465,6 +473,7 @@ mod tests {
                 } else {
                     None
                 },
+                filter_values: HashMap::new(),
             })
             .collect();
 
@@ -493,6 +502,7 @@ mod tests {
             .map(|i| QueryVector {
                 vector: vec![i as f32; 4],
                 ground_truth: Some(HashSet::from(["a".to_string()])),
+                filter_values: HashMap::new(),
             })
             .collect();
 
@@ -597,12 +607,12 @@ mod tests {
         }
         #[async_trait]
         impl QueryTarget for PerQueryTarget {
-            async fn query_batch(&self, vectors: &[&[f32]]) -> BatchOutcome {
+            async fn query_batch(&self, queries: &[&QueryVector]) -> BatchOutcome {
                 // vector[0] selects which of the 3 fixed ids come back.
-                let ids = vectors
+                let ids = queries
                     .iter()
-                    .map(|v| {
-                        Some(match v[0] as i64 {
+                    .map(|q| {
+                        Some(match q.vector[0] as i64 {
                             0 => vec![], // 0/2 in ground truth -> recall 0.0
                             1 => vec!["a".to_string()], // 1/2 -> recall 0.5
                             _ => vec!["a".to_string(), "b".to_string()], // 2/2 -> recall 1.0
@@ -614,9 +624,9 @@ mod tests {
         }
         let gt = Some(HashSet::from(["a".to_string(), "b".to_string()]));
         let vectors = vec![
-            QueryVector { vector: vec![0.0], ground_truth: gt.clone() },
-            QueryVector { vector: vec![1.0], ground_truth: gt.clone() },
-            QueryVector { vector: vec![2.0], ground_truth: gt },
+            QueryVector { vector: vec![0.0], ground_truth: gt.clone(), filter_values: HashMap::new() },
+            QueryVector { vector: vec![1.0], ground_truth: gt.clone(), filter_values: HashMap::new() },
+            QueryVector { vector: vec![2.0], ground_truth: gt, filter_values: HashMap::new() },
         ];
         // duration long enough to cycle through all 3 at concurrency=1 several times
         let profile = LoadProfile { concurrency: 1, duration_s: 0.1, target_rps: 0.0, batch_size: 1 };
@@ -680,12 +690,12 @@ mod tests {
         }
         #[async_trait]
         impl QueryTarget for BatchCapturingTarget {
-            async fn query_batch(&self, vectors: &[&[f32]]) -> BatchOutcome {
-                self.call_lens.lock().unwrap().push(vectors.len());
+            async fn query_batch(&self, queries: &[&QueryVector]) -> BatchOutcome {
+                self.call_lens.lock().unwrap().push(queries.len());
                 // position 0 -> 0/2 in ground truth -> recall 0.0
                 // position 1 -> 1/2 -> recall 0.5
                 // position 2 -> 2/2 -> recall 1.0
-                let ids = (0..vectors.len())
+                let ids = (0..queries.len())
                     .map(|pos| {
                         Some(match pos % 3 {
                             0 => vec![],
@@ -699,8 +709,13 @@ mod tests {
         }
 
         let gt = Some(HashSet::from(["a".to_string(), "b".to_string()]));
-        let vectors: Vec<QueryVector> =
-            (0..9).map(|i| QueryVector { vector: vec![i as f32], ground_truth: gt.clone() }).collect();
+        let vectors: Vec<QueryVector> = (0..9)
+            .map(|i| QueryVector {
+                vector: vec![i as f32],
+                ground_truth: gt.clone(),
+                filter_values: HashMap::new(),
+            })
+            .collect();
         let batch_size = 3;
         let profile = LoadProfile { concurrency: 1, duration_s: 0.15, target_rps: 0.0, batch_size };
         let target = Arc::new(BatchCapturingTarget { call_lens: std::sync::Mutex::new(Vec::new()) });

--- a/crates/nova-storm/src/targets/mod.rs
+++ b/crates/nova-storm/src/targets/mod.rs
@@ -17,6 +17,7 @@ use serde::Deserialize;
 
 use crate::config::QueryConfig;
 use crate::errors::TargetError;
+use crate::queries::QueryVector;
 
 pub mod qdrant;
 
@@ -45,12 +46,13 @@ pub struct BatchOutcome {
 /// (e.g. `qdrant(products)`).
 #[async_trait]
 pub trait QueryTarget: Send + Sync + std::fmt::Display {
-    /// Fire one batch dispatch covering all of `vectors` in a single
-    /// round-trip and return its latency + outcome. The top-k / vector-name
-    /// knobs are baked into the target at construction, so the hot path is
-    /// just the vectors. A single-element slice is not a special case — it's
-    /// the default (`LoadProfile::batch_size == 1`).
-    async fn query_batch(&self, vectors: &[&[f32]]) -> BatchOutcome;
+    /// Fire one batch dispatch covering all of `queries` in a single
+    /// round-trip and return its latency + outcome. The top-k / vector-name /
+    /// static-filter knobs are baked into the target at construction; each
+    /// [`QueryVector`] itself carries whatever a *per-query* filter needs
+    /// (`filter_values`) alongside its vector. A single-element slice is not
+    /// a special case — it's the default (`LoadProfile::batch_size == 1`).
+    async fn query_batch(&self, queries: &[&QueryVector]) -> BatchOutcome;
 
     /// Tear down connections. Default: nothing (clients close on drop).
     async fn close(&self) -> Result<(), TargetError> {

--- a/crates/nova-storm/src/targets/qdrant.rs
+++ b/crates/nova-storm/src/targets/qdrant.rs
@@ -1,19 +1,24 @@
 //! Qdrant implementation of [`QueryTarget`].
 
+use std::collections::HashMap;
 use std::fmt;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use qdrant_client::Qdrant;
 use qdrant_client::qdrant::point_id::PointIdOptions;
 use qdrant_client::qdrant::{
-    QuantizationSearchParams, QueryBatchPointsBuilder, QueryPointsBuilder, ScoredPoint, SearchParams,
+    Condition, QuantizationSearchParams, QueryBatchPointsBuilder, QueryPointsBuilder, Range as QdrantRange,
+    ScoredPoint, SearchParams,
 };
+use qdrant_client::qdrant::Filter as QdrantFilter;
 use serde::Deserialize;
 
 use super::{BatchOutcome, QueryTarget};
 use crate::config::{QuantizationSearchParamsConfig, QueryConfig, SearchParamsConfig};
 use crate::errors::TargetError;
+use crate::filter::{Filter, FilterCondition, FilterFieldValue, MatchSpec, MatchValue, RangeCondition, RangeFromQuery};
+use crate::queries::QueryVector;
 
 /// Fires nearest-neighbour queries at a Qdrant collection over gRPC.
 pub struct QdrantTarget {
@@ -33,6 +38,16 @@ pub struct QdrantTarget {
     /// a wasted allocation (a `String` clone per returned point) on every
     /// query.
     collect_ids: bool,
+    /// Translated once at construction and applied unchanged to every
+    /// query — set only when `query.filter` has no `_from_query` condition
+    /// (a uniform filter has nothing to resolve per query). `None` when
+    /// unfiltered OR when the filter is per-query (see `per_query_filter`).
+    static_filter: Option<QdrantFilter>,
+    /// The config-level filter, kept around only when it has at least one
+    /// `_from_query` condition — re-translated fresh for each query inside
+    /// `query_batch`, using that query's own `QueryVector::filter_values`.
+    /// Mutually exclusive with `static_filter` being `Some`.
+    per_query_filter: Option<Filter>,
 }
 
 impl From<&QuantizationSearchParamsConfig> for QuantizationSearchParams {
@@ -76,6 +91,12 @@ impl QdrantConfig {
         }
         let client = builder.build()?;
 
+        let (static_filter, per_query_filter) = match &query.filter {
+            None => (None, None),
+            Some(f) if f.is_per_query() => (None, Some(f.clone())),
+            Some(f) => (Some(to_qdrant_filter(f, None)?), None),
+        };
+
         Ok(QdrantTarget {
             client,
             collection_name: self.collection_name,
@@ -83,6 +104,8 @@ impl QdrantConfig {
             top_k: query.top_k,
             search_params: query.search_params.as_ref().map(SearchParams::from),
             collect_ids: query.source.ground_truth_column.is_some(),
+            static_filter,
+            per_query_filter,
         })
     }
 }
@@ -93,14 +116,205 @@ impl fmt::Display for QdrantTarget {
     }
 }
 
+impl QdrantTarget {
+    /// The filter to attach to `query`'s request, if any: the pre-translated
+    /// `static_filter` (cheap clone of a small protobuf struct), or a fresh
+    /// translation of `per_query_filter` against `query.filter_values` —
+    /// exactly one of the two is ever set (see their docstrings on
+    /// `QdrantTarget`).
+    fn effective_filter(&self, query: &QueryVector) -> Result<Option<QdrantFilter>, TargetError> {
+        if let Some(filter) = &self.static_filter {
+            return Ok(Some(filter.clone()));
+        }
+        match &self.per_query_filter {
+            Some(filter) => to_qdrant_filter(filter, Some(&query.filter_values)).map(Some),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Translate a backend-agnostic [`Filter`] into a Qdrant [`QdrantFilter`].
+/// `query_values` must be `Some` iff `filter.is_per_query()` — the only
+/// caller with a per-query filter (`QdrantTarget::effective_filter`) always
+/// supplies it.
+fn to_qdrant_filter(
+    filter: &Filter,
+    query_values: Option<&HashMap<String, FilterFieldValue>>,
+) -> Result<QdrantFilter, TargetError> {
+    let group = |conds: &[FilterCondition]| -> Result<Vec<Condition>, TargetError> {
+        conds.iter().map(|c| to_qdrant_condition(c, query_values)).collect()
+    };
+    Ok(QdrantFilter {
+        must: group(&filter.must)?,
+        should: group(&filter.should)?,
+        must_not: group(&filter.must_not)?,
+        min_should: None,
+    })
+}
+
+/// Translate one [`FilterCondition`] into a Qdrant [`Condition`]. Exactly one
+/// of the condition's six fields is set (`Filter::validate` enforces this at
+/// config-load time), so this reads as one branch per kind.
+fn to_qdrant_condition(
+    cond: &FilterCondition,
+    query_values: Option<&HashMap<String, FilterFieldValue>>,
+) -> Result<Condition, TargetError> {
+    if let Some(spec) = &cond.r#match {
+        return to_qdrant_match_condition(&cond.field, spec);
+    }
+    if let Some(range) = &cond.range {
+        return Ok(Condition::range(&cond.field, to_qdrant_range(range)));
+    }
+    if let Some(text) = &cond.match_text {
+        return Ok(Condition::matches_text(&cond.field, text.clone()));
+    }
+
+    // Everything below is a `_from_query` variant — `query_values` is
+    // guaranteed `Some` here by construction (`QdrantTarget::effective_filter`
+    // only calls this with `None` for a filter that has no per-query
+    // condition at all), and every column a `_from_query` leaf names is
+    // guaranteed present (`queries::load_query_vectors` projects exactly the
+    // columns `Filter::query_fields` names, erroring at load time on a NULL).
+    // A missing key here would mean those two guarantees drifted apart — a
+    // logic bug, not a reachable runtime state.
+    let query_values = query_values.expect("per-query filter translation requires resolved query_values");
+    let lookup = |col: &str| {
+        query_values
+            .get(col)
+            .unwrap_or_else(|| panic!("filter column `{col}` missing from query's resolved filter_values"))
+    };
+
+    if let Some(col) = &cond.match_from_query {
+        return to_qdrant_match_from_value(&cond.field, lookup(col));
+    }
+    if let Some(range) = &cond.range_from_query {
+        return to_qdrant_range_from_query(&cond.field, range, query_values);
+    }
+    if let Some(col) = &cond.match_text_from_query {
+        return match lookup(col) {
+            FilterFieldValue::Text(s) => Ok(Condition::matches_text(&cond.field, s.clone())),
+            _ => Err(TargetError::Other(format!(
+                "filter condition on `{}`: `match_text_from_query` column `{col}` must be text",
+                cond.field
+            ))),
+        };
+    }
+    unreachable!("Filter::validate ensures exactly one of the six condition kinds is set")
+}
+
+fn to_qdrant_range(range: &RangeCondition) -> QdrantRange {
+    QdrantRange { gt: range.gt, gte: range.gte, lt: range.lt, lte: range.lte }
+}
+
+/// Translate a `match`/`match_from_query` value. Qdrant's own match condition
+/// has no float variant (only keyword/integer/bool, plus `MatchAny` lists of
+/// integers or keywords) — a `MatchValue::Float` is rejected here, not at
+/// config-parse time, since the config type isn't inherently bound to Qdrant.
+fn to_qdrant_match_condition(field: &str, spec: &MatchSpec) -> Result<Condition, TargetError> {
+    match spec {
+        MatchSpec::One(MatchValue::Bool(b)) => Ok(Condition::matches(field, *b)),
+        MatchSpec::One(MatchValue::Int(i)) => Ok(Condition::matches(field, *i)),
+        MatchSpec::One(MatchValue::Str(s)) => Ok(Condition::matches(field, s.clone())),
+        MatchSpec::One(MatchValue::Float(v)) => Err(float_match_error(field, *v)),
+        MatchSpec::Any(values) => to_qdrant_match_any(field, values),
+    }
+}
+
+/// Qdrant's `MatchAny` only has `Vec<i64>`/`Vec<String>` constructors — no
+/// bool, no float, no mixed-type list.
+fn to_qdrant_match_any(field: &str, values: &[MatchValue]) -> Result<Condition, TargetError> {
+    if values.iter().all(|v| matches!(v, MatchValue::Int(_))) {
+        let ints =
+            values.iter().map(|v| if let MatchValue::Int(i) = v { *i } else { unreachable!() }).collect::<Vec<_>>();
+        return Ok(Condition::matches(field, ints));
+    }
+    if values.iter().all(|v| matches!(v, MatchValue::Str(_))) {
+        let strs = values
+            .iter()
+            .map(|v| if let MatchValue::Str(s) = v { s.clone() } else { unreachable!() })
+            .collect::<Vec<_>>();
+        return Ok(Condition::matches(field, strs));
+    }
+    Err(TargetError::Other(format!(
+        "filter condition on `{field}`: qdrant's MatchAny only supports an all-integer or all-string \
+         list (got a mix, a bool, or a float)"
+    )))
+}
+
+fn float_match_error(field: &str, value: f64) -> TargetError {
+    TargetError::Other(format!(
+        "filter condition on `{field}`: qdrant match does not support the float value `{value}` — use \
+         `range` with equal `gte`/`lte` for a numeric equality check"
+    ))
+}
+
+/// Translate one query's resolved `_from_query` value for a `match`-shaped
+/// condition. A numeric value must be a whole number — Qdrant's match takes
+/// `i64`, not `f64` — same constraint [`to_qdrant_match_condition`] enforces
+/// for a literal, just discovered from data instead of config.
+fn to_qdrant_match_from_value(field: &str, value: &FilterFieldValue) -> Result<Condition, TargetError> {
+    match value {
+        FilterFieldValue::Text(s) => Ok(Condition::matches(field, s.clone())),
+        FilterFieldValue::Num(n) => integer_value(*n)
+            .map(|i| Condition::matches(field, i))
+            .ok_or_else(|| non_integer_from_query_error(field, *n)),
+        FilterFieldValue::TextList(xs) => Ok(Condition::matches(field, xs.clone())),
+        FilterFieldValue::NumList(xs) => xs
+            .iter()
+            .map(|&n| integer_value(n))
+            .collect::<Option<Vec<_>>>()
+            .map(|ints| Condition::matches(field, ints))
+            .ok_or_else(|| {
+                TargetError::Other(format!(
+                    "filter condition on `{field}`: a per-query MatchAny list has a non-integer value \
+                     — qdrant match only supports whole numbers"
+                ))
+            }),
+    }
+}
+
+fn to_qdrant_range_from_query(
+    field: &str,
+    range: &RangeFromQuery,
+    query_values: &HashMap<String, FilterFieldValue>,
+) -> Result<Condition, TargetError> {
+    let bound = |col: &Option<String>| -> Result<Option<f64>, TargetError> {
+        let Some(name) = col else { return Ok(None) };
+        let value = query_values
+            .get(name)
+            .unwrap_or_else(|| panic!("filter column `{name}` missing from query's resolved filter_values"));
+        match value {
+            FilterFieldValue::Num(n) => Ok(Some(*n)),
+            _ => Err(TargetError::Other(format!(
+                "filter condition on `{field}`: `range_from_query` column `{name}` must be numeric"
+            ))),
+        }
+    };
+    Ok(Condition::range(
+        field,
+        QdrantRange { gt: bound(&range.gt)?, gte: bound(&range.gte)?, lt: bound(&range.lt)?, lte: bound(&range.lte)? },
+    ))
+}
+
+fn integer_value(n: f64) -> Option<i64> {
+    (n.fract() == 0.0).then_some(n as i64)
+}
+
+fn non_integer_from_query_error(field: &str, value: f64) -> TargetError {
+    TargetError::Other(format!(
+        "filter condition on `{field}`: qdrant match does not support the non-integer per-query value \
+         `{value}` — use `range_from_query` instead"
+    ))
+}
+
 #[async_trait]
 impl QueryTarget for QdrantTarget {
-    async fn query_batch(&self, vectors: &[&[f32]]) -> BatchOutcome {
-        let query_points: Vec<_> = vectors
+    async fn query_batch(&self, queries: &[&QueryVector]) -> BatchOutcome {
+        let query_points: Vec<_> = match queries
             .iter()
-            .map(|vector| {
+            .map(|q| {
                 let mut builder = QueryPointsBuilder::new(&self.collection_name)
-                    .query(vector.to_vec())
+                    .query(q.vector.to_vec())
                     .limit(self.top_k)
                     .with_payload(false);
                 if let Some(name) = &self.vector_name {
@@ -109,9 +323,27 @@ impl QueryTarget for QdrantTarget {
                 if let Some(params) = self.search_params {
                     builder = builder.params(params);
                 }
-                builder.build()
+                if let Some(filter) = self.effective_filter(q)? {
+                    builder = builder.filter(filter);
+                }
+                Ok(builder.build())
             })
-            .collect();
+            .collect::<Result<Vec<_>, TargetError>>()
+        {
+            Ok(points) => points,
+            // A per-query filter that can't be translated (e.g. a non-integer
+            // value under a keyword `match_from_query`) is a data problem
+            // with this dispatch, not a crash — same "errors at the limit are
+            // a finding" treatment as a Qdrant RPC failure below.
+            Err(e) => {
+                return BatchOutcome {
+                    latency: Duration::from_secs(0),
+                    ok: false,
+                    ids: vec![None; queries.len()],
+                    error: Some(e.to_string()),
+                };
+            }
+        };
         let request = QueryBatchPointsBuilder::new(&self.collection_name, query_points);
 
         let started = Instant::now();
@@ -122,14 +354,14 @@ impl QueryTarget for QdrantTarget {
             // results — treat it the same as a hard failure (no ids) rather
             // than silently misaligning them. `debug_assert_eq!` alone isn't
             // enough: this runs in release builds, the mode real storms use.
-            Ok(resp) if resp.result.len() != vectors.len() => BatchOutcome {
+            Ok(resp) if resp.result.len() != queries.len() => BatchOutcome {
                 latency: started.elapsed(),
                 ok: false,
-                ids: vec![None; vectors.len()],
+                ids: vec![None; queries.len()],
                 error: Some(format!(
                     "query_batch returned {} results for {} submitted queries",
                     resp.result.len(),
-                    vectors.len()
+                    queries.len()
                 )),
             },
             Ok(resp) => BatchOutcome {
@@ -148,7 +380,7 @@ impl QueryTarget for QdrantTarget {
             Err(e) => BatchOutcome {
                 latency: started.elapsed(),
                 ok: false,
-                ids: vec![None; vectors.len()],
+                ids: vec![None; queries.len()],
                 error: Some(e.to_string()),
             },
         }
@@ -253,5 +485,114 @@ mod tests {
         let cfg = StormConfig::from_yaml(yaml).expect("parses");
         let target = qdrant_config(cfg.target).into_target(&cfg.query).expect("builds");
         assert!(target.collect_ids);
+    }
+
+    fn cond(yaml: &str) -> FilterCondition {
+        serde_yaml::from_str(yaml).expect("parses")
+    }
+
+    #[test]
+    fn translates_scalar_match_range_and_text() {
+        let c = to_qdrant_condition(&cond("field: category\nmatch: shoes\n"), None).unwrap();
+        assert!(matches!(
+            c.condition_one_of,
+            Some(qdrant_client::qdrant::condition::ConditionOneOf::Field(_))
+        ));
+
+        to_qdrant_condition(&cond("field: price\nrange:\n  gte: 10.0\n  lt: 100.0\n"), None).unwrap();
+        to_qdrant_condition(&cond("field: description\nmatch_text: waterproof hiking\n"), None).unwrap();
+    }
+
+    #[test]
+    fn translates_homogeneous_match_any_lists() {
+        to_qdrant_condition(&cond("field: tag\nmatch: [a, b, c]\n"), None).unwrap();
+        to_qdrant_condition(&cond("field: code\nmatch: [1, 2, 3]\n"), None).unwrap();
+    }
+
+    #[test]
+    fn rejects_float_match_value() {
+        let err = to_qdrant_condition(&cond("field: price\nmatch: 9.99\n"), None).unwrap_err();
+        assert!(err.to_string().contains("float"));
+    }
+
+    #[test]
+    fn rejects_mixed_type_match_any() {
+        // untagged enum coerces `1` to an int and `\"a\"` to a string -- a
+        // deliberately mixed list, which qdrant's MatchAny can't express.
+        let err = to_qdrant_condition(&cond("field: tag\nmatch: [1, \"a\"]\n"), None).unwrap_err();
+        assert!(err.to_string().contains("MatchAny"));
+    }
+
+    #[test]
+    fn translates_per_query_variants_from_resolved_values() {
+        let values = HashMap::from([
+            ("tenant_column".to_string(), FilterFieldValue::Text("acme".to_string())),
+            ("max_budget".to_string(), FilterFieldValue::Num(42.0)),
+            ("phrase_column".to_string(), FilterFieldValue::Text("waterproof hiking".to_string())),
+        ]);
+
+        to_qdrant_condition(
+            &cond("field: tenant_id\nmatch_from_query: tenant_column\n"),
+            Some(&values),
+        )
+        .unwrap();
+        to_qdrant_condition(
+            &cond("field: budget\nrange_from_query:\n  lt: max_budget\n"),
+            Some(&values),
+        )
+        .unwrap();
+        to_qdrant_condition(
+            &cond("field: description\nmatch_text_from_query: phrase_column\n"),
+            Some(&values),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_non_integer_per_query_match_value() {
+        let values = HashMap::from([("budget_column".to_string(), FilterFieldValue::Num(9.5))]);
+        let err = to_qdrant_condition(&cond("field: budget\nmatch_from_query: budget_column\n"), Some(&values))
+            .unwrap_err();
+        assert!(err.to_string().contains("non-integer"));
+    }
+
+    #[test]
+    fn to_qdrant_filter_groups_must_should_must_not() {
+        let filter: Filter = serde_yaml::from_str(
+            "must:\n  - field: category\n    match: shoes\nshould:\n  - field: color\n    match: red\nmust_not:\n  - field: tag\n    match: discontinued\n",
+        )
+        .unwrap();
+        let translated = to_qdrant_filter(&filter, None).unwrap();
+        assert_eq!(translated.must.len(), 1);
+        assert_eq!(translated.should.len(), 1);
+        assert_eq!(translated.must_not.len(), 1);
+    }
+
+    #[test]
+    fn into_target_bakes_static_filter_when_not_per_query() {
+        let yaml = "target:\n  type: qdrant\n  url: http://localhost:6334\n  collection_name: c\n\
+                    query:\n  top_k: 5\n  source:\n    uri: /tmp/q.parquet\n    column: e\n  filter:\n    must:\n      - field: category\n        match: shoes\n";
+        let cfg = StormConfig::from_yaml(yaml).expect("parses");
+        let target = qdrant_config(cfg.target).into_target(&cfg.query).expect("builds");
+        assert!(target.static_filter.is_some());
+        assert!(target.per_query_filter.is_none());
+    }
+
+    #[test]
+    fn into_target_keeps_per_query_filter_unbaked() {
+        let yaml = "target:\n  type: qdrant\n  url: http://localhost:6334\n  collection_name: c\n\
+                    query:\n  top_k: 5\n  source:\n    uri: /tmp/q.parquet\n    column: e\n  filter:\n    must:\n      - field: tenant_id\n        match_from_query: tenant_column\n";
+        let cfg = StormConfig::from_yaml(yaml).expect("parses");
+        let target = qdrant_config(cfg.target).into_target(&cfg.query).expect("builds");
+        assert!(target.static_filter.is_none());
+        assert!(target.per_query_filter.is_some());
+    }
+
+    #[test]
+    fn into_target_rejects_a_float_match_in_a_static_filter_at_construction() {
+        let yaml = "target:\n  type: qdrant\n  url: http://localhost:6334\n  collection_name: c\n\
+                    query:\n  top_k: 5\n  source:\n    uri: /tmp/q.parquet\n    column: e\n  filter:\n    must:\n      - field: price\n        match: 9.99\n";
+        let cfg = StormConfig::from_yaml(yaml).expect("parses");
+        assert!(qdrant_config(cfg.target).into_target(&cfg.query).is_err());
     }
 }

--- a/crates/nova-storm/src/targets/qdrant.rs
+++ b/crates/nova-storm/src/targets/qdrant.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use async_trait::async_trait;
 use qdrant_client::Qdrant;
@@ -93,8 +93,29 @@ impl QdrantConfig {
 
         let (static_filter, per_query_filter) = match &query.filter {
             None => (None, None),
-            Some(f) if f.is_per_query() => (None, Some(f.clone())),
-            Some(f) => (Some(to_qdrant_filter(f, None)?), None),
+            Some(f) => {
+                // Defense in depth: `StormConfig::from_yaml` already calls
+                // this, but `StormConfig`'s fields are all `pub` and
+                // `nova_storm::run` is a public library entry point, so a
+                // caller that hand-builds one (skipping `from_yaml`) would
+                // otherwise reach `to_qdrant_condition`'s per-query lookups
+                // with a shape `Filter::validate` was supposed to rule out.
+                f.validate().map_err(|e| TargetError::Other(e.to_string()))?;
+                if f.is_per_query() {
+                    // A per-query filter defers ITS OWN `_from_query` leaves
+                    // to request time (they need real data to translate) —
+                    // but any fully-static sibling condition in the same
+                    // filter can, and should, still be validated now: without
+                    // this, a bad static leaf (e.g. a float `match`) would
+                    // only surface once `query_batch` starts running, failing
+                    // every single dispatch for the run's whole duration
+                    // instead of at startup.
+                    validate_static_conditions(f)?;
+                    (None, Some(f.clone()))
+                } else {
+                    (Some(to_qdrant_filter(f, None)?), None)
+                }
+            }
         };
 
         Ok(QdrantTarget {
@@ -152,6 +173,39 @@ fn to_qdrant_filter(
     })
 }
 
+/// Validate every fully-static condition in `filter` — even one that also has
+/// per-query siblings elsewhere in the same `must`/`should`/`must_not` group —
+/// by actually translating it (and discarding the result). Called eagerly at
+/// `QdrantConfig::into_target` time so a bad static leaf (e.g. a float
+/// `match`) fails at startup like the purely-static case does, instead of
+/// only surfacing once `query_batch` starts running (which would fail every
+/// single dispatch for the run's whole duration on what was a catchable
+/// config mistake). Per-query conditions are skipped — they need real
+/// `QueryVector` data to translate, which doesn't exist yet at this point.
+fn validate_static_conditions(filter: &Filter) -> Result<(), TargetError> {
+    filter
+        .must
+        .iter()
+        .chain(filter.should.iter())
+        .chain(filter.must_not.iter())
+        .filter(|c| !c.is_per_query())
+        .try_for_each(|c| to_qdrant_condition(c, None).map(|_| ()))
+}
+
+/// Look up a `_from_query` column's resolved value for the current query.
+/// Guaranteed present by construction: `queries::load_query_vectors` projects
+/// exactly the columns `Filter::query_fields` names (erroring at load time on
+/// a NULL), so a missing key here would mean that guarantee and this lookup
+/// drifted apart — a logic bug, not a reachable runtime state.
+fn resolve_query_value<'a>(
+    query_values: &'a HashMap<String, FilterFieldValue>,
+    col: &str,
+) -> &'a FilterFieldValue {
+    query_values
+        .get(col)
+        .unwrap_or_else(|| panic!("filter column `{col}` missing from query's resolved filter_values"))
+}
+
 /// Translate one [`FilterCondition`] into a Qdrant [`Condition`]. Exactly one
 /// of the condition's six fields is set (`Filter::validate` enforces this at
 /// config-load time), so this reads as one branch per kind.
@@ -172,27 +226,25 @@ fn to_qdrant_condition(
     // Everything below is a `_from_query` variant — `query_values` is
     // guaranteed `Some` here by construction (`QdrantTarget::effective_filter`
     // only calls this with `None` for a filter that has no per-query
-    // condition at all), and every column a `_from_query` leaf names is
-    // guaranteed present (`queries::load_query_vectors` projects exactly the
-    // columns `Filter::query_fields` names, erroring at load time on a NULL).
-    // A missing key here would mean those two guarantees drifted apart — a
-    // logic bug, not a reachable runtime state.
+    // condition at all).
     let query_values = query_values.expect("per-query filter translation requires resolved query_values");
-    let lookup = |col: &str| {
-        query_values
-            .get(col)
-            .unwrap_or_else(|| panic!("filter column `{col}` missing from query's resolved filter_values"))
-    };
 
     if let Some(col) = &cond.match_from_query {
-        return to_qdrant_match_from_value(&cond.field, lookup(col));
+        return to_qdrant_match_from_value(&cond.field, resolve_query_value(query_values, col));
     }
     if let Some(range) = &cond.range_from_query {
         return to_qdrant_range_from_query(&cond.field, range, query_values);
     }
     if let Some(col) = &cond.match_text_from_query {
-        return match lookup(col) {
-            FilterFieldValue::Text(s) => Ok(Condition::matches_text(&cond.field, s.clone())),
+        return match resolve_query_value(query_values, col) {
+            FilterFieldValue::Text(s) if !s.trim().is_empty() => {
+                Ok(Condition::matches_text(&cond.field, s.clone()))
+            }
+            FilterFieldValue::Text(_) => Err(TargetError::Other(format!(
+                "filter condition on `{}`: `match_text_from_query` column `{col}` resolved to a blank \
+                 value for this query — use a non-matching placeholder instead of an empty string",
+                cond.field
+            ))),
             _ => Err(TargetError::Other(format!(
                 "filter condition on `{}`: `match_text_from_query` column `{col}` must be text",
                 cond.field
@@ -249,16 +301,21 @@ fn float_match_error(field: &str, value: f64) -> TargetError {
 }
 
 /// Translate one query's resolved `_from_query` value for a `match`-shaped
-/// condition. A numeric value must be a whole number — Qdrant's match takes
-/// `i64`, not `f64` — same constraint [`to_qdrant_match_condition`] enforces
-/// for a literal, just discovered from data instead of config.
+/// condition. `Int`/`IntList` (an exact integer-typed queries column, e.g. a
+/// `BIGINT` tenant id) map straight across with no precision loss. A `Num`
+/// value must be a whole number — Qdrant's match takes `i64`, not `f64` —
+/// same constraint [`to_qdrant_match_condition`] enforces for a literal, just
+/// discovered from data instead of config; this path is only reached for a
+/// genuinely float/decimal-typed queries column.
 fn to_qdrant_match_from_value(field: &str, value: &FilterFieldValue) -> Result<Condition, TargetError> {
     match value {
         FilterFieldValue::Text(s) => Ok(Condition::matches(field, s.clone())),
+        FilterFieldValue::Int(i) => Ok(Condition::matches(field, *i)),
         FilterFieldValue::Num(n) => integer_value(*n)
             .map(|i| Condition::matches(field, i))
             .ok_or_else(|| non_integer_from_query_error(field, *n)),
         FilterFieldValue::TextList(xs) => Ok(Condition::matches(field, xs.clone())),
+        FilterFieldValue::IntList(xs) => Ok(Condition::matches(field, xs.clone())),
         FilterFieldValue::NumList(xs) => xs
             .iter()
             .map(|&n| integer_value(n))
@@ -280,11 +337,9 @@ fn to_qdrant_range_from_query(
 ) -> Result<Condition, TargetError> {
     let bound = |col: &Option<String>| -> Result<Option<f64>, TargetError> {
         let Some(name) = col else { return Ok(None) };
-        let value = query_values
-            .get(name)
-            .unwrap_or_else(|| panic!("filter column `{name}` missing from query's resolved filter_values"));
-        match value {
+        match resolve_query_value(query_values, name) {
             FilterFieldValue::Num(n) => Ok(Some(*n)),
+            FilterFieldValue::Int(i) => Ok(Some(*i as f64)),
             _ => Err(TargetError::Other(format!(
                 "filter condition on `{field}`: `range_from_query` column `{name}` must be numeric"
             ))),
@@ -310,6 +365,12 @@ fn non_integer_from_query_error(field: &str, value: f64) -> TargetError {
 #[async_trait]
 impl QueryTarget for QdrantTarget {
     async fn query_batch(&self, queries: &[&QueryVector]) -> BatchOutcome {
+        // Started before request-building (not just before the RPC) so a
+        // per-query filter translation failure below reports a real elapsed
+        // duration — same treatment `started.elapsed()` already gets for an
+        // RPC-level `Err` further down — instead of a fake `0` that would
+        // skew this dispatch's contribution to the run's latency percentiles.
+        let started = Instant::now();
         let query_points: Vec<_> = match queries
             .iter()
             .map(|q| {
@@ -337,7 +398,7 @@ impl QueryTarget for QdrantTarget {
             // a finding" treatment as a Qdrant RPC failure below.
             Err(e) => {
                 return BatchOutcome {
-                    latency: Duration::from_secs(0),
+                    latency: started.elapsed(),
                     ok: false,
                     ids: vec![None; queries.len()],
                     error: Some(e.to_string()),
@@ -346,7 +407,6 @@ impl QueryTarget for QdrantTarget {
         };
         let request = QueryBatchPointsBuilder::new(&self.collection_name, query_points);
 
-        let started = Instant::now();
         match self.client.query_batch(request).await {
             // A length mismatch here means the response can no longer be
             // zipped positionally against the submitted queries without
@@ -594,5 +654,40 @@ mod tests {
                     query:\n  top_k: 5\n  source:\n    uri: /tmp/q.parquet\n    column: e\n  filter:\n    must:\n      - field: price\n        match: 9.99\n";
         let cfg = StormConfig::from_yaml(yaml).expect("parses");
         assert!(qdrant_config(cfg.target).into_target(&cfg.query).is_err());
+    }
+
+    #[test]
+    fn into_target_rejects_an_invalid_static_sibling_of_a_per_query_condition() {
+        // The filter overall IS per-query (one match_from_query leaf), but a
+        // fully-static sibling condition (a float match) is invalid -- this
+        // must still fail at construction, not silently defer to query_batch.
+        let yaml = "target:\n  type: qdrant\n  url: http://localhost:6334\n  collection_name: c\n\
+                    query:\n  top_k: 5\n  source:\n    uri: /tmp/q.parquet\n    column: e\n  filter:\n    must:\n      - field: tenant_id\n        match_from_query: tenant_column\n      - field: price\n        match: 9.99\n";
+        let cfg = StormConfig::from_yaml(yaml).expect("parses");
+        let err = qdrant_config(cfg.target).into_target(&cfg.query).map(|_| ()).unwrap_err();
+        assert!(err.to_string().contains("float"));
+    }
+
+    #[test]
+    fn rejects_blank_match_text_from_query_value() {
+        let values =
+            HashMap::from([("phrase_column".to_string(), FilterFieldValue::Text("   ".to_string()))]);
+        let err = to_qdrant_condition(
+            &cond("field: description\nmatch_text_from_query: phrase_column\n"),
+            Some(&values),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("blank"));
+    }
+
+    #[test]
+    fn translates_exact_integer_and_int_list_from_query_values() {
+        let values = HashMap::from([
+            ("tenant_column".to_string(), FilterFieldValue::Int(9_007_199_254_740_993)),
+            ("codes_column".to_string(), FilterFieldValue::IntList(vec![1, 2, 3])),
+        ]);
+        to_qdrant_condition(&cond("field: tenant_id\nmatch_from_query: tenant_column\n"), Some(&values))
+            .unwrap();
+        to_qdrant_condition(&cond("field: code\nmatch_from_query: codes_column\n"), Some(&values)).unwrap();
     }
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -148,6 +148,70 @@ Use this to measure the recall/latency tradeoff of a quantized collection
 [Collection-wide params](../loading/overview.md#collection-wide-params)) under
 different query-time settings without reloading data.
 
+### Filtering (`query.filter`)
+
+Optional payload/metadata filter, shaped like `nova bf`'s own filter (see
+[Brute-Force overview](../brute-force/overview.md)) — `must`/`should`/`must_not`
+groups of `match`/`range`/`match_text` conditions — so a filter authored for a
+`nova bf` ground-truth run and a `nova storm` load test read the same way.
+Translating this into an actual request is backend-specific; today that's
+Qdrant's own `Filter`.
+
+A **static** filter applies uniformly to every query in the run:
+
+```yaml
+query:
+  source:
+    uri: s3://my-bucket/queries.parquet
+    column: query_embedding
+  filter:
+    must:
+      - field: category
+        match: shoes
+      - field: price
+        range:
+          gte: 10.0
+          lt: 100.0
+    should:
+      - field: description
+        match_text: "waterproof hiking"
+```
+
+A **per-query** filter pulls each condition's comparison value from a column in
+the *queries* file instead of a literal — `match_from_query`,
+`range_from_query`, `match_text_from_query` — so two different queries in the
+same run can each be restricted to a different subset (their own tenant,
+budget, or search phrase):
+
+```yaml
+query:
+  source:
+    uri: s3://my-bucket/queries.parquet
+    column: query_embedding
+  filter:
+    must:
+      - field: tenant_id
+        match_from_query: tenant_column   # each query's own tenant, from this column
+      - field: budget
+        range_from_query:
+          lt: max_budget                   # each query's own ceiling
+```
+
+Every column a `_from_query` condition names is read alongside that query's
+vector when the queries file is loaded — a NULL in one of those columns is a
+load-time error, not "no filter for this query": use a non-matching
+placeholder value instead (the same convention `nova bf`'s own MS MARCO
+configs use for unused per-query slots, e.g. `domain_slot_N` columns holding
+`"zzznomatchzzz000"`).
+
+**Qdrant caveat**: Qdrant's match condition has no float-equality variant (only
+keyword, integer, bool, and `MatchAny` lists of integers or keywords) — a
+`match`/`match_from_query` value that's a float, or a `MatchAny` list that mixes
+types, is rejected with a clear error (at config-load time for a static filter,
+at query-dispatch time for a per-query one, since the value there comes from
+data). Use `range`/`range_from_query` with equal `gte`/`lte` bounds for a
+numeric equality check instead.
+
 ## nova sweep
 
 Orchestrate `nova-load` + `nova-storm` across a matrix of collection/index/search


### PR DESCRIPTION
## Summary
- Adds a backend-agnostic payload filter to `nova storm`, shaped like `nova-bf`'s own `Filter`/`FilterCondition` (`must`/`should`/`must_not` of `match`/`range`/`match_text`, plus per-query `match_from_query`/`range_from_query`/`match_text_from_query` variants that pull each query's comparison value from a column in the queries parquet).
- New `crates/nova-storm/src/filter.rs` owns the config schema + validation; `crates/nova-storm/src/targets/qdrant.rs` owns the translation into Qdrant's own `Filter`/`Condition` types (backend translation is inherently backend-specific — e.g. Qdrant has no float-equality match, so a float `match` value is rejected there with a clear error).
- `QueryVector` now carries `filter_values` for any `_from_query`-referenced columns, read alongside the vector in `queries.rs`; a NULL in one of those columns is a load-time error (mirrors `nova-bf`'s own "use a non-matching placeholder, not NULL" convention).
- `QueryTarget::query_batch` now takes `&[&QueryVector]` instead of `&[&[f32]]` so a backend can see per-query filter values alongside the vector (internal trait, one implementor — no back-compat shim).
- Docs: new `### Filtering (query.filter)` section in `docs/reference/cli.md` under `## nova storm`, with a static and a per-query example.

## Adversarial review
Ran an 8-angle adversarial review (line-by-line, removed-behavior, cross-file trace, reuse, simplification, efficiency, altitude, conventions) with 1-vote verification on every surviving candidate. Confirmed and fixed:
- Empty `match: []` bypassed validation → silently produced a Qdrant MatchAny that matches nothing, forever, with no error.
- A large integer `_from_query` value (e.g. a BIGINT tenant id above 2^53) silently lost precision round-tripping through `f64` before casting back to `i64` for a Qdrant match — fixed via a new `FilterFieldValue::Int` that stays exact.
- DECIMAL-typed `_from_query` columns hard-failed the whole query load.
- A blank/whitespace `match_text_from_query` resolved value reached Qdrant's full-text match unvalidated (the literal `match_text` case was already checked; the per-query variant wasn't).
- A per-query filter translation failure reported a fake zero latency for the whole batch instead of real elapsed time, skewing the run's latency percentiles low every time that query recurred.
- A filter with one per-query condition deferred validation of its other, fully-static sibling conditions to request time instead of failing fast at startup like a purely-static filter does.
- `Filter::validate()` is now also called at target-construction time (defense in depth for a hand-built `StormConfig`, not just the YAML-parse path).

Deferred (reported, not fixed — lower severity / larger scope): a few DRY-ability nits (duplicated int-width enumeration, duplicated `has_bound`/MatchAny-homogeneity logic, a "lookup or panic" pattern now at least consolidated into one helper), `static_filter`/`per_query_filter` mutual exclusivity being convention-enforced rather than type-enforced (an `enum` would be stronger), and a confirmed-but-secondary perf finding: a per-query filter is re-translated from scratch on every dispatch instead of cached once per `QueryVector` (real, but requires restructuring how `QdrantTarget` is constructed to fix properly).

## Live end-to-end test
Verified against a **live Qdrant instance** with a **real 5000-point MS MARCO collection** (`bf_test_cos`, 768-dim cosine, real `text`/`domain_bucket`/`text_len` payload) — not synthetic data. Built a queries parquet from the collection's own real vectors/payload (each point queries itself; ground truth = its own id, `top_k=1`, so recall is a clean binary "did the filter still let us find ourselves" signal) and ran 11 configs covering every filter combinator:

| Filter | Expected recall | Actual |
|---|---|---|
| none (baseline) | ~1.0 | 1.0 |
| static `match: medical` | ~2505/5000 = 0.501 | 0.501 |
| static `match:` a bucket that doesn't exist | 0.0 | 0.0 |
| per-query `match_from_query` own bucket | ~1.0 | 1.0 |
| per-query `match_from_query` a guaranteed-wrong bucket | 0.0 | 0.0 |
| per-query `match_text_from_query` own first word | ~1.0 | 1.0 |
| per-query `match_text_from_query` a word that appears nowhere | 0.0 | 0.0 |
| per-query `range_from_query: {lte: own_text_len}` | ~1.0 | 1.0 |
| per-query `range_from_query: {lt: own_text_len}` (excludes self) | 0.0 | 0.0 |
| static `should: match: [medical, academic_scientific]` | 3759/5000 = 0.7518 | 0.7518 |
| static `must_not: match: government_legal` (same set, complementary) | 0.7518 | 0.7518 |

Every result matched its prediction exactly, including the two independent constructions of the same 0.7518 subset (`should`+`MatchAny` vs. `must_not`) agreeing with each other — strong evidence the filter is actually narrowing the candidate set correctly for every condition kind and combinator, not just passing config validation.

## Test plan
- [x] `cargo test -p nova-storm` — 55 tests pass (16 new: filter schema/validation incl. empty-MatchAny/precision/decimal regressions, per-query column loading + NULL handling, Qdrant translation for every condition kind + float/mixed-type/blank-text rejection, eager static-sibling validation, static-vs-per-query baking at construction).
- [x] `cargo clippy -p nova-storm --all-targets` — clean.
- [x] `cargo build --workspace` — clean.
- [x] Live smoke test against a real Qdrant instance with real data (table above) — all 11 configs behave exactly as predicted, zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
