### PR TITLE
`nova-storm` report functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1674,6 +1674,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/configs/skypilot/embed-vllm.yaml
+++ b/configs/skypilot/embed-vllm.yaml
@@ -12,7 +12,13 @@
 resources:
   cloud: aws
   accelerators: A10G:1
-  use_spot: true
+  # A10G:1 alone lands on g5.xlarge (16 GB RAM) — too tight: vLLM's engine
+  # process holds ~6 GB host-side and the pipeline (queued image chunks,
+  # decoded PIL batches, flush buffer) another ~5, and Ray OOM-kills the job
+  # at 95% node memory. 32+ steers to g5.2xlarge (32 GB, same GPU, ~20% more
+  # $/hr).
+  memory: 64+
+  use_spot: false
   # vLLM + CUDA wheels are several GB on top of the embed stack.
   disk_size: 150
   # A real GPU VM AMI (driver + CUDA preinstalled) — see embed.yaml for why

--- a/configs/storm/example.yaml
+++ b/configs/storm/example.yaml
@@ -21,6 +21,10 @@ query:
   # Named vector to hit. Omit for a single-(unnamed-)vector collection.
   vector_name: dense
   top_k: 10                         # neighbours per query (default 10)
+  # Return each hit's full payload (default false = ids/scores only). Turn on
+  # when the modeled production traffic fetches payloads — payload reads and
+  # response bytes are real cost the benchmark otherwise understates.
+  # with_payload: true
   source:
     # Query vectors — a parquet file (or dir) at a local path or s3:// URI, read
     # via DuckDB. Each row's `column` is one query vector.

--- a/configs/storm/example.yaml
+++ b/configs/storm/example.yaml
@@ -48,3 +48,14 @@ load:
   # individual queries — actual query throughput is `rps * batch_size` (see
   # the `qps` field in the printed summary).
   # rps: 500
+
+# Optional: per-dispatch TIME-SERIES output, for plotting transient behavior
+# (acute load, the cluster re-optimizing mid-run) that the end-of-run summary
+# collapses away. One raw row per dispatch, in completion order:
+#   t_s (seconds since run start), latency_ms, ok, recalls
+# Deliberately unaggregated — bucket/smooth downstream (pandas/polars/duckdb).
+# Omit the section for summary-only (default). `path: "-"` streams to stdout —
+# fine interactively, but it breaks `--json` consumers like `nova sweep`.
+# report:
+#   format: csv                     # csv | jsonl
+#   path: storm_ts.csv

--- a/crates/nova-storm/Cargo.toml
+++ b/crates/nova-storm/Cargo.toml
@@ -31,3 +31,6 @@ duckdb = { workspace = true }
 
 # Target backend.
 qdrant-client = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/nova-storm/src/config.rs
+++ b/crates/nova-storm/src/config.rs
@@ -1,8 +1,9 @@
 //! Parsing for the storm `.yaml`.
 //!
-//! Three top-level keys: `target` (the cluster under test, dispatched on its
-//! `type`), `query` (what to search with + where the query vectors live), and
-//! `load` (the per-worker profile).
+//! Four top-level keys: `target` (the cluster under test, dispatched on its
+//! `type`), `query` (what to search with + where the query vectors live),
+//! `load` (the per-worker profile), and optional `report` (per-dispatch
+//! time-series output — see [`crate::report::ReportConfig`]).
 //!
 //! Mirrors `nova-load`'s config paradigm: `${VAR}` references are expanded from
 //! the environment before deserializing (see [`expand_env`]).
@@ -12,6 +13,7 @@ use std::env;
 use serde::Deserialize;
 
 use crate::filter::Filter;
+use crate::report::ReportConfig;
 use crate::targets::TargetConfig;
 
 /// The full parsed storm config.
@@ -22,6 +24,9 @@ pub struct StormConfig {
     pub query: QueryConfig,
     #[serde(default)]
     pub load: LoadProfile,
+    /// Per-dispatch time-series output. Absent (default) = summary only.
+    #[serde(default)]
+    pub report: Option<ReportConfig>,
 }
 
 impl StormConfig {
@@ -358,6 +363,33 @@ load:
         // `qps` was replaced by `rps` with no back-compat alias -- an old config
         // using it now hits `deny_unknown_fields` like any other typo'd key.
         assert!(matches!(StormConfig::from_yaml(yaml).unwrap_err(), ConfigError::Yaml(_)));
+    }
+
+    #[test]
+    fn parses_report_section_and_defaults_to_none() {
+        let base = r#"
+target:
+  type: qdrant
+  url: http://localhost:6334
+  collection_name: c
+query:
+  source:
+    uri: /tmp/q.parquet
+    column: embedding
+"#;
+        // absent -> None: summary-only, exactly the pre-report behavior
+        let cfg = StormConfig::from_yaml(base).expect("parses");
+        assert!(cfg.report.is_none());
+
+        let with_report = format!("{base}report:\n  format: csv\n  path: /tmp/ts.csv\n");
+        let cfg = StormConfig::from_yaml(&with_report).expect("parses");
+        let report = cfg.report.expect("present");
+        assert_eq!(report.format, crate::report::ReportFormat::Csv);
+        assert_eq!(report.path, "/tmp/ts.csv");
+
+        // unknown format dies at parse time like any other config typo
+        let bad = format!("{base}report:\n  format: sqlite\n  path: /tmp/ts.db\n");
+        assert!(matches!(StormConfig::from_yaml(&bad).unwrap_err(), ConfigError::Yaml(_)));
     }
 
     #[test]

--- a/crates/nova-storm/src/config.rs
+++ b/crates/nova-storm/src/config.rs
@@ -68,6 +68,14 @@ pub struct QueryConfig {
     pub vector_name: Option<String>,
     #[serde(default = "default_top_k")]
     pub top_k: u64,
+    /// Ask the server to return each hit's full payload. Default `false`
+    /// (ids/scores only). Turn it on when the production traffic being
+    /// modeled fetches payloads — payload retrieval is real server-side work
+    /// (reads payload storage, possibly from disk, for every hit) and real
+    /// response bytes, so benchmarking without it understates latency for
+    /// such workloads.
+    #[serde(default)]
+    pub with_payload: bool,
     pub source: QuerySource,
     /// Server-side search-time tuning (Qdrant's `SearchParams`) — distinct from
     /// `load`'s client-side knobs (concurrency/batch_size/rps). `None` (default)
@@ -287,6 +295,7 @@ load:
 "#;
         let cfg = StormConfig::from_yaml(yaml).expect("should parse");
         assert_eq!(cfg.query.top_k, 10);
+        assert!(!cfg.query.with_payload); // default: ids/scores only
         assert_eq!(cfg.query.source.limit, 1000);
         assert_eq!(cfg.load.concurrency, 8);
         assert_eq!(cfg.load.target_rps, 75.0); // `rps` -> target_rps
@@ -363,6 +372,23 @@ load:
         // `qps` was replaced by `rps` with no back-compat alias -- an old config
         // using it now hits `deny_unknown_fields` like any other typo'd key.
         assert!(matches!(StormConfig::from_yaml(yaml).unwrap_err(), ConfigError::Yaml(_)));
+    }
+
+    #[test]
+    fn parses_with_payload() {
+        let yaml = r#"
+target:
+  type: qdrant
+  url: http://localhost:6334
+  collection_name: c
+query:
+  with_payload: true
+  source:
+    uri: /tmp/q.parquet
+    column: embedding
+"#;
+        let cfg = StormConfig::from_yaml(yaml).expect("parses");
+        assert!(cfg.query.with_payload);
     }
 
     #[test]

--- a/crates/nova-storm/src/lib.rs
+++ b/crates/nova-storm/src/lib.rs
@@ -15,6 +15,7 @@ pub mod config;
 pub mod errors;
 pub mod filter;
 pub mod queries;
