### PR TITLE
fix(nova-bf): cast text column to large_string in match_text_from_query filter

### DIFF
--- a/python/nova-bf/src/nova_bf/filters.py
+++ b/python/nova-bf/src/nova_bf/filters.py
@@ -217,6 +217,16 @@ def _match_text_from_query_mask(
     literal-prefilter, on top of the word-level cache — the two optimizations
     are independent and compose. See docs/brute-force/overview.md."""
     col = table[cond.field]
+    # `_literal_then_regex_word_mask`'s regex-verify pass does `col.take(idx)`,
+    # which concatenates the gathered chunks into one array. On a corpus whose
+    # text column exceeds 2 GB in a single file (e.g. a FineWeb reshard's
+    # `text`), a 32-bit `string` column's offsets overflow there
+    # ("offset overflow while concatenating arrays"). Cast to `large_string`
+    # (per-chunk, so the cast itself never concatenates past 2 GB) so the gather
+    # uses 64-bit offsets. `string`/`large_string` are match-identical, so this
+    # is purely a capacity fix, not a semantic change.
+    if pa.types.is_string(col.type):
+        col = pc.cast(col, pa.large_string())
     phrases = query_values[cond.match_text_from_query]
     n_rows = len(table)
     result = np.zeros((len(phrases), n_rows), dtype=bool)


### PR DESCRIPTION
## Problem

The MS MARCO 5000 filtered brute-force run (per-query `match_text_from_query` on the `text` field) crashes on the FineWeb resharded corpus:

```
pyarrow.lib.ArrowInvalid: offset overflow while concatenating arrays,
consider casting input from `string` to `large_string` first.
  filters.py:197  _literal_then_regex_word_mask → col.take(pa.array(idx))
```

`_match_text_from_query_mask` → `_literal_then_regex_word_mask` runs a regex-verify pass via `col.take(idx)`, which concatenates the gathered chunks into a single array. A single reshard file's `text` column decodes to well over 2 GB, so a 32-bit `string` column's offsets overflow during that concat.

## Fix

Cast the target text column to `large_string` once in `_match_text_from_query_mask` (per-chunk, so the cast itself never concatenates past 2 GB) before the word-mask loop. The downstream `col.take()` then uses 64-bit offsets.

- `string`/`large_string` are match-identical → capacity fix, **no semantic change**.
- The static `_match_text_mask` path is unaffected (it never `.take()`s).

## Testing

- `test_filters.py` — 41/41 pass (no semantic regression).
- No dedicated regression test: the overflow only manifests past 2 GB of string data in one column, which isn't allocatable in a normal test run.
- End-to-end confirmation on the g5.8xlarge smoke run is pending merge to `master` (workers install nova-bf from `git+…@master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)