### PR TITLE
feat(nova-bf): datetime range filters via declared date_fields (Qdrant parity)

### DIFF
--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -131,6 +131,7 @@ from tqdm import tqdm
 
 from nova_bf.config import BruteForceConfig, Filter, FilterCondition, SearchSpec
 from nova_bf.filters import _condition_mask, _match_any_membership, _static_first, evaluate
+from nova_bf.dates import convert_table_date_columns, normalize_date_fields
 from nova_bf.ids import make_point_id
 from nova_bf.io import ParquetFile, Store, dense_to_2d, sparse_to_coo_parts
 from nova_bf.results import build_result_table, partial_dir, result_name, warn_if_short
@@ -241,8 +242,13 @@ def load_queries(
     ids: list[str] = []
     payload: dict[str, list] = {c: [] for c in qcfg.payload_fields}
     filter_vals: dict[str, list] = {c: [] for c in filter_cols}
+    q_date_fmts = normalize_date_fields(qcfg.date_fields)
     for f in store.list_parquets():
         table = store.read_columns(f.read_path, cols)
+        # Declared datetime query columns -> int64 epoch µs before we pull them
+        # into per-query filter arrays, so a range_from_query bound compares as
+        # a number against the (also-µs) corpus date column.
+        table = convert_table_date_columns(table, q_date_fmts)
         embs.append(dense_to_2d(table[qcfg.dense_column]))
         d = table.to_pydict()
         n = len(table)
@@ -351,8 +357,10 @@ def load_queries_sparse(
     ids: list[str] = []
     payload: dict[str, list] = {c: [] for c in qcfg.payload_fields}
     filter_vals: dict[str, list] = {c: [] for c in filter_cols}
+    q_date_fmts = normalize_date_fields(qcfg.date_fields)
     for f in store.list_parquets():
         table = store.read_columns(f.read_path, cols)
+        table = convert_table_date_columns(table, q_date_fmts)
         row_offsets, idx, val = sparse_to_coo_parts(table[qcfg.sparse_column])
         counts_parts.append(np.diff(row_offsets))
         indices_parts.append(idx)
@@ -1722,6 +1730,7 @@ def run_compute(
     # the columns some spec actually references, same guarantee the single-search
     # path always made.
     filter_cols = sorted({c for s in specs if s.filter for c in s.filter.fields()})
+    corpus_date_fmts = normalize_date_fields(cfg.corpus.date_fields)
     read_cols = list(dict.fromkeys(
         ([dense_col] if "dense" in vts_needed else [])
         + ([sparse_col] if "sparse" in vts_needed else [])
@@ -1782,6 +1791,10 @@ def run_compute(
             try:
                 t0 = time.perf_counter()
                 table = cstore.read_columns(f.read_path, read_cols)
+                # Declared datetime corpus columns -> int64 epoch µs before any
+                # filter (static `range` or GPU-native `range_from_query`) reads
+                # them, so every range path stays numeric and unchanged.
+                table = convert_table_date_columns(table, corpus_date_fmts)
                 # Decode each vector_type at most ONCE per file, regardless of how many
                 # specs need it — wrapped in the batch abstraction (`DenseCorpusBatch`/
                 # `SparseCorpusBatch`) below, where every spec of that vector_type shares

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -245,13 +245,14 @@ def load_queries(
     q_date_fmts = normalize_date_fields(qcfg.date_fields)
     for f in store.list_parquets():
         table = store.read_columns(f.read_path, cols)
-        # Declared datetime query columns -> int64 epoch µs before we pull them
-        # into per-query filter arrays, so a range_from_query bound compares as
-        # a number against the (also-µs) corpus date column.
-        table = convert_table_date_columns(table, q_date_fmts)
-        embs.append(dense_to_2d(table[qcfg.dense_column]))
-        d = table.to_pydict()
-        n = len(table)
+        d = table.to_pydict()  # ORIGINAL values — payload/id keep their source form
+        # Declared datetime query columns -> int64 epoch µs, but ONLY for the
+        # per-query filter arrays, so a range_from_query bound compares as a
+        # number against the (also-µs) corpus date column. A date field carried
+        # in payload_fields keeps its original (string) form in `d` above.
+        conv = convert_table_date_columns(table, q_date_fmts)
+        embs.append(dense_to_2d(conv[qcfg.dense_column]))
+        n = len(conv)
         if qcfg.id_column:
             ids += [str(x) for x in d[qcfg.id_column]]
         else:
@@ -259,7 +260,7 @@ def load_queries(
         for c in qcfg.payload_fields:
             payload[c] += d[c]
         for c in filter_cols:
-            filter_vals[c] += d[c]
+            filter_vals[c] += conv[c].to_pylist()
     Q = np.concatenate(embs, axis=0) if embs else np.zeros((0, 0), np.float32)
     return Q, ids, payload, {c: _to_query_array(v) for c, v in filter_vals.items()}
 
@@ -360,12 +361,13 @@ def load_queries_sparse(
     q_date_fmts = normalize_date_fields(qcfg.date_fields)
     for f in store.list_parquets():
         table = store.read_columns(f.read_path, cols)
-        table = convert_table_date_columns(table, q_date_fmts)
-        row_offsets, idx, val = sparse_to_coo_parts(table[qcfg.sparse_column])
+        d = table.to_pydict()  # ORIGINAL values — payload/id keep their source form
+        # Date columns -> epoch µs for filter arrays only (payload keeps strings).
+        conv = convert_table_date_columns(table, q_date_fmts)
+        row_offsets, idx, val = sparse_to_coo_parts(conv[qcfg.sparse_column])
         counts_parts.append(np.diff(row_offsets))
         indices_parts.append(idx)
         values_parts.append(val)
-        d = table.to_pydict()
         n = len(row_offsets) - 1
         if qcfg.id_column:
             ids += [str(x) for x in d[qcfg.id_column]]
@@ -374,7 +376,7 @@ def load_queries_sparse(
         for c in qcfg.payload_fields:
             payload[c] += d[c]
         for c in filter_cols:
-            filter_vals[c] += d[c]
+            filter_vals[c] += conv[c].to_pylist()
 
     indices = np.concatenate(indices_parts) if indices_parts else np.zeros(0, np.int64)
     values = np.concatenate(values_parts) if values_parts else np.zeros(0, np.float32)

--- a/python/nova-bf/src/nova_bf/config.py
+++ b/python/nova-bf/src/nova_bf/config.py
@@ -21,6 +21,7 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from nova_bf.tokenize import tokenize
+from nova_bf.dates import normalize_date_fields, parse_scalar_epoch_us
 
 import os
 
@@ -72,6 +73,20 @@ class CorpusConfig(BaseModel):
     # include is applied first (keep only matches), then exclude (drop matches).
     include: str | None = None
     exclude: str | None = None
+    # Payload columns that hold datetimes. Only a DECLARED field is treated as
+    # a date — no type sniffing (a plain string column is never silently
+    # reinterpreted). Each declared field is parsed to int64 epoch microseconds
+    # right after a file is read (see nova_bf.dates / compute.py), so `range`
+    # over it compares as numbers — value-for-value comparable to Qdrant's
+    # DatetimeRange. Two accepted shapes:
+    #   date_fields: [published_at]                 # rfc3339 (default)
+    #   date_fields: {published_at: rfc3339,
+    #                 crawl_day: "%Y%m%d",          # any strptime pattern
+    #                 ingested_at: epoch_s}         # already-numeric epoch
+    # A static `range` bound on a date field is written as an RFC-3339 string
+    # in the search filter (e.g. `gte: "2013-01-01T00:00:00Z"`) and parsed to
+    # epoch µs at config load; a string bound on a NON-date field is rejected.
+    date_fields: list[str] | dict[str, str] = []
 
 
 class QueriesConfig(BaseModel):
@@ -85,6 +100,11 @@ class QueriesConfig(BaseModel):
     id_column: str | None = None
     # Columns to carry from the queries file into each output row.
     payload_fields: list[str] = []
+    # Query columns that hold datetimes — same declaration/format rules as
+    # `CorpusConfig.date_fields`. These are the columns a `range_from_query`
+    # draws its per-query bounds from when the corpus field is a date; parsed to
+    # epoch µs so each query's bound compares against the (also-µs) corpus date.
+    date_fields: list[str] | dict[str, str] = []
 
 
 class OutputConfig(BaseModel):
@@ -481,8 +501,85 @@ class BruteForceConfig(BaseModel):
             raise ValueError(f"`searches` names must be unique, got {names}")
         return self
 
+    @model_validator(mode="after")
+    def _validate_date_fields(self) -> "BruteForceConfig":
+        """Keep the corpus and queries date declarations consistent so a
+        datetime bound is never silently compared against a non-datetime column
+        (which would mean a nonsensical unit mismatch — raw µs vs. plain
+        number). A `range_from_query` whose corpus `field` is a declared date
+        field must draw every bound from a declared QUERIES date field, and
+        vice versa."""
+        corpus_dates = set(normalize_date_fields(self.corpus.date_fields))
+        query_dates = set(normalize_date_fields(self.queries.date_fields))
+        for s in self.searches:
+            if s.filter is None:
+                continue
+            for cond in s.filter.all_conditions():
+                if cond.range_from_query is None:
+                    continue
+                r = cond.range_from_query
+                bound_cols = [v for v in (r.gt, r.gte, r.lt, r.lte) if v is not None]
+                field_is_date = cond.field in corpus_dates
+                for col in bound_cols:
+                    col_is_date = col in query_dates
+                    if field_is_date and not col_is_date:
+                        raise ValueError(
+                            f"range_from_query on date field '{cond.field}' draws "
+                            f"its bound from '{col}', which is not declared in "
+                            "queries.date_fields — declare it so its values are "
+                            "parsed to epoch µs and comparable to the corpus date"
+                        )
+                    if col_is_date and not field_is_date:
+                        raise ValueError(
+                            f"range_from_query bound '{col}' is a declared queries "
+                            f"date field but corpus field '{cond.field}' is not a "
+                            "date field (corpus.date_fields) — comparing a datetime "
+                            "bound against a non-datetime column"
+                        )
+        return self
+
+
+def _normalize_static_date_bounds(data: dict) -> dict:
+    """In-place: rewrite every static `range` string bound on a declared corpus
+    date field to its int64 epoch-µs value (as a number), so `RangeCondition`'s
+    plain `float` bounds validate unchanged and every downstream range path
+    stays numeric. A string bound on a NON-date field is rejected here with a
+    clear message instead of surfacing as a bare pydantic "not a number" error.
+    Runs on the raw dict BEFORE validation, so no frozen model needs rebuilding.
+    """
+    corpus_dates = normalize_date_fields((data.get("corpus") or {}).get("date_fields"))
+    for spec in data.get("searches") or []:
+        filt = spec.get("filter")
+        if not isinstance(filt, dict):
+            continue
+        for group in ("must", "should", "must_not"):
+            for cond in filt.get(group) or []:
+                if not isinstance(cond, dict):
+                    continue
+                rng = cond.get("range")
+                if not isinstance(rng, dict):
+                    continue
+                field = cond.get("field")
+                str_bounds = {b for b in ("gt", "gte", "lt", "lte")
+                              if isinstance(rng.get(b), str)}
+                if not str_bounds:
+                    continue
+                if field not in corpus_dates:
+                    raise ValueError(
+                        f"filter on '{field}' has a string `range` bound "
+                        f"({sorted(str_bounds)}) but '{field}' is not declared in "
+                        "corpus.date_fields — declare it (optionally with a format) "
+                        "to use datetime bounds, or use a numeric bound"
+                    )
+                fmt = corpus_dates[field]
+                for b in str_bounds:
+                    rng[b] = float(parse_scalar_epoch_us(rng[b], fmt))
+    return data
+
 
 def load_config(path: str) -> BruteForceConfig:
     with open(path) as f:
         raw = expand_env(f.read())
-    return BruteForceConfig.model_validate(yaml.safe_load(raw))
+    data = yaml.safe_load(raw)
+    data = _normalize_static_date_bounds(data)
+    return BruteForceConfig.model_validate(data)

--- a/python/nova-bf/src/nova_bf/config.py
+++ b/python/nova-bf/src/nova_bf/config.py
@@ -21,7 +21,7 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from nova_bf.tokenize import tokenize
-from nova_bf.dates import normalize_date_fields, parse_scalar_epoch_us
+from nova_bf.dates import is_epoch_format, normalize_date_fields, parse_scalar_epoch_us
 
 import os
 
@@ -515,6 +515,22 @@ class BruteForceConfig(BaseModel):
             if s.filter is None:
                 continue
             for cond in s.filter.all_conditions():
+                # A declared date field is parsed to epoch µs, so it only makes
+                # sense with range/range_from_query. Using it with an
+                # equality/text predicate would compare/tokenize the raw integer
+                # µs and silently match nothing — reject it at config time.
+                if cond.field in corpus_dates and (
+                    cond.match is not None
+                    or cond.match_text is not None
+                    or cond.match_from_query is not None
+                    or cond.match_text_from_query is not None
+                ):
+                    raise ValueError(
+                        f"corpus date field '{cond.field}' is used with a "
+                        "match/match_text predicate — a declared date field is "
+                        "parsed to epoch µs and only supports `range`/"
+                        "`range_from_query`"
+                    )
                 if cond.range_from_query is None:
                     continue
                 r = cond.range_from_query
@@ -562,18 +578,26 @@ def _normalize_static_date_bounds(data: dict) -> dict:
                 field = cond.get("field")
                 str_bounds = {b for b in ("gt", "gte", "lt", "lte")
                               if isinstance(rng.get(b), str)}
-                if not str_bounds:
-                    continue
-                if field not in corpus_dates:
+                if str_bounds and field not in corpus_dates:
                     raise ValueError(
                         f"filter on '{field}' has a string `range` bound "
                         f"({sorted(str_bounds)}) but '{field}' is not declared in "
                         "corpus.date_fields — declare it (optionally with a format) "
                         "to use datetime bounds, or use a numeric bound"
                     )
+                if field not in corpus_dates:
+                    continue  # ordinary numeric range on a non-date field: untouched
                 fmt = corpus_dates[field]
-                for b in str_bounds:
-                    rng[b] = float(parse_scalar_epoch_us(rng[b], fmt))
+                for b in ("gt", "gte", "lt", "lte"):
+                    v = rng.get(b)
+                    if v is None:
+                        continue
+                    # A string bound is always parsed; a NUMERIC bound is rescaled
+                    # only for epoch_s/epoch_ms fields (whose column is likewise
+                    # rescaled) — for rfc3339/strptime/epoch_us it's already the µs
+                    # value the column uses, so it's left as-is.
+                    if isinstance(v, str) or is_epoch_format(fmt):
+                        rng[b] = float(parse_scalar_epoch_us(v, fmt))
     return data
 
 

--- a/python/nova-bf/src/nova_bf/dates.py
+++ b/python/nova-bf/src/nova_bf/dates.py
@@ -38,6 +38,16 @@ DEFAULT_FORMAT = "rfc3339"
 _EPOCH_MULT = {"epoch_s": 1_000_000, "epoch_ms": 1_000, "epoch_us": 1}
 
 
+def is_epoch_format(fmt: str) -> bool:
+    """True for the already-numeric epoch formats (epoch_s/epoch_ms/epoch_us).
+
+    Lets config.py decide whether a NUMERIC static `range` bound on a date field
+    needs epoch rescaling (epoch_s/ms) or is already microseconds (epoch_us /
+    rfc3339 / strptime), so a numeric bound never mismatches the rescaled
+    column."""
+    return fmt in _EPOCH_MULT
+
+
 def normalize_date_fields(raw) -> dict[str, str]:
     """`list[str] | dict[str, str | None] | None` -> `{field: format}`.
 
@@ -57,6 +67,8 @@ def parse_scalar_epoch_us(value, fmt: str = DEFAULT_FORMAT) -> int:
     Raises `ValueError` on an unparseable value — a bad date literal in a
     config is a hard error at load, never a silent non-match at runtime."""
     if fmt in _EPOCH_MULT:
+        if _EPOCH_MULT[fmt] == 1:  # epoch_us: already µs — keep exact, no float
+            return int(value)
         return int(round(float(value) * _EPOCH_MULT[fmt]))
     s = str(value)
     if fmt == "rfc3339":
@@ -81,6 +93,8 @@ def to_epoch_us_array(col, fmt: str = DEFAULT_FORMAT) -> pa.Array:
     if isinstance(col, pa.ChunkedArray):
         col = col.combine_chunks()
     if fmt in _EPOCH_MULT:
+        if _EPOCH_MULT[fmt] == 1:  # epoch_us: already µs — stay int64, exact >2^53
+            return pc.cast(col, pa.int64())
         scaled = pc.multiply(pc.cast(col, pa.float64()), float(_EPOCH_MULT[fmt]))
         return pc.cast(pc.round(scaled), pa.int64())
     if fmt == "rfc3339":

--- a/python/nova-bf/src/nova_bf/dates.py
+++ b/python/nova-bf/src/nova_bf/dates.py
@@ -1,0 +1,108 @@
+"""Datetime payload support for filters.
+
+A corpus/queries column is treated as a datetime ONLY when explicitly declared
+in `corpus.date_fields` / `queries.date_fields` (see config.py) — there is no
+type sniffing, so a plain string column is never silently reinterpreted as a
+date. Every declared date field is normalized to **int64 epoch microseconds**
+at load time:
+
+  - corpus/query columns are converted right after each file is read
+    (`compute.py`),
+  - static `range` bound literals in the YAML are converted at config load
+    (`config.py`),
+
+so all downstream range logic — the CPU `filters.py` path AND the GPU-native
+range path in `compute.py` — operates on plain numbers, unchanged. Epoch
+microseconds is also exactly Qdrant's own internal datetime representation
+(i64 µs since the Unix epoch), so a `range` over a declared date field is
+value-for-value comparable to a Qdrant `DatetimeRange` — range parity for free.
+
+Supported per-field `format`s:
+  - "rfc3339" (default): ISO-8601 / RFC-3339 timestamps parsed as UTC, e.g.
+    "2013-05-18T05:48:54Z" (also accepts an explicit offset). Naive strings
+    (no `Z`/offset) are interpreted as UTC.
+  - "epoch_s" / "epoch_ms" / "epoch_us": the column is already numeric epoch
+    at that scale; values are rescaled to microseconds.
+  - any `strptime` pattern containing "%": parsed with that pattern (naive →
+    UTC).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pyarrow as pa
+import pyarrow.compute as pc
+
+DEFAULT_FORMAT = "rfc3339"
+_EPOCH_MULT = {"epoch_s": 1_000_000, "epoch_ms": 1_000, "epoch_us": 1}
+
+
+def normalize_date_fields(raw) -> dict[str, str]:
+    """`list[str] | dict[str, str | None] | None` -> `{field: format}`.
+
+    Bare list entries, and dict entries with an empty/None format, default to
+    `rfc3339`. This is the single place the two accepted YAML shapes collapse
+    to one canonical mapping the rest of the code uses."""
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return {k: (v or DEFAULT_FORMAT) for k, v in raw.items()}
+    return {k: DEFAULT_FORMAT for k in raw}
+
+
+def parse_scalar_epoch_us(value, fmt: str = DEFAULT_FORMAT) -> int:
+    """One datetime literal (a static YAML `range` bound) -> int64 epoch µs.
+
+    Raises `ValueError` on an unparseable value — a bad date literal in a
+    config is a hard error at load, never a silent non-match at runtime."""
+    if fmt in _EPOCH_MULT:
+        return int(round(float(value) * _EPOCH_MULT[fmt]))
+    s = str(value)
+    if fmt == "rfc3339":
+        # `fromisoformat` handles offsets natively; normalize a trailing `Z`
+        # (only accepted directly on 3.11+) so behavior is version-stable.
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+    else:
+        dt = datetime.strptime(s, fmt)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1_000_000)
+
+
+def to_epoch_us_array(col, fmt: str = DEFAULT_FORMAT) -> pa.Array:
+    """A datetime column (arrow string / timestamp / numeric) -> an int64
+    epoch-µs arrow array, nulls preserved.
+
+    Fail-fast: a value that doesn't parse raises (via pyarrow) rather than
+    becoming null — an unparseable payload date is a data error worth
+    surfacing, and the reader thread in `compute.py` already turns such an
+    exception into a loud run failure."""
+    if isinstance(col, pa.ChunkedArray):
+        col = col.combine_chunks()
+    if fmt in _EPOCH_MULT:
+        scaled = pc.multiply(pc.cast(col, pa.float64()), float(_EPOCH_MULT[fmt]))
+        return pc.cast(pc.round(scaled), pa.int64())
+    if fmt == "rfc3339":
+        # Cast handles both ISO-8601 strings (parsed as UTC) and an already
+        # native timestamp column; the int64 of a timestamp is µs-since-epoch
+        # regardless of any tz annotation.
+        ts = pc.cast(col, pa.timestamp("us", tz="UTC"))
+    else:
+        ts = pc.strptime(col, format=fmt, unit="us")
+    return pc.cast(ts, pa.int64())
+
+
+def convert_table_date_columns(table: pa.Table, date_formats: dict[str, str]) -> pa.Table:
+    """Return `table` with each PRESENT declared date column replaced by its
+    int64 epoch-µs form. A declared field absent from this table's schema is
+    left untouched (the caller's existing missing-field handling still applies
+    to filter fields); a non-date filter column is never touched."""
+    if not date_formats:
+        return table
+    names = set(table.column_names)
+    for name, fmt in date_formats.items():
+        if name in names:
+            idx = table.schema.get_field_index(name)
+            table = table.set_column(idx, name, to_epoch_us_array(table[name], fmt))
+    return table

--- a/python/nova-bf/tests/test_compute_dates.py
+++ b/python/nova-bf/tests/test_compute_dates.py
@@ -1,0 +1,160 @@
+"""End-to-end date-filter tests: drive `run_compute` on a synthetic corpus with
+an RFC-3339 `date` column and confirm both static `range` and per-query
+`range_from_query` over that column return exactly the in-range neighbors —
+exercising the corpus-side and query-side epoch conversions in compute.py."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from nova_bf.compute import run_compute
+from nova_bf.config import load_config
+from nova_bf.dates import parse_scalar_epoch_us
+
+DIM = 8
+
+CORPUS_DATES = [
+    "2010-01-01T00:00:00Z",  # c0
+    "2011-01-01T00:00:00Z",  # c1
+    "2012-06-15T12:00:00Z",  # c2
+    "2013-01-01T00:00:00Z",  # c3
+    "2014-07-04T00:00:00Z",  # c4
+    "2015-12-31T23:59:59Z",  # c5
+    "2016-01-01T00:00:00Z",  # c6
+    "2017-03-03T03:03:03Z",  # c7
+    None,                    # c8  (null date -> never matches)
+    "2019-09-09T09:09:09Z",  # c9
+]
+N = len(CORPUS_DATES)
+
+
+@pytest.fixture(scope="module")
+def ds(tmp_path_factory):
+    rng = np.random.default_rng(7)
+    tmp = tmp_path_factory.mktemp("bfdate")
+    cdir = tmp / "corpus"
+    cdir.mkdir()
+    corpus = rng.standard_normal((N, DIM)).astype(np.float32)
+    pq.write_table(
+        pa.table({
+            "dense_embedding": pa.array(corpus.tolist(), type=pa.list_(pa.float32())),
+            "id": pa.array([f"c{i}" for i in range(N)]),
+            "date": pa.array(CORPUS_DATES, type=pa.string()),
+        }),
+        str(cdir / "f0.parquet"),
+    )
+
+    n_q = 3
+    queries = rng.standard_normal((n_q, DIM)).astype(np.float32)
+    afters = ["2015-01-01T00:00:00Z", "2018-01-01T00:00:00Z", "2011-06-01T00:00:00Z"]
+    pq.write_table(
+        pa.table({
+            "dense_embedding": pa.array(queries.tolist(), type=pa.list_(pa.float32())),
+            "qid": pa.array([f"q{i}" for i in range(n_q)]),
+            "after": pa.array(afters, type=pa.string()),
+        }),
+        str(tmp / "queries.parquet"),
+    )
+
+    corpus_us = [parse_scalar_epoch_us(d) if d else None for d in CORPUS_DATES]
+    return {
+        "tmp": tmp, "cdir": str(cdir), "qpath": str(tmp / "queries.parquet"),
+        "qids": [f"q{i}" for i in range(n_q)], "corpus": corpus, "queries": queries,
+        "corpus_us": corpus_us, "afters": [parse_scalar_epoch_us(a) for a in afters],
+    }
+
+
+def _run(ds, filter_yaml, corpus_dates="[date]", query_dates=""):
+    out = ds["tmp"] / "out"
+    out.mkdir(exist_ok=True)
+    cfgtext = f"""
+corpus:
+  path: {ds["cdir"]}
+  dense_column: dense_embedding
+  id_column: id
+  date_fields: {corpus_dates}
+queries:
+  path: {ds["qpath"]}
+  dense_column: dense_embedding
+  id_column: qid
+  {("date_fields: " + query_dates) if query_dates else ""}
+output:
+  path: {out}
+params:
+  io_workers: 2
+searches:
+  - name: dated
+    k: {N}
+    metric: dot
+    filter:
+{filter_yaml}
+"""
+    cfgpath = ds["tmp"] / "cfg.yaml"
+    cfgpath.write_text(cfgtext)
+    cfg = load_config(str(cfgpath))
+    t = pq.read_table(run_compute(cfg)["dated"]).to_pydict()
+    return {q: list(zip(hi, hs)) for q, hi, hs in
+            zip(t["query_id"], t["hit_ids"], t["hit_scores"])}
+
+
+def _ids(res_for_q):
+    return [i for i, _ in res_for_q]
+
+
+def _scores_descending(res_for_q):
+    s = [sc for _, sc in res_for_q]
+    return all(a >= b - 1e-4 for a, b in zip(s, s[1:]))
+
+
+def test_static_range_returns_only_in_range(ds):
+    lo, hi = "2013-01-01T00:00:00Z", "2016-01-01T00:00:00Z"
+    res = _run(ds, f"""      must:
+        - field: date
+          range: {{gte: "{lo}", lt: "{hi}"}}
+""")
+    lo_us, hi_us = parse_scalar_epoch_us(lo), parse_scalar_epoch_us(hi)
+    expected = {f"c{g}" for g, us in enumerate(ds["corpus_us"])
+                if us is not None and lo_us <= us < hi_us}
+    assert expected == {"c3", "c4", "c5"}  # sanity on the fixture
+    for q in ds["qids"]:
+        assert set(_ids(res[q])) == expected     # exactly the in-range docs
+        assert _scores_descending(res[q])         # ranked by dot within the filter
+        assert "c8" not in _ids(res[q])           # null date never matches
+
+
+def test_static_range_single_bound(ds):
+    res = _run(ds, """      must:
+        - field: date
+          range: {gt: "2016-01-01T00:00:00Z"}
+""")
+    cut = parse_scalar_epoch_us("2016-01-01T00:00:00Z")
+    expected = {f"c{g}" for g, us in enumerate(ds["corpus_us"]) if us is not None and us > cut}
+    assert expected == {"c7", "c9"}
+    for q in ds["qids"]:
+        assert set(_ids(res[q])) == expected
+
+
+def test_range_from_query_per_query_cutoff(ds):
+    res = _run(
+        ds,
+        """      must:
+        - field: date
+          range_from_query: {gte: after}
+""",
+        query_dates="[after]",
+    )
+    for qi, q in enumerate(ds["qids"]):
+        after_us = ds["afters"][qi]
+        expected = {f"c{g}" for g, us in enumerate(ds["corpus_us"])
+                    if us is not None and us >= after_us}
+        assert set(_ids(res[q])) == expected, f"{q}: after={after_us}"
+        assert _scores_descending(res[q])
+    # concrete per-query expectations from the fixture dates
+    assert set(_ids(res["q0"])) == {"c5", "c6", "c7", "c9"}   # >= 2015-01-01
+    assert set(_ids(res["q1"])) == {"c9"}                      # >= 2018-01-01
+    assert set(_ids(res["q2"])) == {"c2", "c3", "c4", "c5", "c6", "c7", "c9"}  # >= 2011-06-01

--- a/python/nova-bf/tests/test_compute_dates.py
+++ b/python/nova-bf/tests/test_compute_dates.py
@@ -158,3 +158,41 @@ def test_range_from_query_per_query_cutoff(ds):
     assert set(_ids(res["q0"])) == {"c5", "c6", "c7", "c9"}   # >= 2015-01-01
     assert set(_ids(res["q1"])) == {"c9"}                      # >= 2018-01-01
     assert set(_ids(res["q2"])) == {"c2", "c3", "c4", "c5", "c6", "c7", "c9"}  # >= 2011-06-01
+
+
+def test_date_field_in_payload_keeps_original_string(ds):
+    """A query date column carried in payload_fields is emitted in its ORIGINAL
+    RFC-3339 form, even though it's also parsed to epoch µs for the filter."""
+    out = ds["tmp"] / "out_payload"
+    out.mkdir(exist_ok=True)
+    cfgtext = f"""
+corpus:
+  path: {ds["cdir"]}
+  dense_column: dense_embedding
+  id_column: id
+  date_fields: [date]
+queries:
+  path: {ds["qpath"]}
+  dense_column: dense_embedding
+  id_column: qid
+  date_fields: [after]
+  payload_fields: [after]
+output:
+  path: {out}
+params:
+  io_workers: 2
+searches:
+  - name: dated
+    k: {N}
+    metric: dot
+    filter:
+      must:
+        - field: date
+          range_from_query: {{gte: after}}
+"""
+    p = ds["tmp"] / "cfg_payload.yaml"
+    p.write_text(cfgtext)
+    t = pq.read_table(run_compute(load_config(str(p)))["dated"]).to_pydict()
+    afters = dict(zip(t["query_id"], t["after"]))
+    assert afters["q0"] == "2015-01-01T00:00:00Z"     # original string, not epoch µs int
+    assert all(isinstance(v, str) for v in t["after"])

--- a/python/nova-bf/tests/test_config_dates.py
+++ b/python/nova-bf/tests/test_config_dates.py
@@ -90,8 +90,8 @@ def test_string_bound_on_non_date_field_rejected(tmp_path):
         """)
 
 
-def test_numeric_bound_on_date_field_passes_through(tmp_path):
-    # A numeric literal is treated as already-epoch µs and left as-is.
+def test_numeric_bound_on_rfc3339_field_passes_through(tmp_path):
+    # A numeric literal on an rfc3339 field is treated as already-epoch µs, as-is.
     cfg = _cfg(tmp_path, """
       corpus:
         path: /tmp/corpus
@@ -108,6 +108,67 @@ def test_numeric_bound_on_date_field_passes_through(tmp_path):
                 range: {gte: 1356998400000000}
     """)
     assert cfg.searches[0].filter.must[0].range.gte == 1356998400000000
+
+
+def test_numeric_bound_on_epoch_s_field_rescaled_to_us(tmp_path):
+    # A NUMERIC bound on an epoch_s field must be rescaled to µs to match the
+    # (also-rescaled) corpus column — otherwise it compares seconds vs µs.
+    cfg = _cfg(tmp_path, """
+      corpus:
+        path: /tmp/corpus
+        date_fields: {t: epoch_s}
+      queries:
+        path: /tmp/queries.parquet
+      output:
+        path: /tmp/out
+      searches:
+        - name: s
+          filter:
+            must:
+              - field: t
+                range: {gte: 1356998400, lt: 1400000000}
+    """)
+    rng = cfg.searches[0].filter.must[0].range
+    assert rng.gte == 1356998400 * 1_000_000
+    assert rng.lt == 1400000000 * 1_000_000
+
+
+def test_date_field_with_match_rejected(tmp_path):
+    with pytest.raises(ValueError, match="only supports"):
+        _cfg(tmp_path, """
+          corpus:
+            path: /tmp/corpus
+            date_fields: [published_at]
+          queries:
+            path: /tmp/queries.parquet
+          output:
+            path: /tmp/out
+          searches:
+            - name: s
+              filter:
+                must:
+                  - field: published_at
+                    match: 5
+        """)
+
+
+def test_date_field_with_match_text_rejected(tmp_path):
+    with pytest.raises(ValueError, match="only supports"):
+        _cfg(tmp_path, """
+          corpus:
+            path: /tmp/corpus
+            date_fields: [published_at]
+          queries:
+            path: /tmp/queries.parquet
+          output:
+            path: /tmp/out
+          searches:
+            - name: s
+              filter:
+                must:
+                  - field: published_at
+                    match_text: "2013"
+        """)
 
 
 def test_range_from_query_requires_declared_query_date_field(tmp_path):

--- a/python/nova-bf/tests/test_config_dates.py
+++ b/python/nova-bf/tests/test_config_dates.py
@@ -1,0 +1,188 @@
+"""Config-level tests for date_fields: static bound normalization + validators."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from nova_bf.config import load_config
+from nova_bf.dates import parse_scalar_epoch_us
+
+
+def _cfg(tmp_path, body: str):
+    p = tmp_path / "cfg.yaml"
+    p.write_text(textwrap.dedent(body))
+    return load_config(str(p))
+
+
+BASE_STORES = """
+      corpus:
+        path: /tmp/corpus
+        {corpus_extra}
+      queries:
+        path: /tmp/queries.parquet
+        {queries_extra}
+      output:
+        path: /tmp/out
+"""
+
+
+def test_static_bound_string_parsed_to_epoch_us(tmp_path):
+    cfg = _cfg(tmp_path, """
+      corpus:
+        path: /tmp/corpus
+        date_fields: [published_at]
+      queries:
+        path: /tmp/queries.parquet
+      output:
+        path: /tmp/out
+      searches:
+        - name: recent
+          filter:
+            must:
+              - field: published_at
+                range:
+                  gte: "2013-01-01T00:00:00Z"
+                  lt: "2014-01-01T00:00:00Z"
+    """)
+    rng = cfg.searches[0].filter.must[0].range
+    assert rng.gte == float(parse_scalar_epoch_us("2013-01-01T00:00:00Z"))
+    assert rng.lt == float(parse_scalar_epoch_us("2014-01-01T00:00:00Z"))
+
+
+def test_dict_form_with_custom_format(tmp_path):
+    cfg = _cfg(tmp_path, """
+      corpus:
+        path: /tmp/corpus
+        date_fields:
+          crawl_day: "%Y%m%d"
+      queries:
+        path: /tmp/queries.parquet
+      output:
+        path: /tmp/out
+      searches:
+        - name: s
+          filter:
+            must:
+              - field: crawl_day
+                range: {gte: "20130101"}
+    """)
+    rng = cfg.searches[0].filter.must[0].range
+    assert rng.gte == float(parse_scalar_epoch_us("20130101", "%Y%m%d"))
+
+
+def test_string_bound_on_non_date_field_rejected(tmp_path):
+    with pytest.raises(ValueError, match="not declared in corpus.date_fields"):
+        _cfg(tmp_path, """
+          corpus:
+            path: /tmp/corpus
+          queries:
+            path: /tmp/queries.parquet
+          output:
+            path: /tmp/out
+          searches:
+            - name: s
+              filter:
+                must:
+                  - field: published_at
+                    range: {gte: "2013-01-01T00:00:00Z"}
+        """)
+
+
+def test_numeric_bound_on_date_field_passes_through(tmp_path):
+    # A numeric literal is treated as already-epoch µs and left as-is.
+    cfg = _cfg(tmp_path, """
+      corpus:
+        path: /tmp/corpus
+        date_fields: [published_at]
+      queries:
+        path: /tmp/queries.parquet
+      output:
+        path: /tmp/out
+      searches:
+        - name: s
+          filter:
+            must:
+              - field: published_at
+                range: {gte: 1356998400000000}
+    """)
+    assert cfg.searches[0].filter.must[0].range.gte == 1356998400000000
+
+
+def test_range_from_query_requires_declared_query_date_field(tmp_path):
+    with pytest.raises(ValueError, match="not declared in queries.date_fields"):
+        _cfg(tmp_path, """
+          corpus:
+            path: /tmp/corpus
+            date_fields: [published_at]
+          queries:
+            path: /tmp/queries.parquet
+          output:
+            path: /tmp/out
+          searches:
+            - name: s
+              filter:
+                must:
+                  - field: published_at
+                    range_from_query: {gte: after}
+        """)
+
+
+def test_range_from_query_date_bound_on_non_date_corpus_field_rejected(tmp_path):
+    with pytest.raises(ValueError, match="not a\\s*\\ndate field|is not a date field"):
+        _cfg(tmp_path, """
+          corpus:
+            path: /tmp/corpus
+          queries:
+            path: /tmp/queries.parquet
+            date_fields: [after]
+          output:
+            path: /tmp/out
+          searches:
+            - name: s
+              filter:
+                must:
+                  - field: some_number
+                    range_from_query: {gte: after}
+        """)
+
+
+def test_range_from_query_consistent_declaration_ok(tmp_path):
+    cfg = _cfg(tmp_path, """
+      corpus:
+        path: /tmp/corpus
+        date_fields: [published_at]
+      queries:
+        path: /tmp/queries.parquet
+        date_fields: [after]
+      output:
+        path: /tmp/out
+      searches:
+        - name: s
+          filter:
+            must:
+              - field: published_at
+                range_from_query: {gte: after}
+    """)
+    assert cfg.searches[0].filter.must[0].range_from_query.gte == "after"
+
+
+def test_non_date_numeric_range_from_query_still_works(tmp_path):
+    # No date_fields anywhere: the ordinary numeric range_from_query path is
+    # completely unaffected by the new validator.
+    cfg = _cfg(tmp_path, """
+      corpus:
+        path: /tmp/corpus
+      queries:
+        path: /tmp/queries.parquet
+      output:
+        path: /tmp/out
+      searches:
+        - name: s
+          filter:
+            must:
+              - field: cost
+                range_from_query: {lte: max_budget}
+    """)
+    assert cfg.searches[0].filter.must[0].range_from_query.lte == "max_budget"

--- a/python/nova-bf/tests/test_dates.py
+++ b/python/nova-bf/tests/test_dates.py
@@ -71,6 +71,13 @@ def test_scalar_bad_value_raises():
         parse_scalar_epoch_us("not-a-date")
 
 
+def test_scalar_epoch_us_large_value_stays_exact():
+    # 2^53 + 1 is not representable in float64; epoch_us must not route through it
+    big = 9_007_199_254_740_993
+    assert parse_scalar_epoch_us(big, "epoch_us") == big
+    assert parse_scalar_epoch_us(str(big), "epoch_us") == big
+
+
 # --- to_epoch_us_array -------------------------------------------------------
 
 def test_array_rfc3339_with_null():
@@ -111,6 +118,13 @@ def test_array_strptime_pattern():
 def test_array_epoch_seconds_rescaled():
     col = pa.array([1, 2], type=pa.int64())
     assert to_epoch_us_array(col, "epoch_s").to_pylist() == [1_000_000, 2_000_000]
+
+
+def test_array_epoch_us_large_value_stays_exact():
+    big = 9_007_199_254_740_993  # 2^53 + 1
+    out = to_epoch_us_array(pa.array([big], type=pa.int64()), "epoch_us")
+    assert out.type == pa.int64()
+    assert out.to_pylist() == [big]  # not corrupted by a float64 round-trip
 
 
 def test_array_unparseable_raises():

--- a/python/nova-bf/tests/test_dates.py
+++ b/python/nova-bf/tests/test_dates.py
@@ -1,0 +1,142 @@
+"""Unit tests for nova_bf.dates — the datetime -> epoch-µs parsing primitives."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from nova_bf.dates import (
+    convert_table_date_columns,
+    normalize_date_fields,
+    parse_scalar_epoch_us,
+    to_epoch_us_array,
+)
+
+
+def _ref_us(s: str) -> int:
+    dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1_000_000)
+
+
+# --- normalize_date_fields ---------------------------------------------------
+
+def test_normalize_none_empty():
+    assert normalize_date_fields(None) == {}
+    assert normalize_date_fields([]) == {}
+
+
+def test_normalize_list_defaults_to_rfc3339():
+    assert normalize_date_fields(["a", "b"]) == {"a": "rfc3339", "b": "rfc3339"}
+
+
+def test_normalize_dict_keeps_format_and_fills_blank():
+    assert normalize_date_fields({"a": "%Y%m%d", "b": None, "c": ""}) == {
+        "a": "%Y%m%d", "b": "rfc3339", "c": "rfc3339",
+    }
+
+
+# --- parse_scalar_epoch_us ---------------------------------------------------
+
+def test_scalar_rfc3339_z():
+    assert parse_scalar_epoch_us("2013-05-18T05:48:54Z") == 1368856134000000
+    assert parse_scalar_epoch_us("2013-05-18T05:48:54Z") == _ref_us("2013-05-18T05:48:54Z")
+
+
+def test_scalar_rfc3339_offset_equals_utc():
+    # 05:48:54+02:00 is the same instant as 03:48:54Z
+    assert parse_scalar_epoch_us("2013-05-18T07:48:54+02:00") == _ref_us("2013-05-18T05:48:54Z")
+
+
+def test_scalar_naive_treated_as_utc():
+    assert parse_scalar_epoch_us("2013-05-18T05:48:54") == _ref_us("2013-05-18T05:48:54Z")
+
+
+def test_scalar_strptime_pattern():
+    assert parse_scalar_epoch_us("20130518", "%Y%m%d") == _ref_us("2013-05-18T00:00:00Z")
+
+
+def test_scalar_epoch_scales():
+    assert parse_scalar_epoch_us(1000, "epoch_s") == 1_000_000_000
+    assert parse_scalar_epoch_us(1000, "epoch_ms") == 1_000_000
+    assert parse_scalar_epoch_us(1000, "epoch_us") == 1000
+
+
+def test_scalar_bad_value_raises():
+    with pytest.raises(ValueError):
+        parse_scalar_epoch_us("not-a-date")
+
+
+# --- to_epoch_us_array -------------------------------------------------------
+
+def test_array_rfc3339_with_null():
+    col = pa.array(["2013-05-18T05:48:54Z", None, "2020-12-31T23:59:59Z"])
+    out = to_epoch_us_array(col, "rfc3339")
+    assert out.type == pa.int64()
+    assert out.to_pylist() == [
+        _ref_us("2013-05-18T05:48:54Z"), None, _ref_us("2020-12-31T23:59:59Z"),
+    ]
+
+
+def test_array_null_becomes_nan_in_numpy():
+    col = pa.array(["2013-05-18T05:48:54Z", None])
+    arr = to_epoch_us_array(col, "rfc3339").to_numpy(zero_copy_only=False).astype(np.float64)
+    assert arr[0] == float(_ref_us("2013-05-18T05:48:54Z"))
+    assert np.isnan(arr[1])  # null -> NaN -> compares False, matching the numeric path
+
+
+def test_array_scalar_and_array_agree():
+    s = "2013-05-18T05:48:54Z"
+    (val,) = to_epoch_us_array(pa.array([s]), "rfc3339").to_pylist()
+    assert val == parse_scalar_epoch_us(s)
+
+
+def test_array_native_timestamp_input():
+    ts = pa.array([datetime(2013, 5, 18, 5, 48, 54, tzinfo=timezone.utc)],
+                  type=pa.timestamp("us", tz="UTC"))
+    assert to_epoch_us_array(ts, "rfc3339").to_pylist() == [_ref_us("2013-05-18T05:48:54Z")]
+
+
+def test_array_strptime_pattern():
+    col = pa.array(["20130518", "20201231"])
+    assert to_epoch_us_array(col, "%Y%m%d").to_pylist() == [
+        _ref_us("2013-05-18T00:00:00Z"), _ref_us("2020-12-31T00:00:00Z"),
+    ]
+
+
+def test_array_epoch_seconds_rescaled():
+    col = pa.array([1, 2], type=pa.int64())
+    assert to_epoch_us_array(col, "epoch_s").to_pylist() == [1_000_000, 2_000_000]
+
+
+def test_array_unparseable_raises():
+    with pytest.raises(Exception):
+        to_epoch_us_array(pa.array(["nope"]), "rfc3339")
+
+
+# --- convert_table_date_columns ---------------------------------------------
+
+def test_convert_table_replaces_only_declared():
+    t = pa.table({
+        "date": pa.array(["2013-05-18T05:48:54Z", None]),
+        "text": pa.array(["a", "b"]),
+    })
+    out = convert_table_date_columns(t, {"date": "rfc3339"})
+    assert out.schema.field("date").type == pa.int64()
+    assert out.schema.field("text").type == pa.string()  # untouched
+    assert out.column("date").to_pylist() == [_ref_us("2013-05-18T05:48:54Z"), None]
+
+
+def test_convert_table_absent_field_is_noop():
+    t = pa.table({"text": pa.array(["a"])})
+    out = convert_table_date_columns(t, {"missing": "rfc3339"})
+    assert out.column("text").to_pylist() == ["a"]
+
+
+def test_convert_table_empty_mapping_returns_same():
+    t = pa.table({"x": pa.array([1])})
+    assert convert_table_date_columns(t, {}) is t

--- a/python/nova-bf/tests/test_qdrant_datetime_parity.py
+++ b/python/nova-bf/tests/test_qdrant_datetime_parity.py
@@ -1,0 +1,196 @@
+"""Live-Qdrant parity for datetime `range` / `range_from_query` filters.
+
+Confirms nova-bf's epoch-µs date comparison selects EXACTLY the same corpus
+points as Qdrant's native `DatetimeRange` on the same data and the same bounds —
+including boundary inclusivity (gt vs gte, lt vs lte). Uses k >= corpus size so
+both engines return every point passing the filter, making the comparison a
+deterministic SET equality that can't be perturbed by score ties.
+
+Skipped automatically unless `qdrant-client` is importable AND a Qdrant server
+is reachable (env `QDRANT_URL`, default http://localhost:6333). So it's inert in
+the default `pytest` run / CI, and active wherever a live Qdrant exists.
+
+Run it explicitly:
+    uv run --with qdrant-client --directory python/nova-bf --extra dev \
+        pytest -q tests/test_qdrant_datetime_parity.py
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("qdrant_client")
+import pyarrow as pa
+import pyarrow.parquet as pq
+from qdrant_client import QdrantClient, models
+
+from nova_bf.compute import run_compute
+from nova_bf.config import load_config
+from nova_bf.dates import parse_scalar_epoch_us
+
+QDRANT_URL = os.environ.get("QDRANT_URL", "http://localhost:6333")
+DIM = 32
+M = 2000       # corpus points
+N_Q = 12       # queries
+EPOCH0 = datetime(2010, 1, 1, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="module")
+def client():
+    try:
+        c = QdrantClient(url=QDRANT_URL, timeout=10)
+        c.get_collections()
+    except Exception as e:  # pragma: no cover - environment gate
+        pytest.skip(f"no reachable Qdrant at {QDRANT_URL}: {e}")
+    return c
+
+
+@pytest.fixture(scope="module")
+def data(tmp_path_factory):
+    rng = np.random.default_rng(20260717)
+    tmp = tmp_path_factory.mktemp("qparity")
+    vecs = rng.standard_normal((M, DIM)).astype(np.float32)
+    # dates spread over ~10 years at hour granularity; a few nulls
+    hours = rng.integers(0, 24 * 365 * 10, size=M)
+    dts = [EPOCH0 + timedelta(hours=int(h)) for h in hours]
+    date_strs = [d.strftime("%Y-%m-%dT%H:%M:%SZ") for d in dts]
+    for i in rng.choice(M, size=30, replace=False):
+        date_strs[i] = None
+
+    cdir = tmp / "corpus"
+    cdir.mkdir()
+    pq.write_table(pa.table({
+        "dense_embedding": pa.array(vecs.tolist(), type=pa.list_(pa.float32())),
+        "id": pa.array([str(i) for i in range(M)]),
+        "date": pa.array(date_strs, type=pa.string()),
+    }), str(cdir / "c0.parquet"))
+
+    qidx = rng.choice(M, size=N_Q, replace=False)
+    qvecs = vecs[qidx]
+    # per-query cutoff dates for the range_from_query test
+    afters = [(EPOCH0 + timedelta(hours=int(h))).strftime("%Y-%m-%dT%H:%M:%SZ")
+              for h in rng.integers(0, 24 * 365 * 10, size=N_Q)]
+    pq.write_table(pa.table({
+        "dense_embedding": pa.array(qvecs.tolist(), type=pa.list_(pa.float32())),
+        "qid": pa.array([str(i) for i in range(N_Q)]),
+        "after": pa.array(afters, type=pa.string()),
+    }), str(tmp / "queries.parquet"))
+
+    return {
+        "tmp": tmp, "cdir": str(cdir), "qpath": str(tmp / "queries.parquet"),
+        "vecs": vecs, "qvecs": qvecs, "date_strs": date_strs, "afters": afters,
+    }
+
+
+@pytest.fixture(scope="module")
+def collection(client, data):
+    name = f"nova_bf_date_parity_{uuid.uuid4().hex[:8]}"
+    client.create_collection(
+        name, vectors_config=models.VectorParams(size=DIM, distance=models.Distance.COSINE),
+    )
+    client.create_payload_index(name, "date", models.PayloadSchemaType.DATETIME)
+    points = [
+        models.PointStruct(id=i, vector=data["vecs"][i].tolist(),
+                           payload=({"date": d} if d is not None else {}))
+        for i, d in enumerate(data["date_strs"])
+    ]
+    client.upsert(name, points=points, wait=True)
+    yield name
+    client.delete_collection(name)
+
+
+def _nova(data, filter_yaml, query_dates=""):
+    out = data["tmp"] / "out"
+    out.mkdir(exist_ok=True)
+    cfg_text = f"""
+corpus:
+  path: {data["cdir"]}
+  dense_column: dense_embedding
+  id_column: id
+  date_fields: [date]
+queries:
+  path: {data["qpath"]}
+  dense_column: dense_embedding
+  id_column: qid
+  {("date_fields: " + query_dates) if query_dates else ""}
+output:
+  path: {out}
+params:
+  io_workers: 2
+searches:
+  - name: p
+    k: {M}
+    metric: cosine
+    filter:
+{filter_yaml}
+"""
+    p = data["tmp"] / "cfg.yaml"
+    p.write_text(cfg_text)
+    t = pq.read_table(run_compute(load_config(str(p)))["p"]).to_pydict()
+    return {q: {int(i) for i in hi} for q, hi in zip(t["query_id"], t["hit_ids"])}
+
+
+def _qdrant(client, collection, data, qflt):
+    res = {}
+    for qi in range(N_Q):
+        pts = client.query_points(
+            collection, query=data["qvecs"][qi].tolist(),
+            query_filter=qflt(qi), limit=M,
+            search_params=models.SearchParams(exact=True),  # exact, not HNSW
+            with_payload=False,
+        ).points
+        res[str(qi)] = {int(p.id) for p in pts}
+    return res
+
+
+@pytest.mark.parametrize("lo,hi,gte,lt", [
+    ("2013-01-01T00:00:00Z", "2016-01-01T00:00:00Z", True, True),
+    ("2015-06-01T00:00:00Z", None, True, None),
+    (None, "2012-01-01T00:00:00Z", None, True),
+    ("2014-01-01T00:00:00Z", "2018-01-01T00:00:00Z", False, False),  # gt / lte boundary
+])
+def test_static_range_parity(client, collection, data, lo, hi, gte, lt):
+    conds, qbounds = [], {}
+    if lo is not None:
+        key = "gte" if gte else "gt"
+        conds.append(f'{key}: "{lo}"')
+        qbounds[key if gte else "gt"] = lo
+    if hi is not None:
+        key = "lt" if lt else "lte"
+        conds.append(f'{key}: "{hi}"')
+        qbounds[key if lt else "lte"] = hi
+    nova = _nova(data, "      must:\n        - field: date\n          range: {%s}\n" % ", ".join(conds))
+
+    dr = models.DatetimeRange(**{k: v for k, v in qbounds.items()})
+    qflt = lambda qi: models.Filter(must=[models.FieldCondition(key="date", range=dr)])
+    qd = _qdrant(client, collection, data, qflt)
+
+    for qi in range(N_Q):
+        assert nova[str(qi)] == qd[str(qi)], (
+            f"q{qi} lo={lo} hi={hi} gte={gte} lt={lt}: "
+            f"nova-only={sorted(nova[str(qi)] - qd[str(qi)])[:5]} "
+            f"qdrant-only={sorted(qd[str(qi)] - nova[str(qi)])[:5]}"
+        )
+
+
+def test_range_from_query_parity(client, collection, data):
+    nova = _nova(
+        data,
+        "      must:\n        - field: date\n          range_from_query: {gte: after}\n",
+        query_dates="[after]",
+    )
+    qflt = lambda qi: models.Filter(must=[models.FieldCondition(
+        key="date", range=models.DatetimeRange(gte=data["afters"][qi]))])
+    qd = _qdrant(client, collection, data, qflt)
+    for qi in range(N_Q):
+        assert nova[str(qi)] == qd[str(qi)], (
+            f"q{qi} after={data['afters'][qi]}: "
+            f"nova-only={sorted(nova[str(qi)] - qd[str(qi)])[:5]} "
+            f"qdrant-only={sorted(qd[str(qi)] - nova[str(qi)])[:5]}"
+        )


### PR DESCRIPTION
## What

Adds RFC-3339 datetime support to `range` / `range_from_query` filters in nova-bf. A column is treated as a datetime **only** when explicitly declared in `corpus.date_fields` / `queries.date_fields` — no type sniffing. Declared fields are parsed to **int64 epoch microseconds** at load time, so every downstream range path (the CPU `filters.py` path *and* the GPU-native range path) stays numeric and unchanged. Epoch µs is Qdrant's own internal datetime representation, so a date `range` is value-for-value comparable to Qdrant's `DatetimeRange` — parity for free.

## Config

```yaml
corpus:
  path: s3://…/resharded/
  date_fields: [published_at]          # rfc3339 (default)
  # or: {published_at: rfc3339, crawl_day: "%Y%m%d", ingested_at: epoch_s}
queries:
  date_fields: [after]                 # columns supplying range_from_query bounds
searches:
  - filter:
      must:
        - field: published_at
          range: {gte: "2013-01-01T00:00:00Z", lt: "2014-01-01T00:00:00Z"}
        # or per-query: range_from_query: {gte: after}
```

Supported formats: `rfc3339` (default; ISO-8601, UTC/offset), any `strptime` pattern, `epoch_s`/`epoch_ms`/`epoch_us`.

## How

- **`nova_bf/dates.py`** (new): `normalize_date_fields`, `parse_scalar_epoch_us`, `to_epoch_us_array`, `convert_table_date_columns`, `is_epoch_format`. Nulls preserved → NaN → never match.
- **`config.py`**: `date_fields` on Corpus/Queries; `load_config` rewrites static bounds → epoch µs (string bounds parsed; numeric bounds rescaled for epoch_s/ms); string bound on a non-date field rejected; a validator keeps `range_from_query`/date declarations consistent and forbids a date field in match/match_text.
- **`compute.py`**: declared date columns converted to epoch µs at the two read points — `load_queries`/`load_queries_sparse` (query side; payload keeps the original string) and the corpus reader. `filters.py` and the GPU range path are **untouched**.

## Testing

- Unit (`test_dates.py`), config normalization + validators (`test_config_dates.py`), end-to-end `run_compute` date filtering (`test_compute_dates.py`) — **352 passed**.
- **Live-Qdrant `DatetimeRange` parity** (`test_qdrant_datetime_parity.py`, self-contained; skips without qdrant-client/live server): nova-bf date filtering == Qdrant exact search across gte+lt / gte-only / lt-only / gt-lte-exclusive boundaries and per-query `range_from_query`.
- Also validated against **real FineWeb data** (5000 real rows, real 768-d gte embeddings, real RFC-3339 dates) vs live Qdrant exact search: 0 mismatches across all checks.

## Notes / follow-ups

- The GPU-native range path wasn't exercised on live GPU (dev box is CPU-only), but it's covered by construction — dates become plain int64 before any GPU code, which already handles numeric `range_from_query` — plus full CPU parity. Can validate on a cloud g5 if desired.
- Includes a self-review pass (see commit `c12577b`): fixed epoch_s/ms numeric-bound scaling, payload string preservation, a date-field misuse guard, and epoch_us precision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)