+pub mod report;
 pub mod runner;
 pub mod targets;
 
@@ -31,7 +32,22 @@ use runner::Summary;
 /// Run a storm end to end: load the query set, connect the target, drive the
 /// load profile, and return this worker's latency summary.
 pub async fn run(config: StormConfig) -> Result<Summary, StormError> {
-    let StormConfig { target, query, load } = config;
+    let StormConfig { target, query, load, report } = config;
+
+    // Open the time-series sink FIRST: begin() creating the file (or a db
+    // sink its tables) is exactly the step that fails on a bad path, and it
+    // must die here — before query loading and before any load is offered.
+    let recorder = match &report {
+        Some(cfg) => {
+            let mut r = cfg.build();
+            r.begin().map_err(|e| {
+                StormError::Other(format!("report sink `{}` failed to open: {e}", cfg.path))
+            })?;
+            tracing::info!("time-series report: {:?} -> {}", cfg.format, cfg.path);
+            Some(r)
+        }
+        None => None,
+    };
 
     let vectors = load_query_vectors(&query.source, query.filter.as_ref())?;
     if vectors.is_empty() {
@@ -113,7 +129,7 @@ pub async fn run(config: StormConfig) -> Result<Summary, StormError> {
         ProgressBar::hidden()
     };
 
-    let results = runner::run_storm(target, vectors, &load, query.top_k).await;
+    let results = runner::run_storm(target, vectors, &load, query.top_k, recorder).await;
     spinner.finish_and_clear();
 
     Ok(results.summary())

--- a/crates/nova-storm/src/report.rs
+++ b/crates/nova-storm/src/report.rs
@@ -4,8 +4,10 @@
 //! a latency spike at t=90s from the cluster re-optimizing is indistinguishable
 //! from the same samples spread evenly. A [`Recorder`] preserves it: the
 //! collector task (which already sees every [`DispatchSample`] off the hot
-//! path) forwards each sample here as it arrives, so acute load behavior and
-//! cluster-adjustment transients can be plotted afterwards.
+//! path) forwards each sample to a dedicated writer thread ([`spawn_writer`])
+//! that owns the sink, so acute load behavior and cluster-adjustment transients
+//! can be plotted afterwards — and so the sink's blocking writes stay off the
+//! runtime's worker threads.
 //!
 //! Rows are deliberately raw and unopinionated — per-dispatch samples with a
 //! timestamp, no bucketing or smoothing. Any aggregation (rolling percentiles,
@@ -18,10 +20,21 @@
 
 use std::fs::File;
 use std::io::{self, BufWriter, Write};
+use std::sync::mpsc::{SyncSender, sync_channel};
+use std::thread::{self, JoinHandle};
 
 use serde::Deserialize;
 
 use crate::runner::DispatchSample;
+
+/// Bounded depth of the collector → writer-thread queue. Full means the sink
+/// can't keep pace with dispatch (a slow/remote disk, `path: "-"` piped into a
+/// slow consumer, a future db sink). We drop-and-count rather than either grow
+/// unbounded (OOM on a multi-minute high-rps run) or block the collector (which
+/// would push backpressure onto the load loop and bias the very latency numbers
+/// being measured). A local-disk CSV/JSONL sink outpaces dispatch by orders of
+/// magnitude, so this only fills under genuinely slow sinks.
+const WRITER_QUEUE_DEPTH: usize = 8192;
 
 /// The `report:` config section. Absent → no time-series output (just the
 /// end-of-run summary, exactly as before).
@@ -57,20 +70,59 @@ impl ReportConfig {
     }
 }
 
-/// A sink for per-dispatch samples, driven by the collector task.
+/// A sink for per-dispatch samples.
 ///
 /// Lifecycle: `begin()` once before the load starts (create the file / write
 /// the CSV header / create tables — fail HERE, not mid-run, so a bad path
-/// dies before load is offered), `record()` per dispatch in completion order,
-/// `finish()` once after the last sample (flush/close).
+/// dies before load is offered, called on the caller's thread), then `record()`
+/// per dispatch in arrival order and `finish()` once at the end — both on the
+/// dedicated writer thread ([`spawn_writer`]), never on a tokio runtime worker.
 ///
-/// Called from the collector task only — implementations need `Send` but never
-/// synchronization, and buffered blocking writes are fine: the workers are
-/// decoupled by the channel, so a sink can't perturb the load loop.
+/// That thread placement is deliberate: `record()` may block (a file write's
+/// `write()` syscall, a db round-trip). Running it on a runtime worker would
+/// pin that worker for the syscall's duration — and `#[tokio::main]` sizes the
+/// worker pool to the core count, so on a 1-vCPU box that worker is the *only*
+/// one and a blocking write would stall every task, dispatch completions
+/// included. On its own thread the blocking wait parks in the kernel and yields
+/// the CPU back to the runtime, so implementations may block freely; they need
+/// `Send` (moved onto the thread) but never internal synchronization.
 pub trait Recorder: Send {
     fn begin(&mut self) -> io::Result<()>;
     fn record(&mut self, sample: &DispatchSample) -> io::Result<()>;
     fn finish(&mut self) -> io::Result<()>;
+}
+
+/// Move an already-`begin()`-ed recorder onto a dedicated OS thread and return
+/// the bounded sender the collector forwards samples on, plus the join handle.
+///
+/// The thread owns the recorder and does all blocking I/O; the collector only
+/// `try_send`s (see [`WRITER_QUEUE_DEPTH`] for the drop-on-full rationale).
+/// A `record()` error disables recording — the thread flushes what it has via
+/// `finish()` and exits, which disconnects the channel so the collector stops
+/// forwarding — but never touches the load test. The thread ends (and `finish()`
+/// runs) when the collector drops the sender.
+pub fn spawn_writer(
+    mut recorder: Box<dyn Recorder>,
+) -> (SyncSender<DispatchSample>, JoinHandle<()>) {
+    let (tx, rx) = sync_channel::<DispatchSample>(WRITER_QUEUE_DEPTH);
+    let handle = thread::Builder::new()
+        .name("storm-report-writer".into())
+        .spawn(move || {
+            while let Ok(s) = rx.recv() {
+                if let Err(e) = recorder.record(&s) {
+                    // Time-series is auxiliary: losing it mid-run (disk full,
+                    // closed pipe) must not kill the load test. Warn once, stop
+                    // recording, keep the summary intact.
+                    tracing::warn!("report sink failed, disabling time-series output: {e}");
+                    break;
+                }
+            }
+            if let Err(e) = recorder.finish() {
+                tracing::warn!("report sink failed on finish: {e}");
+            }
+        })
+        .expect("spawn storm report-writer thread");
+    (tx, handle)
 }
 
 /// CSV/JSONL file sink (`path: "-"` = stdout).
@@ -90,6 +142,12 @@ impl Recorder for FileRecorder {
         let sink: Box<dyn Write + Send> = if self.path == "-" {
             Box::new(io::stdout())
         } else {
+            // File::create truncates — flag it so an operator doesn't silently
+            // clobber a prior run's series by reusing a path (e.g. across a
+            // sweep's iterations).
+            if std::path::Path::new(&self.path).exists() {
+                tracing::warn!("report path `{}` already exists — overwriting", self.path);
+            }
             Box::new(File::create(&self.path)?)
         };
         let mut out = BufWriter::new(sink);

--- a/crates/nova-storm/src/report.rs
+++ b/crates/nova-storm/src/report.rs
@@ -1,0 +1,203 @@
+//! Transient (time-series) reporting: one row per batch dispatch, as it lands.
+//!
+//! The end-of-run [`Summary`](crate::runner::Summary) collapses the time axis —
+//! a latency spike at t=90s from the cluster re-optimizing is indistinguishable
+//! from the same samples spread evenly. A [`Recorder`] preserves it: the
+//! collector task (which already sees every [`DispatchSample`] off the hot
+//! path) forwards each sample here as it arrives, so acute load behavior and
+//! cluster-adjustment transients can be plotted afterwards.
+//!
+//! Rows are deliberately raw and unopinionated — per-dispatch samples with a
+//! timestamp, no bucketing or smoothing. Any aggregation (rolling percentiles,
+//! 1s buckets) is derivable downstream from raw rows; the reverse is not.
+//!
+//! [`Recorder`] is the abstraction point: `csv` and `jsonl` sinks exist today;
+//! a database sink (sqlite, …) is a new impl, not a redesign — `begin()` is
+//! where it would create its tables, the same way the file sinks create their
+//! file (and the CSV sink its header) there.
+
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
+
+use serde::Deserialize;
+
+use crate::runner::DispatchSample;
+
+/// The `report:` config section. Absent → no time-series output (just the
+/// end-of-run summary, exactly as before).
+///
+/// ```yaml
+/// report:
+///   format: csv            # csv | jsonl
+///   path: storm_ts.csv     # "-" = stdout
+/// ```
+///
+/// Note on `path: "-"`: stdout otherwise carries ONLY the end-of-run summary
+/// (one JSON line under `--json`) for callers like `nova sweep` to parse —
+/// streaming rows into it breaks that contract, so "-" is for interactive
+/// piping, not for `--json` runs.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReportConfig {
+    pub format: ReportFormat,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReportFormat {
+    Csv,
+    Jsonl,
+}
+
+impl ReportConfig {
+    /// Build the configured sink. Cheap: no I/O until [`Recorder::begin`].
+    pub fn build(&self) -> Box<dyn Recorder> {
+        Box::new(FileRecorder { path: self.path.clone(), format: self.format, out: None })
+    }
+}
+
+/// A sink for per-dispatch samples, driven by the collector task.
+///
+/// Lifecycle: `begin()` once before the load starts (create the file / write
+/// the CSV header / create tables — fail HERE, not mid-run, so a bad path
+/// dies before load is offered), `record()` per dispatch in completion order,
+/// `finish()` once after the last sample (flush/close).
+///
+/// Called from the collector task only — implementations need `Send` but never
+/// synchronization, and buffered blocking writes are fine: the workers are
+/// decoupled by the channel, so a sink can't perturb the load loop.
+pub trait Recorder: Send {
+    fn begin(&mut self) -> io::Result<()>;
+    fn record(&mut self, sample: &DispatchSample) -> io::Result<()>;
+    fn finish(&mut self) -> io::Result<()>;
+}
+
+/// CSV/JSONL file sink (`path: "-"` = stdout).
+///
+/// CSV columns: `t_s,latency_ms,ok,recalls` — `recalls` is `;`-joined (one
+/// value per ground-truthed query in the dispatch; usually 0 or 1 values at
+/// batch_size=1), empty when none. JSONL carries the same fields with
+/// `recalls` as a real array.
+struct FileRecorder {
+    path: String,
+    format: ReportFormat,
+    out: Option<BufWriter<Box<dyn Write + Send>>>,
+}
+
+impl Recorder for FileRecorder {
+    fn begin(&mut self) -> io::Result<()> {
+        let sink: Box<dyn Write + Send> = if self.path == "-" {
+            Box::new(io::stdout())
+        } else {
+            Box::new(File::create(&self.path)?)
+        };
+        let mut out = BufWriter::new(sink);
+        if self.format == ReportFormat::Csv {
+            writeln!(out, "t_s,latency_ms,ok,recalls")?;
+        }
+        self.out = Some(out);
+        Ok(())
+    }
+
+    fn record(&mut self, s: &DispatchSample) -> io::Result<()> {
+        let out = self.out.as_mut().ok_or_else(|| {
+            io::Error::other("record() before begin()")
+        })?;
+        match self.format {
+            ReportFormat::Csv => {
+                let recalls = s
+                    .recalls
+                    .iter()
+                    .map(|r| format!("{r:.4}"))
+                    .collect::<Vec<_>>()
+                    .join(";");
+                writeln!(out, "{:.6},{:.3},{},{}", s.t_s, s.latency_ms, s.ok, recalls)
+            }
+            ReportFormat::Jsonl => {
+                // Hand-rolled: fields are two floats, a bool, and a float
+                // array — no serde derive needed on the hot sample type.
+                let recalls = s
+                    .recalls
+                    .iter()
+                    .map(|r| format!("{r:.4}"))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                writeln!(
+                    out,
+                    r#"{{"t_s":{:.6},"latency_ms":{:.3},"ok":{},"recalls":[{}]}}"#,
+                    s.t_s, s.latency_ms, s.ok, recalls
+                )
+            }
+        }
+    }
+
+    fn finish(&mut self) -> io::Result<()> {
+        match self.out.as_mut() {
+            Some(out) => out.flush(),
+            None => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(t_s: f64, latency_ms: f64, ok: bool, recalls: Vec<f64>) -> DispatchSample {
+        DispatchSample { t_s, latency_ms, ok, recalls }
+    }
+
+    fn run_recorder(cfg: &ReportConfig, samples: &[DispatchSample]) -> String {
+        let mut rec = cfg.build();
+        rec.begin().expect("begin creates the file");
+        for s in samples {
+            rec.record(s).expect("record");
+        }
+        rec.finish().expect("finish");
+        std::fs::read_to_string(&cfg.path).expect("file exists after begin()")
+    }
+
+    #[test]
+    fn csv_has_header_and_one_row_per_dispatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ts.csv").to_string_lossy().into_owned();
+        let cfg = ReportConfig { format: ReportFormat::Csv, path };
+
+        let text = run_recorder(
+            &cfg,
+            &[
+                sample(0.001, 12.5, true, vec![0.9, 1.0]),
+                sample(0.052, 8.25, false, vec![]),
+            ],
+        );
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines[0], "t_s,latency_ms,ok,recalls");
+        assert_eq!(lines[1], "0.001000,12.500,true,0.9000;1.0000");
+        assert_eq!(lines[2], "0.052000,8.250,false,");
+        assert_eq!(lines.len(), 3);
+    }
+
+    #[test]
+    fn jsonl_rows_parse_and_roundtrip_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ts.jsonl").to_string_lossy().into_owned();
+        let cfg = ReportConfig { format: ReportFormat::Jsonl, path };
+
+        let text = run_recorder(&cfg, &[sample(1.5, 20.0, true, vec![0.5])]);
+        let row: serde_json::Value = serde_json::from_str(text.trim()).expect("valid json");
+        assert_eq!(row["t_s"], 1.5);
+        assert_eq!(row["latency_ms"], 20.0);
+        assert_eq!(row["ok"], true);
+        assert_eq!(row["recalls"][0], 0.5);
+    }
+
+    #[test]
+    fn begin_fails_fast_on_an_unwritable_path() {
+        let cfg = ReportConfig {
+            format: ReportFormat::Csv,
+            path: "/nonexistent-dir/ts.csv".into(),
+        };
+        assert!(cfg.build().begin().is_err()); // dies BEFORE load is offered
+    }
+}

--- a/crates/nova-storm/src/runner.rs
+++ b/crates/nova-storm/src/runner.rs
@@ -23,6 +23,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc::TrySendError;
 
 use tokio::sync::{Semaphore, mpsc};
 use tokio::task::JoinSet;
@@ -54,6 +55,13 @@ pub struct StormResults {
     /// raw samples so `summary()` can self-describe regardless of what
     /// `LoadProfile` is in scope.
     pub batch_size: usize,
+    /// Time-series samples dropped because the report sink couldn't keep pace
+    /// (the bounded writer queue was full). `0` unless `report:` is configured
+    /// AND its sink lagged; the load test and this summary are unaffected — the
+    /// only casualty is completeness of the time-series file. Not the same as
+    /// `n_err` (failed dispatches): a dropped sample was a *successful* (or
+    /// failed) dispatch whose row simply never reached the sink.
+    pub dropped_samples: u64,
 }
 
 /// Aggregated stats for THIS worker. Fleet-wide stats must merge raw samples
@@ -252,40 +260,56 @@ pub async fn run_storm(
     let vectors = Arc::new(vectors);
     let (tx, mut rx) = mpsc::unbounded_channel::<DispatchSample>();
 
-    // Collector: drain samples into the raw distributions + counts, forwarding
-    // each to the recorder (time-series sink) as it lands. Owning both in one
-    // task keeps the workers lock-free on the hot path — a slow sink can lag
-    // the collector, never the load loop (the channel is unbounded).
+    // Hand the (already-`begin()`-ed) recorder to a dedicated OS thread so its
+    // blocking writes never land on a runtime worker — see `report::spawn_writer`
+    // for why that matters (especially on a 1-vCPU box). The collector forwards
+    // to it over a bounded channel and drops-on-full, so a sink slower than
+    // dispatch can neither grow memory unbounded nor backpressure the load loop.
+    let (writer_tx, writer_handle) = match recorder {
+        Some(r) => {
+            let (wtx, handle) = crate::report::spawn_writer(r);
+            (Some(wtx), Some(handle))
+        }
+        None => (None, None),
+    };
+
+    // Collector: drain samples into the raw distributions + counts, then forward
+    // each to the writer thread. The accumulation here is the authoritative
+    // summary and never loses a sample; only the (auxiliary) time-series file
+    // does, and only when its sink can't keep up. Owning the accumulation in one
+    // task keeps the workers lock-free on the hot path.
     let collector = tokio::spawn(async move {
-        let mut recorder = recorder;
+        let mut writer_tx = writer_tx;
         let mut latencies = Vec::new();
         let mut recalls = Vec::new();
         let mut n_ok = 0u64;
         let mut n_err = 0u64;
+        let mut dropped = 0u64;
         while let Some(s) = rx.recv().await {
-            if let Some(r) = recorder.as_mut()
-                && let Err(e) = r.record(&s)
-            {
-                // Time-series is auxiliary: losing it mid-run (disk full,
-                // closed pipe) must not kill the load test. Warn once,
-                // stop recording, keep the summary intact.
-                tracing::warn!("report sink failed, disabling time-series output: {e}");
-                recorder = None;
-            }
+            // Accumulate first — copying the fields the summary needs — so `s`
+            // is still owned to hand to the writer without a clone.
             latencies.push(s.latency_ms);
-            recalls.extend(s.recalls);
+            recalls.extend(s.recalls.iter().copied());
             if s.ok {
                 n_ok += 1;
             } else {
                 n_err += 1;
             }
+            if let Some(wtx) = writer_tx.as_ref() {
+                match wtx.try_send(s) {
+                    Ok(()) => {}
+                    // Sink is behind: count the drop and keep going rather than
+                    // block (blocking would perturb the measurement).
+                    Err(TrySendError::Full(_)) => dropped += 1,
+                    // Writer stopped (a record() error disabled it, or it already
+                    // finished): stop forwarding for the rest of the run.
+                    Err(TrySendError::Disconnected(_)) => writer_tx = None,
+                }
+            }
         }
-        if let Some(mut r) = recorder
-            && let Err(e) = r.finish()
-        {
-            tracing::warn!("report sink failed on finish: {e}");
-        }
-        (latencies, recalls, n_ok, n_err)
+        // Drop the sender so the writer thread's `recv` ends and it runs finish().
+        drop(writer_tx);
+        (latencies, recalls, n_ok, n_err, dropped)
     });
 
     let started = Instant::now();
@@ -302,10 +326,25 @@ pub async fn run_storm(
     drop(tx);
     let wall_s = started.elapsed().as_secs_f64();
 
-    let (latencies_ms, recalls, n_ok, n_err) = collector.await.unwrap_or_default();
+    let (latencies_ms, recalls, n_ok, n_err, dropped_samples) =
+        collector.await.unwrap_or_default();
+    // Join the writer thread so its `finish()` (final flush) completes before we
+    // return — otherwise a caller reading the file back could race the flush.
+    // Cheap: the load is done and the channel is closed, so the thread is already
+    // exiting.
+    if let Some(handle) = writer_handle {
+        let _ = handle.join();
+    }
+    if dropped_samples > 0 {
+        tracing::warn!(
+            "time-series report incomplete: dropped {dropped_samples} sample(s) — the sink \
+             couldn't keep pace with dispatch (bounded writer queue full); the summary is \
+             unaffected"
+        );
+    }
     let _ = target.close().await;
 
-    StormResults { latencies_ms, recalls, n_ok, n_err, wall_s, batch_size }
+    StormResults { latencies_ms, recalls, n_ok, n_err, wall_s, batch_size, dropped_samples }
 }
 
 /// Hold `concurrency` requests in flight until the window closes; each task
@@ -689,6 +728,7 @@ mod tests {
             n_err: 0,
             wall_s: 1.0,
             batch_size: 1,
+            dropped_samples: 0,
         };
         let summary = results.summary();
 
@@ -702,7 +742,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn recorder_receives_one_timestamped_row_per_dispatch() {
-        use crate::report::{Recorder, ReportConfig, ReportFormat};
+        use crate::report::{ReportConfig, ReportFormat};
 
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("ts.csv").to_string_lossy().into_owned();
@@ -718,14 +758,46 @@ mod tests {
         let text = std::fs::read_to_string(&path).expect("csv written");
         let lines: Vec<&str> = text.lines().collect();
         assert_eq!(lines[0], "t_s,latency_ms,ok,recalls");
-        // exactly one row per dispatch — the time series IS the raw run
-        assert_eq!(lines.len() as u64, 1 + summary.requests);
+        // one row per dispatch that reached the sink — the time series IS the
+        // raw run, minus any samples dropped when the writer queue was full
+        // (with an instant mock target the load loop can briefly outrun the
+        // writer; the summary still counts every dispatch).
+        assert_eq!(lines.len() as u64, 1 + summary.requests - results.dropped_samples);
         // timestamps are on the run's time axis: non-negative, within the
         // window (plus scheduling slack), and present on every row
         for line in &lines[1..] {
             let t: f64 = line.split(',').next().unwrap().parse().expect("t_s parses");
-            assert!(t >= 0.0 && t < 5.0, "t_s out of range: {t}");
+            assert!((0.0..5.0).contains(&t), "t_s out of range: {t}");
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_failing_sink_disables_recording_without_killing_the_run() {
+        // The central robustness guarantee: a report sink that errors on write
+        // must NOT take down the load test — the summary stays whole, the run
+        // completes normally, only the (auxiliary) time series is lost.
+        struct FailingRecorder;
+        impl crate::report::Recorder for FailingRecorder {
+            fn begin(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+            fn record(&mut self, _s: &DispatchSample) -> std::io::Result<()> {
+                Err(std::io::Error::other("sink is down"))
+            }
+            fn finish(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let profile = LoadProfile { concurrency: 4, duration_s: 0.2, target_rps: 0.0, batch_size: 1 };
+        let target = Arc::new(MockTarget::ok(vec![]));
+        let results =
+            run_storm(target, vectors(), &profile, 10, Some(Box::new(FailingRecorder))).await;
+        let summary = results.summary();
+
+        // Load ran to completion despite the sink failing on the very first row.
+        assert!(summary.requests > 0, "the load test must complete even with a dead sink");
+        assert_eq!(summary.errors, 0, "dispatch errors are unrelated to sink failure");
     }
 
     #[test]

--- a/crates/nova-storm/src/runner.rs
+++ b/crates/nova-storm/src/runner.rs
@@ -169,12 +169,19 @@ fn recall_at_k(returned: &[String], ground_truth: &HashSet<String>, k: u64) -> f
     hits as f64 / k as f64
 }
 
-/// One batch dispatch's observation forwarded from a worker to the collector.
-/// `latency_ms`/`ok` describe the one round-trip; `recalls` holds 0..N values,
-/// one per query in the batch that had both ground truth and returned ids.
-struct DispatchSample {
-    latency_ms: f64,
-    ok: bool,
+/// One batch dispatch's observation forwarded from a worker to the collector
+/// (and, verbatim, to a configured [`Recorder`](crate::report::Recorder) —
+/// this IS the time-series row). `latency_ms`/`ok` describe the one
+/// round-trip; `recalls` holds 0..N values, one per query in the batch that
+/// had both ground truth and returned ids.
+#[derive(Debug, Clone)]
+pub struct DispatchSample {
+    /// Seconds since the run started, stamped at dispatch COMPLETION (the
+    /// same moment the latency sample exists) in the worker — not at collector
+    /// receive time, which could lag behind under load.
+    pub t_s: f64,
+    pub latency_ms: f64,
+    pub ok: bool,
     /// A query contributes no entry here (not a `0.0` entry) when it had no
     /// ground truth to compare against, OR the whole dispatch failed (`!ok`)
     /// — a failed request has no "returned ids" to score, so it must not
@@ -182,7 +189,7 @@ struct DispatchSample {
     /// under load-induced errors even when every *successful* query has
     /// perfect recall — a different, already-visible finding via
     /// `errors`/`requests_per_sec`, not one recall should also report.
-    recalls: Vec<f64>,
+    pub recalls: Vec<f64>,
 }
 
 /// Build a [`DispatchSample`] from a completed batch dispatch, applying the
@@ -191,11 +198,13 @@ struct DispatchSample {
 /// `out.ids[i]` being `None` already covers both "no ground truth was
 /// tracked" and "the dispatch failed" — see `BatchOutcome::ids` — so `zip`
 /// alone is the whole rule; no separate `out.ok` check is needed here.
+/// `started` anchors the sample's `t_s` on the run's time axis.
 fn dispatch_sample(
     out: &crate::targets::BatchOutcome,
     idxs: &[usize],
     vectors: &[QueryVector],
     top_k: u64,
+    started: Instant,
 ) -> DispatchSample {
     let recalls = idxs
         .iter()
@@ -204,7 +213,12 @@ fn dispatch_sample(
             ids.as_ref().zip(vectors[i].ground_truth.as_ref()).map(|(ids, gt)| recall_at_k(ids, gt, top_k))
         })
         .collect();
-    DispatchSample { latency_ms: out.latency.as_secs_f64() * 1000.0, ok: out.ok, recalls }
+    DispatchSample {
+        t_s: started.elapsed().as_secs_f64(),
+        latency_ms: out.latency.as_secs_f64() * 1000.0,
+        ok: out.ok,
+        recalls,
+    }
 }
 
 /// The batch-of-`batch_size` indices into a round-robin `vectors` set of
@@ -233,18 +247,31 @@ pub async fn run_storm(
     vectors: Vec<QueryVector>,
     profile: &LoadProfile,
     top_k: u64,
+    recorder: Option<Box<dyn crate::report::Recorder>>,
 ) -> StormResults {
     let vectors = Arc::new(vectors);
     let (tx, mut rx) = mpsc::unbounded_channel::<DispatchSample>();
 
-    // Collector: drain samples into the raw distributions + counts. Owning the
-    // accumulation in one task keeps the workers lock-free on the hot path.
+    // Collector: drain samples into the raw distributions + counts, forwarding
+    // each to the recorder (time-series sink) as it lands. Owning both in one
+    // task keeps the workers lock-free on the hot path — a slow sink can lag
+    // the collector, never the load loop (the channel is unbounded).
     let collector = tokio::spawn(async move {
+        let mut recorder = recorder;
         let mut latencies = Vec::new();
         let mut recalls = Vec::new();
         let mut n_ok = 0u64;
         let mut n_err = 0u64;
         while let Some(s) = rx.recv().await {
+            if let Some(r) = recorder.as_mut()
+                && let Err(e) = r.record(&s)
+            {
+                // Time-series is auxiliary: losing it mid-run (disk full,
+                // closed pipe) must not kill the load test. Warn once,
+                // stop recording, keep the summary intact.
+                tracing::warn!("report sink failed, disabling time-series output: {e}");
+                recorder = None;
+            }
             latencies.push(s.latency_ms);
             recalls.extend(s.recalls);
             if s.ok {
@@ -252,6 +279,11 @@ pub async fn run_storm(
             } else {
                 n_err += 1;
             }
+        }
+        if let Some(mut r) = recorder
+            && let Err(e) = r.finish()
+        {
+            tracing::warn!("report sink failed on finish: {e}");
         }
         (latencies, recalls, n_ok, n_err)
     });
@@ -261,9 +293,9 @@ pub async fn run_storm(
     let batch_size = profile.batch_size.max(1);
 
     if profile.target_rps > 0.0 {
-        run_paced(&target, &vectors, profile, stop_at, top_k, &tx).await;
+        run_paced(&target, &vectors, profile, started, stop_at, top_k, &tx).await;
     } else {
-        run_closed_loop(&target, &vectors, profile, stop_at, top_k, &tx).await;
+        run_closed_loop(&target, &vectors, profile, started, stop_at, top_k, &tx).await;
     }
 
     // Drop the last sender so the collector's `recv` loop ends.
@@ -282,6 +314,7 @@ async fn run_closed_loop(
     target: &Arc<dyn QueryTarget>,
     vectors: &Arc<Vec<QueryVector>>,
     profile: &LoadProfile,
+    started: Instant,
     stop_at: Instant,
     top_k: u64,
     tx: &mpsc::UnboundedSender<DispatchSample>,
@@ -303,7 +336,7 @@ async fn run_closed_loop(
                 let idxs = batch_indices(start, batch_size, n);
                 let queries: Vec<&QueryVector> = idxs.iter().map(|&i| &vectors[i]).collect();
                 let out = target.query_batch(&queries).await;
-                let _ = tx.send(dispatch_sample(&out, &idxs, &vectors, top_k));
+                let _ = tx.send(dispatch_sample(&out, &idxs, &vectors, top_k, started));
             }
         });
     }
@@ -320,6 +353,7 @@ async fn run_paced(
     target: &Arc<dyn QueryTarget>,
     vectors: &Arc<Vec<QueryVector>>,
     profile: &LoadProfile,
+    started: Instant,
     stop_at: Instant,
     top_k: u64,
     tx: &mpsc::UnboundedSender<DispatchSample>,
@@ -350,7 +384,7 @@ async fn run_paced(
         inflight.spawn(async move {
             let queries: Vec<&QueryVector> = idxs.iter().map(|&i| &vectors[i]).collect();
             let out = target.query_batch(&queries).await;
-            let _ = tx.send(dispatch_sample(&out, &idxs, &vectors, top_k));
+            let _ = tx.send(dispatch_sample(&out, &idxs, &vectors, top_k, started));
             drop(permit); // release the in-flight slot
         });
 
@@ -423,7 +457,7 @@ mod tests {
     async fn closed_loop_fires_many_and_records_each() {
         let profile = LoadProfile { concurrency: 4, duration_s: 0.2, target_rps: 0.0, batch_size: 1 };
         let target = Arc::new(MockTarget::ok(vec![]));
-        let results = run_storm(target, vectors(), &profile, 10).await;
+        let results = run_storm(target, vectors(), &profile, 10, None).await;
         let summary = results.summary();
 
         assert!(summary.requests > 0);
@@ -444,7 +478,7 @@ mod tests {
         let duration_s = 0.5;
         let profile = LoadProfile { concurrency: 16, duration_s, target_rps, batch_size: 1 };
         let target = Arc::new(MockTarget::ok(vec![]));
-        let results = run_storm(target, vectors(), &profile, 10).await;
+        let results = run_storm(target, vectors(), &profile, 10, None).await;
         let summary = results.summary();
 
         // The whole point: pacing holds the offered rate at/under target. Allow a
@@ -478,7 +512,7 @@ mod tests {
             .collect();
 
         let profile = LoadProfile { concurrency: 2, duration_s: 0.15, target_rps: 0.0, batch_size: 1 };
-        let results = run_storm(target, vectors, &profile, 4).await;
+        let results = run_storm(target, vectors, &profile, 4, None).await;
         let summary = results.summary();
 
         // every recorded recall sample must be exactly 0.25 -- never 0, never
@@ -507,7 +541,7 @@ mod tests {
             .collect();
 
         let profile = LoadProfile { concurrency: 2, duration_s: 0.15, target_rps: 0.0, batch_size: 1 };
-        let results = run_storm(target, vectors, &profile, 1).await;
+        let results = run_storm(target, vectors, &profile, 1, None).await;
         let summary = results.summary();
 
         assert_eq!(summary.errors, summary.requests); // every query failed
@@ -630,7 +664,7 @@ mod tests {
         ];
         // duration long enough to cycle through all 3 at concurrency=1 several times
         let profile = LoadProfile { concurrency: 1, duration_s: 0.1, target_rps: 0.0, batch_size: 1 };
-        let results = run_storm(Arc::new(PerQueryTarget), vectors, &profile, 2).await;
+        let results = run_storm(Arc::new(PerQueryTarget), vectors, &profile, 2, None).await;
 
         // Only asserts the pipeline actually produced all 3 distinct values --
         // NOT their exact proportions, which depend on how many times each of
@@ -664,6 +698,34 @@ mod tests {
         // mean and median coincide here (symmetric distribution) -- min is the
         // one that actually differs from both, proving it's not just an alias.
         assert_ne!(summary.min_recall, summary.mean_recall);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn recorder_receives_one_timestamped_row_per_dispatch() {
+        use crate::report::{Recorder, ReportConfig, ReportFormat};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ts.csv").to_string_lossy().into_owned();
+        let cfg = ReportConfig { format: ReportFormat::Csv, path: path.clone() };
+        let mut recorder = cfg.build();
+        recorder.begin().expect("begin");
+
+        let profile = LoadProfile { concurrency: 4, duration_s: 0.2, target_rps: 0.0, batch_size: 1 };
+        let target = Arc::new(MockTarget::ok(vec![]));
+        let results = run_storm(target, vectors(), &profile, 10, Some(recorder)).await;
+        let summary = results.summary();
+
+        let text = std::fs::read_to_string(&path).expect("csv written");
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines[0], "t_s,latency_ms,ok,recalls");
+        // exactly one row per dispatch — the time series IS the raw run
+        assert_eq!(lines.len() as u64, 1 + summary.requests);
+        // timestamps are on the run's time axis: non-negative, within the
+        // window (plus scheduling slack), and present on every row
+        for line in &lines[1..] {
+            let t: f64 = line.split(',').next().unwrap().parse().expect("t_s parses");
+            assert!(t >= 0.0 && t < 5.0, "t_s out of range: {t}");
+        }
     }
 
     #[test]
@@ -719,7 +781,7 @@ mod tests {
         let batch_size = 3;
         let profile = LoadProfile { concurrency: 1, duration_s: 0.15, target_rps: 0.0, batch_size };
         let target = Arc::new(BatchCapturingTarget { call_lens: std::sync::Mutex::new(Vec::new()) });
-        let results = run_storm(target.clone(), vectors, &profile, 2).await;
+        let results = run_storm(target.clone(), vectors, &profile, 2, None).await;
 
         let call_lens = target.call_lens.lock().unwrap();
         assert!(!call_lens.is_empty());

--- a/crates/nova-storm/src/targets/qdrant.rs
+++ b/crates/nova-storm/src/targets/qdrant.rs
@@ -38,6 +38,11 @@ pub struct QdrantTarget {
     /// a wasted allocation (a `String` clone per returned point) on every
     /// query.
     collect_ids: bool,
+    /// Ask the server for each hit's full payload (`query.with_payload`).
+    /// The payloads are dropped on arrival — storm measures, it doesn't
+    /// consume — but requesting them makes the server do the payload reads
+    /// and ship the bytes, which is the cost being modeled.
+    with_payload: bool,
     /// Translated once at construction and applied unchanged to every
     /// query — set only when `query.filter` has no `_from_query` condition
     /// (a uniform filter has nothing to resolve per query). `None` when
@@ -125,6 +130,7 @@ impl QdrantConfig {
             top_k: query.top_k,
             search_params: query.search_params.as_ref().map(SearchParams::from),
             collect_ids: query.source.ground_truth_column.is_some(),
+            with_payload: query.with_payload,
             static_filter,
             per_query_filter,
         })
@@ -377,7 +383,7 @@ impl QueryTarget for QdrantTarget {
                 let mut builder = QueryPointsBuilder::new(&self.collection_name)
                     .query(q.vector.to_vec())
                     .limit(self.top_k)
-                    .with_payload(false);
+                    .with_payload(self.with_payload);
                 if let Some(name) = &self.vector_name {
                     builder = builder.using(name.clone());
                 }

--- a/python/nova-embed/src/nova_embed/cli/run_embedder.py
+++ b/python/nova-embed/src/nova_embed/cli/run_embedder.py
@@ -136,6 +136,20 @@ def embed(config, num_jobs, job_rank, dry_run):
         _print_dry_run(cfg, config_path, source_dict, num_jobs)
         return
 
+    # Carry source provenance (source_file_name + source_row_number) into the
+    # output when enabled. Injected only when on, so sources that don't support
+    # it aren't forced to accept the kwarg. Set BEFORE any source is built so
+    # the row-counting instance is fully configured and reusable as the
+    # pipeline source.
+    if pipeline.include_source_provenance:
+        source_dict["include_provenance"] = True
+
+    # The fields being embedded must survive the source's read projection even
+    # if the user's exclude_columns would drop them.
+    source_dict.setdefault("required_columns", sorted(cfg.input_specs))
+
+    source = None
+    expected_total_rows = None
     filename_prefix = ""
     if num_jobs is not None:
         if job_rank is None:
@@ -161,23 +175,24 @@ def embed(config, num_jobs, job_rank, dry_run):
             slice_limit,
             dataset_total,
         )
-        source_dict["offset"] = slice_offset
-        source_dict["limit"] = slice_limit
+        expected_total_rows = slice_limit
+
+        # Re-scope the counting instance instead of building a second source:
+        # for HF sources a fresh instance re-reads every parquet footer, and at
+        # N ranks that doubles an already-huge burst of rate-limited requests.
+        set_window = getattr(source_for_count, "set_window", None)
+        if callable(set_window):
+            set_window(slice_offset, slice_limit)
+            source = source_for_count
+        else:
+            source_dict["offset"] = slice_offset
+            source_dict["limit"] = slice_limit
 
         rank_width = max(2, len(str(num_jobs - 1)))
         filename_prefix = f"rank{job_rank:0{rank_width}d}_"
 
-    # Carry source provenance (source_file_name + source_row_number) into the
-    # output when enabled. Injected only when on, so sources that don't support
-    # it aren't forced to accept the kwarg.
-    if pipeline.include_source_provenance:
-        source_dict["include_provenance"] = True
-
-    # The fields being embedded must survive the source's read projection even
-    # if the user's exclude_columns would drop them.
-    source_dict.setdefault("required_columns", sorted(cfg.input_specs))
-
-    source = SOURCES.build(dict(source_dict))
+    if source is None:
+        source = SOURCES.build(dict(source_dict))
 
     engine = build_engine(cfg.embedders)
 
@@ -193,9 +208,6 @@ def embed(config, num_jobs, job_rank, dry_run):
 
     storage_dict = cfg.storage.build_dict()
     storage = STORAGE.build(dict(storage_dict))
-
-    # prefer the per-job limit (set by --num-jobs slicing); else there's no cap
-    expected_total_rows = source_dict.get("limit")
 
     asyncio.run(
         run_embedder(

--- a/python/nova-embed/src/nova_embed/sources/huggingface.py
+++ b/python/nova-embed/src/nova_embed/sources/huggingface.py
@@ -92,8 +92,13 @@ class HuggingFaceSource(DatasetSource):
                 the configured input columns here so the field being embedded
                 always survives.
             offset / limit: applied as a row-window across all selected files.
-            total_rows_override: skip the metadata sweep at construction time by
-                trusting this number; metadata is still read per-file as we go.
+            total_rows_override: trust this number instead of summing every
+                file's footer. THE knob for fleet runs: with it set, a rank
+                never does the full-dataset footer sweep — it reads footers in
+                path order only until its own (offset, limit) window is covered
+                (see _ensure_counts), cutting HF requests per rank from
+                O(all files) to O(files before the window's end). The total is
+                printed in every run's "Indexed ... total rows" log line.
             path_filter: substring filter on parquet file paths (e.g. "train/").
                 Defaults to filtering by the split name when present in paths.
             metadata_workers: parallelism for the per-file footer fetches. Keep
@@ -155,78 +160,124 @@ class HuggingFaceSource(DatasetSource):
                 f"path_filter={path_filter!r}"
             )
         self._parquet_paths = parquet_paths
-        # lazy: list of (path, num_rows) -- populated on first use
-        self._files_with_counts: list[tuple[str, int]] | None = None
+        # incremental footer index: (path, num_rows) in path order, extended on
+        # demand — see _ensure_counts. _next_path_idx is the first unread path.
+        self._files_with_counts: list[tuple[str, int]] = []
+        self._next_path_idx = 0
+        self._counts_complete = False
 
     @property
     def source_name(self) -> str:
         return self.dataset_name
 
-    def _ensure_counts(self) -> None:
-        if self._files_with_counts is not None:
-            return
+    def set_window(self, offset: int, limit: int | None) -> None:
+        """Re-scope this source to a row window, keeping the footer index.
 
+        Lets the CLI reuse the instance it built for `--num-jobs` row counting
+        as the pipeline source, instead of building a second instance that
+        re-reads every footer — at fleet scale the footer sweep is the dominant
+        HF request cost, so it must happen at most once per process.
+        """
+        self._offset = offset or 0
+        self._limit = limit
+        self._local_paths = {}  # prefetch staging is window-scoped
+
+    def _fetch_count(self, path: str) -> tuple[str, int | None]:
         import pyarrow.parquet as pq
 
-        def fetch(path: str) -> tuple[str, int | None]:
-            url = f"datasets/{self.dataset_name}/{path}"
-            last_err: Exception | None = None
-            for attempt in range(6):
-                try:
-                    pf = pq.ParquetFile(url, filesystem=self._fs)
-                    return path, pf.metadata.num_rows
-                except Exception as e:
-                    last_err = e
-                    is_rate_limit = "429" in str(e) or "Too Many Requests" in str(e)
-                    if is_rate_limit:
-                        # HF rate-limit windows are minutes-long, so back off harder.
-                        wait = min(5 * 2**attempt, 120)
-                        reason = "rate limited"
-                    else:
-                        # Generic flake (5xx, connection reset, DNS hiccup, etc.).
-                        # These are usually one-shot — a couple of seconds is enough.
-                        wait = min(2 * 2**attempt, 30)
-                        reason = f"transient error ({type(e).__name__})"
-                    logger.warning(
-                        "%s reading footer for %s (attempt %d/6), retrying in %ds: %s",
-                        reason,
-                        path,
-                        attempt + 1,
-                        wait,
-                        e,
-                    )
-                    time.sleep(wait)
-            logger.warning(
-                "Giving up on footer read for %s after 6 retries: %s", path, last_err
-            )
-            return path, None
+        url = f"datasets/{self.dataset_name}/{path}"
+        last_err: Exception | None = None
+        for attempt in range(6):
+            try:
+                pf = pq.ParquetFile(url, filesystem=self._fs)
+                return path, pf.metadata.num_rows
+            except Exception as e:
+                last_err = e
+                is_rate_limit = "429" in str(e) or "Too Many Requests" in str(e)
+                if is_rate_limit:
+                    # HF rate-limit windows are minutes-long, so back off harder.
+                    wait = min(5 * 2**attempt, 120)
+                    reason = "rate limited"
+                else:
+                    # Generic flake (5xx, connection reset, DNS hiccup, etc.).
+                    # These are usually one-shot — a couple of seconds is enough.
+                    wait = min(2 * 2**attempt, 30)
+                    reason = f"transient error ({type(e).__name__})"
+                logger.warning(
+                    "%s reading footer for %s (attempt %d/6), retrying in %ds: %s",
+                    reason,
+                    path,
+                    attempt + 1,
+                    wait,
+                    e,
+                )
+                time.sleep(wait)
+        logger.warning(
+            "Giving up on footer read for %s after 6 retries: %s", path, last_err
+        )
+        return path, None
 
+    def _ensure_counts(self, through: int | None = None) -> None:
+        """Extend the footer index far enough to cover global row `through`.
+
+        ``through=None`` indexes every file. Otherwise footers are read in path
+        order, in small parallel batches, and reading STOPS once the cumulative
+        row count reaches ``through`` — a rank whose window ends early never
+        pays for footers past it. Each footer is ~2-3 HTTP requests against
+        HF's rate-limited resolve endpoint, and N ranks × all files is how a
+        fleet burns through a request quota in minutes, so never read more
+        than the caller needs. Results accumulate: a later, broader call
+        continues where this one stopped.
+        """
+        if self._counts_complete:
+            return
+        cumulative = sum(n for _, n in self._files_with_counts)
+        if through is not None and cumulative >= through:
+            return
+
+        remaining = len(self._parquet_paths) - self._next_path_idx
         logger.info(
-            "Reading parquet footers for %d files (parallel=%d)...",
+            "Reading parquet footers (%d of %d files unread, parallel=%d%s)...",
+            remaining,
             len(self._parquet_paths),
             self._metadata_workers,
+            "" if through is None else f", stopping at row {through:,}",
         )
+        batch_size = self._metadata_workers * 8
         with ThreadPoolExecutor(max_workers=self._metadata_workers) as ex:
-            results = list(ex.map(fetch, self._parquet_paths))
+            while self._next_path_idx < len(self._parquet_paths):
+                batch = self._parquet_paths[
+                    self._next_path_idx : self._next_path_idx + batch_size
+                ]
+                results = list(ex.map(self._fetch_count, batch))
+                failed = [p for p, n in results if n is None]
+                if failed:
+                    # Silently dropping files would corrupt the offset table --
+                    # offsets are derived from the cumulative sum of file row
+                    # counts. Better to fail loud so the user knows their slice
+                    # is incomplete.
+                    raise RuntimeError(
+                        f"Footer read failed for {len(failed)}/{len(results)} parquet "
+                        f"files in {self.dataset_name}. First failures: {failed[:5]}. "
+                        "Retry, or pass a tighter path_filter to skip them explicitly."
+                    )
+                self._next_path_idx += len(batch)
+                for p, n in results:
+                    # zero-row files are real and ok (just empty), but we drop
+                    # them from the offset table to keep the math clean.
+                    if n > 0:
+                        self._files_with_counts.append((p, n))
+                        cumulative += n
+                if through is not None and cumulative >= through:
+                    break
 
-        failed = [p for p, n in results if n is None]
-        if failed:
-            # Silently dropping files would corrupt the offset table -- offsets are
-            # derived from cumulative sum of file row counts. Better to fail loud
-            # so the user knows their slice is incomplete.
-            raise RuntimeError(
-                f"Footer read failed for {len(failed)}/{len(results)} parquet files in "
-                f"{self.dataset_name}. First failures: {failed[:5]}. "
-                "Retry, or pass a tighter path_filter to skip them explicitly."
-            )
-
-        # zero-row files are real and ok (just empty), but we drop them from the
-        # offset table to keep the math clean.
-        self._files_with_counts = [(p, n) for p, n in results if n > 0]
+        if self._next_path_idx >= len(self._parquet_paths):
+            self._counts_complete = True
         logger.info(
-            "Indexed %d parquet files, %d total rows",
+            "Indexed %d parquet files, %d rows%s",
             len(self._files_with_counts),
-            sum(n for _, n in self._files_with_counts),
+            cumulative,
+            "" if self._counts_complete else " (partial index, window-bounded)",
         )
 
     def list_files(self) -> list[tuple[str, int]]:
@@ -239,6 +290,11 @@ class HuggingFaceSource(DatasetSource):
             return self._total_rows_override
         self._ensure_counts()
         return sum(n for _, n in self._files_with_counts)
+
+    @property
+    def _window_end(self) -> int | None:
+        """Global row index just past this rank's window (None = unbounded)."""
+        return None if self._limit is None else self._offset + self._limit
 
     def _prefetch_files(self) -> None:
         """Download only the parquet files overlapping this rank's window to local disk.
@@ -254,7 +310,7 @@ class HuggingFaceSource(DatasetSource):
         from pathlib import Path
         from huggingface_hub import hf_hub_download
 
-        self._ensure_counts()
+        self._ensure_counts(self._window_end)
         to_download = [
             path
             for path, _ in files_in_window(
@@ -296,7 +352,7 @@ class HuggingFaceSource(DatasetSource):
         Same membership as ``files_in_window`` (the sharding contract), plus each
         file's global start offset so the reader can compute its intra-file slice.
         """
-        self._ensure_counts()
+        self._ensure_counts(self._window_end)
         out: list[tuple[str, int, int]] = []
         cumulative = 0
         for path, num_rows in self._files_with_counts:

--- a/python/nova-embed/tests/test_hf_source.py
+++ b/python/nova-embed/tests/test_hf_source.py
@@ -1,0 +1,92 @@
+"""HuggingFaceSource footer-index behavior: the sweep is the dominant HF
+request cost at fleet scale, so these tests lock in HOW MANY footers get read,
+not just what the index contains. No network: _fetch_count is stubbed.
+"""
+
+from __future__ import annotations
+
+from nova_embed.sources.huggingface import HuggingFaceSource
+
+
+def make_source(counts: list[int], offset: int = 0, limit: int | None = None):
+    """Bare instance (no HF API calls) over files of the given row counts.
+
+    Returns (source, fetched) where `fetched` records every footer read.
+    """
+    src = HuggingFaceSource.__new__(HuggingFaceSource)
+    paths = [f"data/{i:04d}.parquet" for i in range(len(counts))]
+    by_path = dict(zip(paths, counts))
+    src.dataset_name = "org/data"
+    src._parquet_paths = paths
+    src._files_with_counts = []
+    src._next_path_idx = 0
+    src._counts_complete = False
+    src._metadata_workers = 2
+    src._total_rows_override = None
+    src._offset = offset
+    src._limit = limit
+    src._local_paths = {}
+
+    fetched: list[str] = []
+
+    def fetch(path):
+        fetched.append(path)
+        return path, by_path[path]
+
+    src._fetch_count = fetch
+    return src, fetched
+
+
+def test_total_rows_reads_every_footer():
+    src, fetched = make_source([10] * 30)
+    assert src.get_total_rows() == 300
+    assert len(fetched) == 30
+
+
+def test_window_stops_footer_sweep_early():
+    # rank window [0, 100) over 100 files x 10 rows: only the first batch of
+    # footers is needed, not all 100
+    src, fetched = make_source([10] * 100, offset=0, limit=100)
+    window = src._window_files()
+    assert [p for p, _, _ in window] == [f"data/{i:04d}.parquet" for i in range(10)]
+    assert len(fetched) < 100  # early stop: never indexed past the window
+    # batched sweep may read slightly past the window boundary, never before it
+    assert len(fetched) >= 10
+
+
+def test_total_rows_override_skips_sweep_entirely():
+    src, fetched = make_source([10] * 50)
+    src._total_rows_override = 500
+    assert src.get_total_rows() == 500
+    assert fetched == []
+
+
+def test_index_extends_without_rereading():
+    src, fetched = make_source([10] * 100, offset=0, limit=100)
+    src._window_files()
+    first_pass = len(fetched)
+    src.get_total_rows()  # broader ask: completes the index
+    assert len(fetched) == 100  # continued where it stopped
+    assert len(set(fetched)) == len(fetched)  # no footer read twice
+    assert first_pass < 100
+
+
+def test_set_window_rescopes_and_reuses_index():
+    src, fetched = make_source([10] * 40)
+    assert src.get_total_rows() == 400  # full sweep (the counting pass)
+    src.set_window(200, 100)
+    window = src._window_files()
+    assert [p for p, _, _ in window] == [
+        f"data/{i:04d}.parquet" for i in range(20, 30)
+    ]
+    assert len(fetched) == 40  # window change reused the index: zero new reads
+
+
+def test_window_files_carry_correct_offsets():
+    src, _ = make_source([5, 10, 20], offset=7, limit=10)
+    window = src._window_files()
+    # rows 7..17 live in file 1 (rows 5..15) and file 2 (rows 15..35)
+    assert window == [
+        ("data/0001.parquet", 10, 5),
+        ("data/0002.parquet", 20, 15),
+    ]


### PR DESCRIPTION
## overview
Currently, `nova-storm` only reports steady-state or **aggregate** performance metrics. That is, one holistic measurement averaged across an entire run. These runs may last several minutes. Its often helpful to have _transient_ stats about a run. Specifically, how throughput changes as the run continues on. This is particularly useful for experiments that attempt to measure transient performance like read/write contention, changing workloads, etc.

This PR adds functionality to dump transient throughput and recall data as a `csv` or `jsonl` file as the code is running. Here is an AI summary of code changes for details:

## nova-storm: time-series reporting

`nova storm` now (optionally) logs **one raw row per batch dispatch** as it lands, so transient behavior — acute load, the cluster re-optimizing mid-run — can be plotted instead of being collapsed into the end-of-run summary.

```yaml
# new optional top-level section; omit = summary-only (unchanged)
report:
  format: csv          # csv | jsonl
  path: storm_ts.csv   # "-" = stdout (breaks --json parsing, e.g. nova sweep)
```

Rows: `t_s,latency_ms,ok,recalls` — `t_s` is seconds since run start, stamped at dispatch completion in the worker. Deliberately unaggregated; bucket downstream in pandas/duckdb.

**How:** a `Recorder` trait (`report.rs`) — `begin()` / `record()` / `finish()` — driven by the collector task that already sees every sample off the hot path, so the load loop is untouched. `begin()` creates the file (and would `CREATE TABLE` for a future sqlite sink); it runs before query loading, so a bad path fails fast. A sink failure mid-run warns and disables recording — never kills the load test. CSV/JSONL impls today; new backends = new trait impl.
