### PR TITLE
nova-load: make Milvus + Elasticsearch backends functional; unify ind…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2023,6 +2023,7 @@ dependencies = [
  "milvus-sdk-rust",
  "object_store",
  "qdrant-client",
+ "reqwest",
  "rstest",
  "serde",
  "serde_json",

--- a/crates/nova-load/Cargo.toml
+++ b/crates/nova-load/Cargo.toml
@@ -42,11 +42,15 @@ duckdb = { workspace = true }
 elasticsearch = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 milvus = { workspace = true, optional = true }
+# The milvus backend polls index-build progress (pending_index_rows) over
+# Milvus's REST API, because the gRPC SDK's bundled proto is too old to carry
+# that field. Only pulled in with the `milvus` feature.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 
 [features]
 default = []
 elastic = ["dep:elasticsearch", "dep:url"]
-milvus = ["dep:milvus"]
+milvus = ["dep:milvus", "dep:reqwest"]
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/crates/nova-load/src/lib.rs
+++ b/crates/nova-load/src/lib.rs
@@ -44,7 +44,8 @@ pub async fn run(config: LoadConfig) -> Result<(), LoadError> {
     let store = config.vectorstore.connect().await?;
 
     let dims = resolve_dims(&config.datasource, &config.vectors).await?;
-    create_collection(store.as_ref(), &config.vectors, dims).await?;
+    let schema = CollectionSchema { vectors: config.vectors.clone(), dims };
+    store.ensure_collection(&schema).await?;
     store.defer_indexing().await?;
 
     // `load_files` lists + partitions internally.
@@ -59,7 +60,7 @@ pub async fn run(config: LoadConfig) -> Result<(), LoadError> {
     )
     .await?;
 
-    finish_indexing(store.as_ref()).await?;
+    finish_indexing(store.as_ref(), &schema).await?;
     tracing::info!("done: {n} points loaded");
     Ok(())
 }
@@ -72,7 +73,8 @@ pub async fn prepare(config: LoadConfig) -> Result<(), LoadError> {
     // No file listing — dims come from sampling one file (or explicit config),
     // so prepare doesn't pay to enumerate a huge corpus.
     let dims = resolve_dims(&config.datasource, &config.vectors).await?;
-    create_collection(store.as_ref(), &config.vectors, dims).await?;
+    let schema = CollectionSchema { vectors: config.vectors.clone(), dims };
+    store.ensure_collection(&schema).await?;
     store.defer_indexing().await?;
     tracing::info!("prepared collection on {store}");
     Ok(())
@@ -100,23 +102,34 @@ pub async fn load(config: LoadConfig, partition: Partition) -> Result<(), LoadEr
 /// every worker's `load` has completed.
 pub async fn finalize(config: LoadConfig) -> Result<(), LoadError> {
     let store = config.vectorstore.connect().await?;
-    finish_indexing(store.as_ref()).await?;
+    // This process never called `ensure_collection`, so re-derive the schema
+    // that `enable_indexing` needs (per-vector metric etc.). No dims needed here —
+    // the collection already exists, so no backend creates fields in this phase —
+    // which also means `finalize` doesn't have to reach the datasource to sample.
+    let schema = CollectionSchema { vectors: config.vectors.clone(), dims: HashMap::new() };
+    finish_indexing(store.as_ref(), &schema).await?;
     tracing::info!("finalized {store}");
     Ok(())
 }
 
-/// Patch HNSW/quantization/optimizer settings on an *already-existing*
-/// collection in place, then wait for the change to finish optimization — no data is
-/// touched. Uses the same `LoadConfig` shape as every other phase; `datasource`
-/// and `vectors` are required by that shared schema but unused here (only
-/// `vectorstore.params.{hnsw,quantization,optimizers}` matters).
+/// Re-apply index settings from config to an *already-existing* collection, then
+/// wait for the change to reconverge — no data is touched. Uses the same
+/// `LoadConfig` shape as every other phase. Backends read what they need from it:
+/// Qdrant patches `vectorstore.params.{hnsw,quantization,optimizers}` in place;
+/// Milvus drops+rebuilds each index with the configured `index_type`/`index_params`
+/// and the per-vector `distance`.
 pub async fn reindex(config: LoadConfig) -> Result<(), LoadError> {
     let store = config.vectorstore.connect().await?;
+    // Build the schema so backends that rebuild (Milvus/Elastic) can read
+    // per-vector settings (metric). No dims needed — reindex touches an existing
+    // collection, so nothing here creates fields; this also keeps reindex from
+    // having to reach the datasource just to sample a dimension.
+    let schema = CollectionSchema { vectors: config.vectors.clone(), dims: HashMap::new() };
     let started = Instant::now();
-    store.reindex().await?;
+    store.reindex(&schema).await?;
     let converged_at = store.wait_for_indexing().await?;
     let effective_elapsed = converged_at.duration_since(started);
-    tracing::info!("reindex timing: effective_seconds={:.3}", effective_elapsed.as_secs_f64());
+    tracing::info!("reindex timing: index_seconds={:.3}", effective_elapsed.as_secs_f64());
     tracing::info!("reindexed {store}");
     Ok(())
 }
@@ -189,20 +202,23 @@ async fn resolve_dims(
     Ok(engine::infer_dims(&sample, vectors))
 }
 
-async fn create_collection(
+async fn finish_indexing(
     store: &dyn VectorStore,
-    vectors: &HashMap<String, VectorSpec>,
-    dims: HashMap<String, u64>,
+    schema: &CollectionSchema,
 ) -> Result<(), LoadError> {
-    let schema = CollectionSchema { vectors: vectors.clone(), dims };
-    store.ensure_collection(&schema).await?;
-    Ok(())
-}
-
-async fn finish_indexing(store: &dyn VectorStore) -> Result<(), LoadError> {
     tracing::info!("re-enabling indexing…");
-    store.enable_indexing().await?;
-    store.wait_for_indexing().await?;
+    // Time index building the same way `reindex` does: from kicking indexing off
+    // (`enable_indexing`) to the instant the backend first reached its converged
+    // state — `wait_for_indexing` returns that instant, so this EXCLUDES the
+    // stability hold each backend adds on top (e.g. Qdrant's 5s green-hold,
+    // Milvus's 30s pending-zero hold). It's the effective build time, not wall
+    // clock. Backend-agnostic: reports for whichever store this is.
+    let started = Instant::now();
+    store.enable_indexing(schema).await?;
+    let converged_at = store.wait_for_indexing().await?;
+    // Each backend reports its own timing: build time (Qdrant/Milvus) vs ES's
+    // inline index_time (Elasticsearch) — see `report_index_time`.
+    store.report_index_time(converged_at.duration_since(started)).await;
     store.close().await?;
     Ok(())
 }

--- a/crates/nova-load/src/stores/elastic.rs
+++ b/crates/nova-load/src/stores/elastic.rs
@@ -8,18 +8,26 @@
 //! error out — ES models those differently (`sparse_vector`, and no real
 //! multivector), and this backend exists to get dense corpora into an ES cluster.
 
+use std::collections::HashMap;
 use std::fmt;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use elasticsearch::auth::Credentials;
 use elasticsearch::cert::CertificateValidation;
 use elasticsearch::http::transport::{SingleNodeConnectionPool, TransportBuilder};
-use elasticsearch::indices::{IndicesCreateParts, IndicesDeleteParts, IndicesExistsParts};
+use elasticsearch::indices::{
+    IndicesCreateParts, IndicesDeleteParts, IndicesExistsParts, IndicesForcemergeParts,
+    IndicesGetMappingParts, IndicesPutMappingParts, IndicesPutSettingsParts, IndicesRefreshParts,
+    IndicesStatsParts,
+};
 use elasticsearch::{BulkOperation, BulkParts, Elasticsearch};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use url::Url;
 
+use crate::config::VectorKind;
 use crate::stores::{CollectionSchema, Point, PointId, StoreError, VectorStore, VectorValue};
 
 /// Connection + store settings for an Elasticsearch backend (`vectorstore:`).
@@ -45,6 +53,12 @@ pub struct ElasticConfig {
     /// serves HTTPS with a self-signed cert. DEV ONLY — don't use in production.
     #[serde(default)]
     pub tls_insecure: bool,
+    /// `dense_vector` `index_options` passed through verbatim into the field
+    /// mapping (e.g. `{type: int8_hnsw, m: 16, ef_construction: 200}`). When
+    /// unset, ES picks its default. The `similarity` is NOT set here — it comes
+    /// from the per-vector `distance`, like every other backend.
+    #[serde(default)]
+    pub index_options: Option<HashMap<String, Value>>,
     /// Drop + recreate the index if it already exists (instead of reusing it).
     #[serde(default)]
     pub recreate: bool,
@@ -64,6 +78,7 @@ impl fmt::Debug for ElasticConfig {
             .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
             .field("index_name", &self.index_name)
             .field("tls_insecure", &self.tls_insecure)
+            .field("index_options", &self.index_options)
             .field("recreate", &self.recreate)
             .finish()
     }
@@ -73,6 +88,23 @@ pub struct ElasticStore {
     client: Elasticsearch,
     index_name: String,
     recreate: bool,
+    /// `dense_vector` index_options from config, applied at mapping creation and
+    /// (re)applied by `reindex`.
+    index_options: Option<HashMap<String, Value>>,
+    /// Per-vector distance→similarity + index_options that the last create/reindex
+    /// asked for, checked against the live mapping by the sanity check in
+    /// `wait_for_indexing`. Populated by `enable_indexing`/`reindex` on the same
+    /// store instance (both run via `finish_indexing`/`reindex`).
+    expected: Mutex<Vec<ExpectedField>>,
+}
+
+/// The mapping config expected for one dense_vector field, checked against the
+/// live mapping after (re)indexing.
+#[derive(Clone)]
+struct ExpectedField {
+    field: String,
+    similarity: String,
+    index_options: Option<HashMap<String, Value>>,
 }
 
 impl ElasticConfig {
@@ -101,6 +133,8 @@ impl ElasticConfig {
             client: Elasticsearch::new(transport),
             index_name: self.index_name,
             recreate: self.recreate,
+            index_options: self.index_options,
+            expected: Mutex::new(Vec::new()),
         })
     }
 }
@@ -138,8 +172,6 @@ impl ElasticStore {
     /// Build the `mappings.properties` for the index: one `dense_vector` per
     /// dense vector spec. Payload fields are left to ES dynamic mapping.
     fn mappings(&self, schema: &CollectionSchema) -> Result<Value, StoreError> {
-        use crate::config::VectorKind;
-
         let mut props = serde_json::Map::new();
         for (name, spec) in &schema.vectors {
             match spec.kind {
@@ -147,15 +179,16 @@ impl ElasticStore {
                     let dims = schema.dims.get(name).ok_or_else(|| {
                         StoreError::Other(format!("vector `{name}`: dims not resolved"))
                     })?;
-                    props.insert(
-                        name.clone(),
-                        json!({
-                            "type": "dense_vector",
-                            "dims": dims,
-                            "index": true,
-                            "similarity": similarity(spec.distance.as_deref()),
-                        }),
-                    );
+                    let mut field = serde_json::Map::from_iter([
+                        ("type".to_string(), json!("dense_vector")),
+                        ("dims".to_string(), json!(dims)),
+                        ("index".to_string(), json!(true)),
+                        ("similarity".to_string(), json!(similarity(spec.distance.as_deref()))),
+                    ]);
+                    if let Some(opts) = &self.index_options {
+                        field.insert("index_options".to_string(), json!(opts));
+                    }
+                    props.insert(name.clone(), Value::Object(field));
                 }
                 VectorKind::Sparse | VectorKind::Multivector => {
                     return Err(StoreError::Other(format!(
@@ -167,6 +200,218 @@ impl ElasticStore {
             }
         }
         Ok(json!({ "mappings": { "properties": props } }))
+    }
+
+    /// PUT the index's `refresh_interval` setting. `Value::Null` clears the
+    /// override (ES falls back to its 1s default); a string like `"-1"` disables
+    /// periodic refresh for bulk loading.
+    async fn put_refresh_interval(&self, value: Value) -> Result<(), StoreError> {
+        let resp = self
+            .client
+            .indices()
+            .put_settings(IndicesPutSettingsParts::Index(&[self.index_name.as_str()]))
+            .body(json!({ "index": { "refresh_interval": value } }))
+            .send()
+            .await
+            .map_err(to_other)?;
+        if !resp.status_code().is_success() {
+            let detail = resp.text().await.unwrap_or_default();
+            return Err(StoreError::Other(format!("put refresh_interval failed: {detail}")));
+        }
+        Ok(())
+    }
+
+    /// Force a refresh so newly-indexed documents become searchable now.
+    async fn refresh(&self) -> Result<(), StoreError> {
+        let resp = self
+            .client
+            .indices()
+            .refresh(IndicesRefreshParts::Index(&[self.index_name.as_str()]))
+            .send()
+            .await
+            .map_err(to_other)?;
+        if !resp.status_code().is_success() {
+            let detail = resp.text().await.unwrap_or_default();
+            return Err(StoreError::Other(format!("refresh failed: {detail}")));
+        }
+        Ok(())
+    }
+
+    /// Number of merges currently running on the index (`_stats/merge` →
+    /// `indices.<name>.total.merges.current`). ES builds each segment's HNSW
+    /// graph when the segment is written and rebuilds it as segments merge, so a
+    /// settled merge count is the "no more index building happening" signal —
+    /// the ES analog of Qdrant's green status and Milvus's `pending_index_rows`.
+    async fn merges_current(&self) -> Result<i64, StoreError> {
+        let index = self.index_name.as_str();
+        let resp = self
+            .client
+            .indices()
+            .stats(IndicesStatsParts::IndexMetric(&[index], &["merge"]))
+            .send()
+            .await
+            .map_err(to_other)?;
+        if !resp.status_code().is_success() {
+            let detail = resp.text().await.unwrap_or_default();
+            return Err(StoreError::Other(format!("merge stats failed: {detail}")));
+        }
+        let body: Value = resp.json().await.map_err(to_other)?;
+        // Prefer the per-index total; fall back to the cluster-wide `_all` total.
+        let current = body["indices"][index]["total"]["merges"]["current"]
+            .as_i64()
+            .or_else(|| body["_all"]["total"]["merges"]["current"].as_i64())
+            .unwrap_or(0);
+        Ok(current)
+    }
+
+    /// ES's own cumulative index time (ms). ES builds each `dense_vector` HNSW
+    /// graph inline at segment flush *during ingestion* — there's no separate
+    /// post-upload build phase like Milvus/Qdrant — so this stat (not our
+    /// post-load `index_seconds`) is the meaningful "indexing cost" figure.
+    async fn index_time_millis(&self) -> Result<i64, StoreError> {
+        let index = self.index_name.as_str();
+        let resp = self
+            .client
+            .indices()
+            .stats(IndicesStatsParts::IndexMetric(&[index], &["indexing"]))
+            .send()
+            .await
+            .map_err(to_other)?;
+        let body: Value = resp.json().await.map_err(to_other)?;
+        Ok(body["indices"][index]["total"]["indexing"]["index_time_in_millis"]
+            .as_i64()
+            .or_else(|| body["_all"]["total"]["indexing"]["index_time_in_millis"].as_i64())
+            .unwrap_or(0))
+    }
+
+    /// The live `mappings.properties` object for this index.
+    async fn get_properties(&self) -> Result<Value, StoreError> {
+        let index = self.index_name.as_str();
+        let resp = self
+            .client
+            .indices()
+            .get_mapping(IndicesGetMappingParts::Index(&[index]))
+            .send()
+            .await
+            .map_err(to_other)?;
+        if !resp.status_code().is_success() {
+            let detail = resp.text().await.unwrap_or_default();
+            return Err(StoreError::Other(format!("get mapping failed: {detail}")));
+        }
+        let body: Value = resp.json().await.map_err(to_other)?;
+        Ok(body[index]["mappings"]["properties"].clone())
+    }
+
+    /// PUT a single field's mapping definition (used to update `index_options`).
+    /// ES enforces which changes are legal (e.g. HNSW `m` may only increase) and
+    /// rejects the rest — we surface its error verbatim.
+    async fn put_field_mapping(&self, field: &str, def: Value) -> Result<(), StoreError> {
+        let index = self.index_name.as_str();
+        let resp = self
+            .client
+            .indices()
+            .put_mapping(IndicesPutMappingParts::Index(&[index]))
+            .body(json!({ "properties": { field: def } }))
+            .send()
+            .await
+            .map_err(to_other)?;
+        if !resp.status_code().is_success() {
+            let detail = resp.text().await.unwrap_or_default();
+            return Err(StoreError::Other(format!("put mapping for `{field}` failed: {detail}")));
+        }
+        Ok(())
+    }
+
+    /// Trigger an async force-merge to a single segment. Rewriting the segments
+    /// re-encodes existing vectors into the current `index_options` format (an
+    /// Update Mapping alone leaves already-indexed vectors in their old format),
+    /// so this is what makes a `reindex` actually take effect. Async so it
+    /// doesn't block on a long merge; `wait_for_indexing` waits for it to settle.
+    async fn force_merge(&self) -> Result<(), StoreError> {
+        let index = self.index_name.as_str();
+        let resp = self
+            .client
+            .indices()
+            .forcemerge(IndicesForcemergeParts::Index(&[index]))
+            .max_num_segments(1)
+            .wait_for_completion(false)
+            .send()
+            .await
+            .map_err(to_other)?;
+        if !resp.status_code().is_success() {
+            let detail = resp.text().await.unwrap_or_default();
+            return Err(StoreError::Other(format!("force merge failed: {detail}")));
+        }
+        Ok(())
+    }
+
+    /// Per-vector expected mapping (similarity from distance + configured
+    /// index_options), erroring on sparse/multivector.
+    fn expected_fields(&self, schema: &CollectionSchema) -> Result<Vec<ExpectedField>, StoreError> {
+        schema
+            .vectors
+            .iter()
+            .map(|(name, spec)| match spec.kind {
+                VectorKind::Dense => Ok(ExpectedField {
+                    field: name.clone(),
+                    similarity: similarity(spec.distance.as_deref()).to_string(),
+                    index_options: self.index_options.clone(),
+                }),
+                VectorKind::Sparse | VectorKind::Multivector => Err(StoreError::Other(format!(
+                    "elastic backend supports dense vectors only for now; \
+                     vector `{name}` is {:?}",
+                    spec.kind
+                ))),
+            })
+            .collect()
+    }
+
+    /// Sanity check: confirm the live mapping reflects what we asked for — the
+    /// `similarity` matches and every configured `index_options` key is present
+    /// with the requested value (ES fills in defaults for the rest, so this is a
+    /// subset check, not full equality). Runs after (re)indexing settles.
+    async fn verify_expected(&self) -> Result<(), StoreError> {
+        let expected = self.expected.lock().expect("mapping lock").clone();
+        if expected.is_empty() {
+            return Ok(());
+        }
+        let props = self.get_properties().await?;
+        for e in &expected {
+            let got = &props[&e.field];
+            if got.is_null() {
+                return Err(StoreError::Other(format!(
+                    "sanity check: field `{}` missing from mapping on {self}",
+                    e.field
+                )));
+            }
+            let got_sim = got["similarity"].as_str().unwrap_or_default();
+            if got_sim != e.similarity {
+                return Err(StoreError::Other(format!(
+                    "sanity check FAILED on {self} field `{}`: requested similarity={} \
+                     but mapping has {got_sim}",
+                    e.field, e.similarity
+                )));
+            }
+            if let Some(opts) = &e.index_options {
+                let got_opts = &got["index_options"];
+                for (k, v) in opts {
+                    if got_opts.get(k) != Some(v) {
+                        return Err(StoreError::Other(format!(
+                            "sanity check FAILED on {self} field `{}`: requested \
+                             index_options.{k}={v} but mapping has {:?}",
+                            e.field,
+                            got_opts.get(k)
+                        )));
+                    }
+                }
+            }
+            tracing::info!(
+                "{self} field `{}` verified: similarity={got_sim} index_options={}",
+                e.field,
+                got["index_options"]
+            );
+        }
+        Ok(())
     }
 }
 
@@ -262,6 +507,154 @@ impl VectorStore for ElasticStore {
     }
 
     async fn close(&self) -> Result<(), StoreError> {
+        Ok(())
+    }
+
+    async fn defer_indexing(&self) -> Result<(), StoreError> {
+        // Disable periodic refresh so bulk indexing doesn't pay to build a new
+        // searchable segment on every interval. The index is created by
+        // `ensure_collection` before this runs, so the settings PUT targets an
+        // existing index. Restored in `enable_indexing`.
+        self.put_refresh_interval(json!("-1")).await
+    }
+
+    async fn enable_indexing(&self, schema: &CollectionSchema) -> Result<(), StoreError> {
+        // Restore the default refresh behavior (null = fall back to the 1s
+        // default), then force one refresh so everything bulk-loaded becomes
+        // searchable immediately rather than on the next interval.
+        self.put_refresh_interval(Value::Null).await?;
+        self.refresh().await?;
+        // Record what the mapping should be so `wait_for_indexing` can verify it.
+        *self.expected.lock().expect("mapping lock") = self.expected_fields(schema)?;
+        Ok(())
+    }
+
+    async fn wait_for_indexing(&self) -> Result<Instant, StoreError> {
+        // Reach a genuine steady state, like the Qdrant and Milvus backends —
+        // not just "docs are searchable". ES writes each segment's HNSW graph when
+        // the segment is flushed and then rebuilds graphs as segments merge in the
+        // background, so "indexing is really done" means: the latest writes are
+        // flushed (force a refresh) AND no merges are running — HELD for a window,
+        // so a brief lull between merge waves doesn't look like completion. Return
+        // the instant the merges first settled (start of the hold), so the caller
+        // measures real build time excluding the hold.
+        const POLL_INTERVAL: Duration = Duration::from_secs(1);
+        const SETTLED_HOLD: Duration = Duration::from_secs(5);
+        const TIMEOUT: Duration = Duration::from_secs(1800);
+
+        // Flush the last segments (with their graphs) so they're searchable and
+        // counted; also correct when called standalone (e.g. after `reindex`).
+        self.refresh().await?;
+
+        let start = Instant::now();
+        let mut settled_since: Option<Instant> = None;
+        loop {
+            if start.elapsed() >= TIMEOUT {
+                return Err(StoreError::Other(format!(
+                    "timed out after {}s waiting for merges to settle on {self}",
+                    TIMEOUT.as_secs()
+                )));
+            }
+
+            let current = self.merges_current().await?;
+            tracing::info!("{self} indexing: merges_current={current}");
+
+            if current == 0 {
+                let since = *settled_since.get_or_insert_with(Instant::now);
+                if since.elapsed() >= SETTLED_HOLD {
+                    tracing::info!(
+                        "{self} indexing settled (no merges running for {}s)",
+                        SETTLED_HOLD.as_secs()
+                    );
+                    // Sanity-check the mapping (runs after `since`, so it's not
+                    // counted in the caller's timing). The indexing-time figure is
+                    // reported separately by `report_index_time`.
+                    self.verify_expected().await?;
+                    return Ok(since);
+                }
+            } else if settled_since.take().is_some() {
+                // Merges resumed after a lull — restart the hold window.
+                tracing::warn!(
+                    "{self} merges resumed (merges_current={current}); restarting {}s window",
+                    SETTLED_HOLD.as_secs()
+                );
+            }
+
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
+    async fn report_index_time(&self, effective: std::time::Duration) {
+        // ES builds the HNSW graph inline during ingestion, so `effective` (the
+        // post-load merge-settle window) is NOT the indexing cost — it's ~0.
+        // Report ES's own cumulative index_time as the headline figure instead.
+        match self.index_time_millis().await {
+            Ok(ms) => tracing::info!(
+                "{self} indexing finished: index_seconds={:.3} \
+                 (ES builds inline during ingest; post-load merge-settle={:.3}s)",
+                ms as f64 / 1000.0,
+                effective.as_secs_f64()
+            ),
+            Err(e) => tracing::info!(
+                "{self} indexing finished: index_seconds={:.3} \
+                 (ES index_time unavailable: {e})",
+                effective.as_secs_f64()
+            ),
+        }
+    }
+
+    async fn reindex(&self, schema: &CollectionSchema) -> Result<(), StoreError> {
+        // ES reindex, in-place: update each dense_vector field's `index_options`
+        // via the Update Mapping API, then force-merge so existing vectors are
+        // re-encoded into the new format (an Update Mapping alone leaves already-
+        // indexed vectors in their old format). The subsequent `wait_for_indexing`
+        // waits for the merge to settle and sanity-checks the live mapping.
+        //
+        // `similarity`/`dims` are immutable in ES — if the requested distance
+        // differs from the existing mapping, we error out rather than silently
+        // no-op'ing (changing it requires a NEW index + the `_reindex` API).
+        let expected = self.expected_fields(schema)?;
+        let props = self.get_properties().await?;
+
+        for e in &expected {
+            let existing = &props[&e.field];
+            if existing.is_null() {
+                return Err(StoreError::Other(format!(
+                    "reindex: field `{}` not found in mapping on {self}",
+                    e.field
+                )));
+            }
+            let existing_sim = existing["similarity"].as_str().unwrap_or_default();
+            if existing_sim != e.similarity {
+                return Err(StoreError::Other(format!(
+                    "reindex: elastic can't change `similarity` in place on `{}` \
+                     ({existing_sim} → {}); that needs a new index + the _reindex API",
+                    e.field, e.similarity
+                )));
+            }
+            match &self.index_options {
+                Some(opts) => {
+                    let mut def = existing.as_object().cloned().unwrap_or_default();
+                    def.insert("index_options".to_string(), json!(opts));
+                    tracing::info!(
+                        "{self}: reindexing `{}` → index_options={}",
+                        e.field,
+                        json!(opts)
+                    );
+                    // ES validates legality (e.g. HNSW `m` may only increase).
+                    self.put_field_mapping(&e.field, Value::Object(def)).await?;
+                }
+                None => tracing::warn!(
+                    "{self}: no index_options configured; reindex only force-merges to \
+                     consolidate segments (no mapping change) on `{}`",
+                    e.field
+                ),
+            }
+        }
+
+        *self.expected.lock().expect("mapping lock") = expected;
+        // Rewrite existing vectors into the (possibly new) format.
+        self.force_merge().await?;
         Ok(())
     }
 

--- a/crates/nova-load/src/stores/milvus_store.rs
+++ b/crates/nova-load/src/stores/milvus_store.rs
@@ -7,11 +7,27 @@
 //!
 //! Scope for now: **dense vectors, id only**. This SDK exposes no JSON/dynamic
 //! field, so **payload is not persisted** — it's dropped with a warning. Sparse
-//! and multivector values error out. The SDK also has no `COSINE` metric, so
-//! cosine maps to inner-product (correct only for L2-normalized vectors).
+//! and multivector values error out.
 //!
-//! In this SDK the data-plane ops (`insert`/`flush`/`create_index`/`load`) live on
-//! a `Collection` obtained via `client.get_collection(name)`, not on the client.
+//! Index lifecycle (bulk-load shaped): `ensure_collection` creates the collection
+//! with **no index** so the upsert pays no per-insert index cost; `enable_indexing`
+//! then flushes and builds the configured index; `wait_for_indexing` polls until
+//! the build is steady, then explicitly `load`s the collection into memory so it's
+//! queryable. The load is timed and reported SEPARATELY from the index build (it's
+//! not part of `index_seconds`).
+//!
+//! Two ops go over Milvus's **REST API** (`/v2/vectordb/...`, same host:port as
+//! gRPC in 2.4+) rather than the gRPC SDK, because the vendored `milvus-sdk-rust`
+//! 0.1.0 is too old: (1) index create/describe/drop — the SDK's `MetricType` enum
+//! has no `COSINE` (and its `From<IndexDescription>` would *panic* on one), and
+//! can't express arbitrary index types; (2) build progress — the SDK's proto drops
+//! `pending_index_rows`, the true "indexing finished" signal. Everything else
+//! (collection create/insert/flush) uses the gRPC SDK.
+//!
+//! Milvus inserts are **columnar** (`FieldColumn` per field), so `upsert_batch`
+//! transposes the row-shaped [`Point`]s into one id column + one column per dense
+//! vector. The primary key is a **varchar** (every id is stringified, so UUID
+//! point ids work), and vectors are float-vector fields.
 //!
 //! Worker note: distributed `load` workers call `upsert_batch` without ever
 //! calling `ensure_collection` (the controller does that in `prepare`). So the
@@ -20,13 +36,15 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use milvus::client::{Client, ClientBuilder};
 use milvus::data::FieldColumn;
-use milvus::index::{IndexParams, IndexType, MetricType};
 use milvus::schema::{CollectionSchemaBuilder, FieldSchema};
 use serde::Deserialize;
+use serde_json::json;
 
 use crate::config::VectorKind;
 use crate::stores::{CollectionSchema, Point, PointId, StoreError, VectorStore, VectorValue};
@@ -47,6 +65,18 @@ pub struct MilvusConfig {
     /// Max length for the varchar primary key (UUIDs need 36).
     #[serde(default = "default_id_len")]
     pub id_max_length: i32,
+    /// Vector index type to build in `enable_indexing`, passed through to Milvus
+    /// verbatim — any type this Milvus build supports works (e.g. `IVF_FLAT`,
+    /// `IVF_SQ8`, `HNSW`, `DISKANN`, `FLAT`, `AUTOINDEX`). Defaults to
+    /// `AUTOINDEX` (Milvus picks a sensible index).
+    #[serde(default = "default_index_type")]
+    pub index_type: String,
+    /// Extra index-build params, passed through verbatim (e.g. `{nlist: 128}` for
+    /// IVF, `{M: 16, efConstruction: 200}` for HNSW). Ignored for `AUTOINDEX`
+    /// (Milvus rejects extra params there). The metric is NOT set here — it comes
+    /// from the top-level `vectors:` distance, like every other backend.
+    #[serde(default)]
+    pub index_params: HashMap<String, serde_json::Value>,
     /// Drop + recreate the collection if it already exists.
     #[serde(default)]
     pub recreate: bool,
@@ -58,16 +88,67 @@ fn default_collection() -> String {
 fn default_id_len() -> i32 {
     128
 }
+fn default_index_type() -> String {
+    "AUTOINDEX".to_string()
+}
 
 pub struct MilvusStore {
     client: Client,
     collection_name: String,
     id_max_length: i32,
     recreate: bool,
+    /// Base URL for Milvus's REST API (same host:port as gRPC in 2.4+). Used
+    /// only by `wait_for_indexing` to read `pending_index_rows`, which the gRPC
+    /// SDK's bundled proto is too old to expose. See `wait_for_indexing`.
+    rest_base: String,
+    /// REST bearer token (`username:password`), if credentials were configured.
+    auth_token: Option<String>,
+    http: reqwest::Client,
+    /// Vector index type + extra params to build (from config), passed through to
+    /// Milvus's REST index-create so any supported index works.
+    index_type: String,
+    index_params: HashMap<String, serde_json::Value>,
+    /// What `enable_indexing` asked Milvus to build, recorded so the post-build
+    /// sanity check in `wait_for_indexing` can confirm it stuck. `enable_indexing`
+    /// and `wait_for_indexing` always run on the same store instance (both via
+    /// `finish_indexing`), so this hands off between them without touching the
+    /// trait signature.
+    expected_indexes: Mutex<Vec<ExpectedIndex>>,
+}
+
+/// The index config `enable_indexing` requested for one vector field — checked
+/// against the built index in `wait_for_indexing`.
+#[derive(Clone)]
+struct ExpectedIndex {
+    field_name: String,
+    index_name: String,
+    index_type: String,
+    metric_type: String,
+    /// Build params we asked for (e.g. `{M: 16, efConstruction: 200}` / `{nlist: 128}`).
+    /// Verified against the gRPC-reported params (REST describe omits them).
+    params: HashMap<String, serde_json::Value>,
+}
+
+/// A JSON scalar as a plain string, so a requested `16` (number) and a
+/// Milvus-reported `"16"` (string) compare equal.
+fn scalar_string(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => String::new(),
+        other => other.to_string(),
+    }
 }
 
 impl MilvusConfig {
     pub async fn connect(self) -> Result<MilvusStore, StoreError> {
+        // The gRPC and REST APIs share the same endpoint; keep the URL for REST
+        // before it's moved into the gRPC client builder below.
+        let rest_base = self.url.trim_end_matches('/').to_string();
+        let auth_token = match (&self.username, &self.password) {
+            (Some(u), Some(p)) => Some(format!("{u}:{p}")),
+            _ => None,
+        };
+
         // Owned String: tonic's Endpoint is TryFrom<String>, not From<&String>.
         let mut builder = ClientBuilder::new(self.url);
         if let Some(u) = &self.username {
@@ -77,25 +158,69 @@ impl MilvusConfig {
             builder = builder.password(p);
         }
         let client = builder.build().await.map_err(to_other)?;
+        // `Client::builder().build()` surfaces a TLS-stack init failure as an
+        // error rather than panicking like `Client::new()`.
+        let http = reqwest::Client::builder().build().map_err(to_other)?;
         Ok(MilvusStore {
             client,
             collection_name: self.collection_name,
             id_max_length: self.id_max_length,
             recreate: self.recreate,
+            rest_base,
+            auth_token,
+            http,
+            index_type: self.index_type,
+            index_params: self.index_params,
+            expected_indexes: Mutex::new(Vec::new()),
         })
     }
+}
+
+/// One index's build progress, as returned by the REST
+/// `/v2/vectordb/indexes/describe` endpoint. Field names match the JSON.
+#[derive(Debug, Deserialize)]
+struct IndexProgress {
+    #[serde(rename = "indexName", default)]
+    index_name: String,
+    #[serde(rename = "fieldName", default)]
+    field_name: String,
+    #[serde(rename = "indexType", default)]
+    index_type: String,
+    #[serde(rename = "metricType", default)]
+    metric_type: String,
+    #[serde(rename = "indexState", default)]
+    index_state: String,
+    #[serde(rename = "indexedRows", default)]
+    indexed_rows: i64,
+    #[serde(rename = "totalRows", default)]
+    total_rows: i64,
+    /// Rows queued for indexing but not yet built. This can be > 0 even when
+    /// `indexed_rows == total_rows` (Milvus reports "done", then keeps going),
+    /// so it — not the indexed/total pair — is the true "indexing finished"
+    /// signal. Absent from the gRPC SDK's old proto; the reason we poll REST.
+    #[serde(rename = "pendingRows", default)]
+    pending_rows: i64,
+    #[serde(rename = "failReason", default)]
+    fail_reason: String,
 }
 
 fn to_other<E: std::fmt::Display>(e: E) -> StoreError {
     StoreError::Other(e.to_string())
 }
 
-/// Qdrant-style distance name → Milvus metric. This SDK has no `COSINE`, so
-/// cosine falls back to inner product (equivalent only for normalized vectors).
-fn metric(distance: Option<&str>) -> MetricType {
-    match distance.unwrap_or("cosine") {
-        "euclid" => MetricType::L2,
-        _ => MetricType::IP, // dot, and cosine (see note above)
+/// Qdrant-style distance name → Milvus REST metric type. Unlike the gRPC SDK's
+/// closed `MetricType` enum (which has no COSINE), the REST index-create accepts
+/// the real metric names Milvus supports — so cosine is genuine cosine, not an
+/// inner-product stand-in.
+fn rest_metric(distance: Option<&str>) -> &'static str {
+    match distance {
+        None | Some("cosine") => "COSINE",
+        Some("euclid") => "L2",
+        Some("dot") => "IP",
+        Some(other) => {
+            tracing::warn!("milvus: unknown distance `{other}`, defaulting to COSINE metric");
+            "COSINE"
+        }
     }
 }
 
@@ -105,24 +230,299 @@ impl fmt::Display for MilvusStore {
     }
 }
 
-/// Dense vector fields (name, dim), erroring on sparse/multivector.
-fn dense_fields(schema: &CollectionSchema) -> Result<Vec<(&String, i64)>, StoreError> {
-    let mut out = Vec::new();
-    for (name, spec) in &schema.vectors {
-        match spec.kind {
-            VectorKind::Dense => {
-                let dim = *schema.dims.get(name).ok_or_else(|| {
-                    StoreError::Other(format!("vector `{name}`: dims not resolved"))
-                })?;
-                out.push((name, dim as i64));
+impl MilvusStore {
+    /// POST a Milvus REST v2 request and return its `data` payload, erroring on a
+    /// non-zero response code. Only used by `wait_for_indexing` (see the note
+    /// there on why index-build progress goes over REST rather than gRPC).
+    async fn rest_post(&self, path: &str, body: serde_json::Value) -> Result<serde_json::Value, StoreError> {
+        let url = format!("{}/v2/vectordb/{path}", self.rest_base);
+        let mut req = self.http.post(&url).json(&body);
+        if let Some(token) = &self.auth_token {
+            req = req.bearer_auth(token);
+        }
+        let resp = req.send().await.map_err(to_other)?;
+        // Check the HTTP status before parsing JSON: a proxy 502, an auth 401
+        // returning HTML, or hitting the gRPC port by mistake would otherwise
+        // surface as an opaque serde parse error instead of the real status.
+        let status = resp.status();
+        if !status.is_success() {
+            let detail = resp.text().await.unwrap_or_default();
+            return Err(StoreError::Other(format!("milvus REST {path} HTTP {status}: {detail}")));
+        }
+        let body: serde_json::Value = resp.json().await.map_err(to_other)?;
+        if body.get("code").and_then(serde_json::Value::as_i64) != Some(0) {
+            return Err(StoreError::Other(format!("milvus REST {path} failed: {body}")));
+        }
+        Ok(body.get("data").cloned().unwrap_or(serde_json::Value::Null))
+    }
+
+    /// Names of the indexes on this collection (usually one per vector field).
+    async fn rest_index_names(&self) -> Result<Vec<String>, StoreError> {
+        let data = self
+            .rest_post("indexes/list", json!({ "collectionName": self.collection_name }))
+            .await?;
+        serde_json::from_value(data).map_err(to_other)
+    }
+
+    /// Describe one index (returns a row per segment/field the endpoint reports).
+    async fn rest_describe(&self, index_name: &str) -> Result<Vec<IndexProgress>, StoreError> {
+        let data = self
+            .rest_post(
+                "indexes/describe",
+                json!({ "collectionName": self.collection_name, "indexName": index_name }),
+            )
+            .await?;
+        serde_json::from_value(data).map_err(to_other)
+    }
+
+    /// Create one vector index over `field` via the REST API, applying the
+    /// configured index type + params and the given metric. Uses REST (not the
+    /// gRPC SDK) so we can request any index type and — critically — real
+    /// `COSINE`, which the SDK's closed enum can't express.
+    async fn rest_create_index(
+        &self,
+        field: &str,
+        index_name: &str,
+        metric: &str,
+    ) -> Result<(), StoreError> {
+        let mut index_param = serde_json::Map::new();
+        index_param.insert("fieldName".into(), json!(field));
+        index_param.insert("indexName".into(), json!(index_name));
+        index_param.insert("metricType".into(), json!(metric));
+        // Milvus rejects extra params for AUTOINDEX ("only metric type can be
+        // passed"); for every other type the index type + params go INSIDE the
+        // `params` object (a top-level `indexType` is silently treated as
+        // AUTOINDEX).
+        if self.index_type.eq_ignore_ascii_case("AUTOINDEX") {
+            if !self.index_params.is_empty() {
+                tracing::warn!("{self}: index_params are ignored for AUTOINDEX");
             }
-            VectorKind::Sparse | VectorKind::Multivector => {
-                return Err(StoreError::Other(format!(
-                    "milvus backend supports dense vectors only for now; vector `{name}` is {:?}",
-                    spec.kind
-                )));
+        } else {
+            let mut params = serde_json::Map::new();
+            params.insert("index_type".into(), json!(self.index_type));
+            for (k, v) in &self.index_params {
+                params.insert(k.clone(), v.clone());
+            }
+            index_param.insert("params".into(), serde_json::Value::Object(params));
+        }
+
+        self.rest_post(
+            "indexes/create",
+            json!({
+                "collectionName": self.collection_name,
+                "indexParams": [serde_json::Value::Object(index_param)],
+            }),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Sum index-build progress across the named indexes, returning
+    /// `(indexed_rows, total_rows, pending_index_rows, all_finished)`. Errors if
+    /// any index is in the `Failed` state (surfacing its fail reason).
+    async fn rest_index_progress(
+        &self,
+        names: &[String],
+    ) -> Result<(i64, i64, i64, bool), StoreError> {
+        let (mut indexed, mut total, mut pending) = (0i64, 0i64, 0i64);
+        let mut all_finished = true;
+        for name in names {
+            for p in &self.rest_describe(name).await? {
+                if p.index_state == "Failed" {
+                    return Err(StoreError::Other(format!(
+                        "milvus index `{}` build failed on {self}: {}",
+                        p.index_name, p.fail_reason
+                    )));
+                }
+                if p.index_state != "Finished" {
+                    all_finished = false;
+                }
+                indexed += p.indexed_rows;
+                total += p.total_rows;
+                pending += p.pending_rows;
             }
         }
+        Ok((indexed, total, pending, all_finished))
+    }
+
+    /// The index build params to verify: those we actually sent. AUTOINDEX takes
+    /// no params (Milvus rejects them), so there's nothing to check there.
+    fn params_to_verify(&self) -> HashMap<String, serde_json::Value> {
+        if self.index_type.eq_ignore_ascii_case("AUTOINDEX") {
+            HashMap::new()
+        } else {
+            self.index_params.clone()
+        }
+    }
+
+    /// Read an index's build params over raw gRPC `DescribeIndex`. Milvus's REST
+    /// describe omits build params (M/efConstruction/nlist); the gRPC response
+    /// carries them in its `params` key-value list. We read those raw — no
+    /// conversion to the SDK's `IndexInfo`, whose `MetricType` parse would panic
+    /// on COSINE. Returns a flat string map of {index_type, metric_type, + the
+    /// nested build params}. Uses a fresh unauthenticated connection, so callers
+    /// treat an error as "couldn't verify" rather than fatal.
+    async fn grpc_index_params(
+        &self,
+        field_name: &str,
+        index_name: &str,
+    ) -> Result<HashMap<String, String>, StoreError> {
+        use milvus::proto::common::{MsgBase, MsgType};
+        use milvus::proto::milvus::DescribeIndexRequest;
+        use milvus::proto::milvus::milvus_service_client::MilvusServiceClient;
+
+        let mut client =
+            MilvusServiceClient::connect(self.rest_base.clone()).await.map_err(to_other)?;
+        let req = DescribeIndexRequest {
+            base: Some(MsgBase {
+                msg_type: MsgType::DescribeIndex as i32,
+                msg_id: 0,
+                timestamp: 0,
+                source_id: 0,
+                target_id: 0,
+            }),
+            db_name: String::new(),
+            collection_name: self.collection_name.clone(),
+            field_name: field_name.to_string(),
+            index_name: index_name.to_string(),
+        };
+        let resp = client.describe_index(req).await.map_err(to_other)?.into_inner();
+        let desc = resp
+            .index_descriptions
+            .into_iter()
+            .find(|d| d.index_name == index_name || d.field_name == field_name)
+            .ok_or_else(|| {
+                StoreError::Other(format!("gRPC describe returned no index `{index_name}`"))
+            })?;
+
+        let mut out = HashMap::new();
+        for kv in desc.params {
+            if kv.key == "params" {
+                // Nested JSON, e.g. {"M":"16","efConstruction":"200"} or {"nlist":128}.
+                if let Ok(serde_json::Value::Object(m)) =
+                    serde_json::from_str::<serde_json::Value>(&kv.value)
+                {
+                    for (k, v) in m {
+                        out.insert(k, scalar_string(&v));
+                    }
+                }
+            } else {
+                out.insert(kv.key, kv.value);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Load the collection into memory so it's queryable, timing the load and
+    /// reporting it on its own line (kept out of the index-build timing). Milvus's
+    /// SDK `load` blocks until the load reaches 100%.
+    async fn load_collection(&self) -> Result<(), StoreError> {
+        let started = Instant::now();
+        let collection =
+            self.client.get_collection(self.collection_name.as_str()).await.map_err(to_other)?;
+        collection.load(1).await.map_err(to_other)?;
+        tracing::info!(
+            "{self} load finished: load_seconds={:.3}",
+            started.elapsed().as_secs_f64()
+        );
+        Ok(())
+    }
+
+    /// Sanity check: confirm each index `enable_indexing` asked Milvus to build
+    /// actually came back with the index type + metric we requested. Runs after
+    /// convergence in `wait_for_indexing`; NOT part of the timed build (the caller
+    /// measures up to the converged instant, which predates this). Comparisons are
+    /// case-insensitive (Milvus normalizes the names it echoes back).
+    async fn verify_indexes(&self) -> Result<(), StoreError> {
+        let expected = self.expected_indexes.lock().expect("index lock").clone();
+        for e in &expected {
+            let described = self.rest_describe(&e.index_name).await?;
+            let got = described.iter().find(|p| p.index_name == e.index_name).ok_or_else(|| {
+                StoreError::Other(format!(
+                    "sanity check: index `{}` not found after build on {self}",
+                    e.index_name
+                ))
+            })?;
+            if !got.index_type.eq_ignore_ascii_case(&e.index_type)
+                || !got.metric_type.eq_ignore_ascii_case(&e.metric_type)
+            {
+                return Err(StoreError::Other(format!(
+                    "sanity check FAILED on {self} index `{}`: requested \
+                     index_type={}/metric_type={} but Milvus built \
+                     index_type={}/metric_type={}",
+                    e.index_name, e.index_type, e.metric_type, got.index_type, got.metric_type
+                )));
+            }
+            tracing::info!(
+                "{self} index `{}` verified: index_type={} metric_type={}",
+                e.index_name,
+                got.index_type,
+                got.metric_type
+            );
+
+            // Build params (M/efConstruction/nlist) aren't in the REST describe —
+            // read them over gRPC and confirm each one we requested is reflected.
+            // Best-effort: if gRPC is unreachable (e.g. auth), warn rather than
+            // fail, since type+metric are already verified above.
+            if !e.params.is_empty() {
+                match self.grpc_index_params(&e.field_name, &e.index_name).await {
+                    Ok(built) => {
+                        for (k, v) in &e.params {
+                            let want = scalar_string(v);
+                            match built.get(k) {
+                                Some(got) if *got == want => {}
+                                other => {
+                                    return Err(StoreError::Other(format!(
+                                        "sanity check FAILED on {self} index `{}`: requested \
+                                         {k}={want} but built index reports {k}={other:?}",
+                                        e.index_name
+                                    )));
+                                }
+                            }
+                        }
+                        tracing::info!(
+                            "{self} index `{}` params verified: {:?}",
+                            e.index_name,
+                            e.params
+                        );
+                    }
+                    Err(err) => tracing::warn!(
+                        "{self} index `{}`: could not read build params over gRPC to verify \
+                         ({err}); verified index_type + metric_type only",
+                        e.index_name
+                    ),
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Validate that every vector is dense (Milvus backend scope), erroring on
+/// sparse/multivector. Returns the dense vector names.
+fn dense_field_names(schema: &CollectionSchema) -> Result<Vec<&String>, StoreError> {
+    schema
+        .vectors
+        .iter()
+        .map(|(name, spec)| match spec.kind {
+            VectorKind::Dense => Ok(name),
+            VectorKind::Sparse | VectorKind::Multivector => Err(StoreError::Other(format!(
+                "milvus backend supports dense vectors only for now; vector `{name}` is {:?}",
+                spec.kind
+            ))),
+        })
+        .collect()
+}
+
+/// Dense vector fields with their dims — for collection creation, which needs
+/// the dim. Errors on sparse/multivector or unresolved dims.
+fn dense_fields(schema: &CollectionSchema) -> Result<Vec<(&String, i64)>, StoreError> {
+    let mut out = Vec::new();
+    for name in dense_field_names(schema)? {
+        let dim = *schema.dims.get(name).ok_or_else(|| {
+            StoreError::Other(format!("vector `{name}`: dims not resolved"))
+        })?;
+        out.push((name, dim as i64));
     }
     Ok(out)
 }
@@ -144,18 +544,12 @@ impl VectorStore for MilvusStore {
             "milvus backend does not persist payload (the SDK has no JSON field); \
              only the id + dense vectors are stored"
         );
-        if schema
-            .vectors
-            .values()
-            .any(|s| matches!(s.distance.as_deref(), None | Some("cosine")))
-        {
-            tracing::warn!(
-                "milvus SDK has no COSINE metric — cosine vectors are indexed with \
-                 inner product; ensure they are L2-normalized"
-            );
-        }
 
-        // add_field takes &mut self (mutates in place), so don't reassign.
+        // Create the collection WITHOUT any index: leaving the vector fields
+        // unindexed lets the bulk upsert run without paying index-build cost per
+        // insert. The real index is created later in `enable_indexing`, once the
+        // data is in (see there). `defer_indexing` is a no-op for the same reason
+        // — there's no index to pause during the load.
         let mut builder = CollectionSchemaBuilder::new(name, "nova-load");
         builder.add_field(FieldSchema::new_primary_varchar(
             PK_FIELD,
@@ -167,21 +561,7 @@ impl VectorStore for MilvusStore {
             builder.add_field(FieldSchema::new_float_vector(vname.as_str(), "", *dim));
         }
         let milvus_schema = builder.build().map_err(to_other)?;
-
-        // create_collection returns the live Collection handle.
-        let collection = self.client.create_collection(milvus_schema, None).await.map_err(to_other)?;
-
-        // Index each vector field so the collection is loadable/searchable later.
-        for (vname, _) in &dense {
-            let mt = metric(schema.vectors[vname.as_str()].distance.as_deref());
-            let params = IndexParams::new(
-                format!("{vname}_idx"),
-                IndexType::IvfFlat,
-                mt,
-                HashMap::from([("nlist".to_string(), "128".to_string())]),
-            );
-            collection.create_index(vname.as_str(), params).await.map_err(to_other)?;
-        }
+        self.client.create_collection(milvus_schema, None).await.map_err(to_other)?;
         Ok(())
     }
 
@@ -228,12 +608,214 @@ impl VectorStore for MilvusStore {
         Ok(())
     }
 
-    async fn enable_indexing(&self) -> Result<(), StoreError> {
-        // Persist buffered inserts, then load the collection so it's queryable.
+    async fn defer_indexing(&self) -> Result<(), StoreError> {
+        // No-op: `ensure_collection` creates the collection with NO index, so
+        // there's nothing to pause during the bulk upsert. The index is built
+        // afterward in `enable_indexing`.
+        Ok(())
+    }
+
+    async fn enable_indexing(&self, schema: &CollectionSchema) -> Result<(), StoreError> {
+        // The collection was created unindexed (see `ensure_collection`). Now that
+        // the bulk upsert is done, persist the buffered inserts and build the
+        // real index (via REST — see `rest_create_index`). We don't load here —
+        // the load happens once the build converges, in `wait_for_indexing`, timed
+        // separately. Only field names are needed (not dims — the index create is
+        // by field), so this doesn't force the caller to resolve dims in the
+        // `finalize` path.
+        let dense = dense_field_names(schema)?;
+
         let collection =
             self.client.get_collection(self.collection_name.as_str()).await.map_err(to_other)?;
         collection.flush().await.map_err(to_other)?;
-        collection.load(1).await.map_err(to_other)?;
+
+        // Skip fields that already carry an index (a re-run over an existing
+        // collection); we still record every field as "expected" so the sanity
+        // check verifies pre-existing indexes match the requested config too.
+        let existing = self.rest_index_names().await?;
+        let mut expected = Vec::with_capacity(dense.len());
+        for &vname in &dense {
+            let index_name = format!("{vname}_idx");
+            let metric = rest_metric(schema.vectors[vname.as_str()].distance.as_deref());
+            if !existing.iter().any(|n| n == &index_name) {
+                self.rest_create_index(vname, &index_name, metric).await?;
+            }
+            expected.push(ExpectedIndex {
+                field_name: vname.to_string(),
+                index_name,
+                index_type: self.index_type.clone(),
+                metric_type: metric.to_string(),
+                params: self.params_to_verify(),
+            });
+        }
+        *self.expected_indexes.lock().expect("index lock") = expected;
+        Ok(())
+    }
+
+    async fn wait_for_indexing(&self) -> Result<Instant, StoreError> {
+        // Adapted from VECHINI's Milvus loader (milvus/scripts/index.py). Milvus
+        // builds segment indexes asynchronously, and — the important part — it
+        // will report an index "Finished" with `indexed_rows == total_rows`, then
+        // decide to index more (you can observe indexed=total AND pending > 0 at
+        // the same time). So the honest "indexing is really done" signal is
+        // `pending_index_rows == 0`, and it has to *hold*: VECHINI waits for it to
+        // stay 0 over a window. We do the same, with a 30s hold.
+        //
+        // `pending_index_rows` isn't in the gRPC SDK's bundled proto (its
+        // `IndexDescription` stops at field 8), so — exactly the field pymilvus
+        // reads via DescribeIndex — we read it from Milvus's REST API instead
+        // (same endpoint, `/v2/vectordb/indexes/describe`). We log the counts each
+        // poll so a jump back up is visible.
+        //
+        // Completion = every index `Finished` AND `pending_index_rows == 0`,
+        // HELD for the window. We deliberately do NOT gate on row counts:
+        //  - `get_collection_stats` rowCount lags (it read 0 for a fully-loaded
+        //    collection all through the build), so it's not a usable target;
+        //  - right after `create_index` Milvus briefly reports pending=0/Finished
+        //    (stale) — but the hold + regression-reset below absorbs that: when
+        //    the build actually starts, pending jumps > 0 and restarts the window.
+        // This also makes an *empty* collection converge (pending stays 0) instead
+        // of spinning to the timeout.
+        const POLL_INTERVAL: Duration = Duration::from_secs(2);
+        const PENDING_ZERO_HOLD: Duration = Duration::from_secs(30);
+        const TIMEOUT: Duration = Duration::from_secs(3600);
+
+        // Which indexes to watch (usually one per vector field). Works in the
+        // distributed `finalize` process too, which never saw the schema.
+        let names = self.rest_index_names().await?;
+        if names.is_empty() {
+            tracing::warn!("no indexes found on {self}; nothing to wait for");
+            return Ok(Instant::now());
+        }
+
+        let start = Instant::now();
+        let mut pending_zero_since: Option<Instant> = None;
+        loop {
+            if start.elapsed() >= TIMEOUT {
+                return Err(StoreError::Other(format!(
+                    "timed out after {}s waiting for milvus index build on {self}",
+                    TIMEOUT.as_secs()
+                )));
+            }
+
+            let (indexed, total, pending, all_finished) = self.rest_index_progress(&names).await?;
+
+            // pending_index_rows == 0, every index Finished, held over the window.
+            let converged = all_finished && pending == 0;
+            tracing::info!(
+                "{self} index build: indexed_rows={indexed} total_rows={total} \
+                 pending_index_rows={pending} finished={all_finished}"
+            );
+
+            if converged {
+                let since = *pending_zero_since.get_or_insert_with(Instant::now);
+                if since.elapsed() >= PENDING_ZERO_HOLD {
+                    tracing::info!(
+                        "{self} index build converged (indexed_rows={indexed}, \
+                         pending_index_rows held 0 for {}s)",
+                        PENDING_ZERO_HOLD.as_secs()
+                    );
+                    // Sanity-check the built index against what we requested. This
+                    // runs AFTER `since` (the converged instant we return), so the
+                    // caller's build-time measurement excludes it.
+                    self.verify_indexes().await?;
+                    // Explicitly load the collection into memory so it's queryable.
+                    // Timed and reported SEPARATELY from the index build — the
+                    // returned `since` predates this, so `index_seconds`
+                    // excludes the load. Runs for both the enable-index and the
+                    // reindex flows (both end here).
+                    self.load_collection().await?;
+                    return Ok(since);
+                }
+            } else if pending_zero_since.take().is_some() {
+                // We thought it was done; Milvus went back to work. Restart the
+                // hold window — this is the "jumps back up" case.
+                tracing::warn!(
+                    "{self} index build regressed (indexed_rows={indexed}, \
+                     pending_index_rows={pending}, finished={all_finished}); \
+                     restarting {}s stability window",
+                    PENDING_ZERO_HOLD.as_secs()
+                );
+            }
+
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
+    async fn reindex(&self, schema: &CollectionSchema) -> Result<(), StoreError> {
+        // Milvus has no in-place index patch, so "reindex" = drop each vector
+        // index and rebuild it with the configured type/params/metric. The metric
+        // comes from config (the field's `vectors:` distance) when that field is
+        // configured; otherwise the field's existing metric is preserved. The
+        // subsequent `wait_for_indexing` waits for the rebuild + sanity-checks it.
+        let names = self.rest_index_names().await?;
+        if names.is_empty() {
+            tracing::warn!("{self}: no indexes to reindex");
+            return Ok(());
+        }
+
+        // Known Milvus issue: dropping and rebuilding an index can occasionally
+        // regress query performance. Observed up to Milvus 2.6.6; may be fixed in
+        // later builds — not something we can control, but worth flagging.
+        tracing::warn!(
+            "{self}: reindex drops and rebuilds each vector index. NOTE — Milvus has \
+             a known issue where drop+rebuild can occasionally hurt query \
+             performance (observed up to 2.6.6, possibly fixed since). See \
+             https://github.com/milvus-io/milvus/discussions/47149"
+        );
+
+        // An index can't be dropped while the collection is loaded (a prior load —
+        // e.g. from `enable_indexing`/`wait_for_indexing` — leaves it in memory),
+        // so release it first. `wait_for_indexing` reloads it after the rebuild.
+        // Best-effort: releasing an unloaded collection is a harmless no-op.
+        if let Err(e) =
+            self.rest_post("collections/release", json!({ "collectionName": self.collection_name }))
+                .await
+        {
+            tracing::debug!("{self}: release before reindex was a no-op or failed: {e}");
+        }
+
+        let mut expected = Vec::with_capacity(names.len());
+        for index_name in &names {
+            let info = self
+                .rest_describe(index_name)
+                .await?
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    StoreError::Other(format!("reindex: index `{index_name}` vanished on {self}"))
+                })?;
+            let field = info.field_name;
+            let old_type = info.index_type;
+            // New metric from config if the field is a configured vector; else keep
+            // the existing one (reindex is usually about the index type, not the
+            // distance, but honor a changed `vectors:` distance when present).
+            let metric = match schema.vectors.get(&field) {
+                Some(spec) => rest_metric(spec.distance.as_deref()).to_string(),
+                None => info.metric_type,
+            };
+
+            tracing::info!(
+                "{self}: reindexing `{index_name}` on field `{field}`: \
+                 index_type {old_type} → {}, metric_type → {metric}",
+                self.index_type
+            );
+            self.rest_post(
+                "indexes/drop",
+                json!({ "collectionName": self.collection_name, "indexName": index_name }),
+            )
+            .await?;
+            self.rest_create_index(&field, index_name, &metric).await?;
+
+            expected.push(ExpectedIndex {
+                field_name: field,
+                index_name: index_name.clone(),
+                index_type: self.index_type.clone(),
+                metric_type: metric,
+                params: self.params_to_verify(),
+            });
+        }
+        *self.expected_indexes.lock().expect("index lock") = expected;
         Ok(())
     }
 

--- a/crates/nova-load/src/stores/mod.rs
+++ b/crates/nova-load/src/stores/mod.rs
@@ -126,7 +126,12 @@ pub trait VectorStore: Send + Sync + std::fmt::Display {
     async fn defer_indexing(&self) -> Result<(), StoreError>;
 
     /// Re-enable indexing after bulk load. Called after all upserts complete.
-    async fn enable_indexing(&self) -> Result<(), StoreError>;
+    /// Receives the same [`CollectionSchema`] passed to `ensure_collection` so
+    /// backends that defer index *creation* until the data is in (e.g. Milvus,
+    /// which loads into an unindexed collection and builds the index here) have
+    /// the vector specs + dims on hand — the caller re-derives it in the
+    /// distributed `finalize` step, which never called `ensure_collection`.
+    async fn enable_indexing(&self, schema: &CollectionSchema) -> Result<(), StoreError>;
 
     /// Block until indexing is complete. Called after enable_indexing().
     ///
@@ -134,14 +139,43 @@ pub trait VectorStore: Send + Sync + std::fmt::Display {
     /// ultimately held long enough to be accepted as converged.
     async fn wait_for_indexing(&self) -> Result<std::time::Instant, StoreError>;
 
-    /// Patch index-affecting collection settings (HNSW/quantization/optimizer
-    /// overrides, from this store's own config) on an *already-existing*
-    /// collection, in place — does not touch data. Callers that need to block
-    /// until the change has reconverged should call [`wait_for_indexing`]
-    /// (`VectorStore::wait_for_indexing`) afterward, same as the existing
-    /// `enable_indexing`/`wait_for_indexing` split. Backends that can't patch
-    /// in place must still implement this explicitly (e.g. as a no-op).
-    async fn reindex(&self) -> Result<(), StoreError>;
+    /// Log a one-line indexing-time report after a load's `wait_for_indexing`.
+    /// `effective` is the converged instant minus when indexing was kicked off
+    /// (build time, excluding the stability hold). Default: report it as
+    /// `index_seconds` — correct for backends that build the index *after*
+    /// the upload (Qdrant, Milvus). Backends whose real cost is NOT in this
+    /// window — Elasticsearch builds the HNSW graph inline during ingest, so the
+    /// post-load window is ~0 — override this to report a meaningful figure.
+    ///
+    /// CAVEAT — these timings are NOT directly comparable across backends. Each
+    /// vector store accounts for "indexing time" differently, so treat the
+    /// numbers as within-backend signals, not an apples-to-apples benchmark:
+    ///   - Qdrant / Milvus: `index_seconds` = a distinct post-upload index build
+    ///     we time directly (Qdrant defers HNSW; Milvus builds after insert).
+    ///   - Elasticsearch: builds the graph inline *during* ingest, so
+    ///     `index_seconds` is ES's own `index_time` stat (fused ingest+build),
+    ///     not the post-upload window — and ingest cost is really in the loader's
+    ///     throughput (`pts/s`), not here.
+    ///   - Milvus also reports a separate `load_seconds` (pulling the index into
+    ///     memory) that the others have no equivalent of.
+    async fn report_index_time(&self, effective: std::time::Duration) {
+        tracing::info!(
+            "{self} indexing finished: index_seconds={:.3}",
+            effective.as_secs_f64()
+        );
+    }
+
+    /// Re-apply index settings from config to an *already-existing* collection —
+    /// does not touch data. Backends patch in place where they can (Qdrant:
+    /// HNSW/quantization/optimizer overrides); where they can't (Milvus), this
+    /// drops and rebuilds the index with the configured type/params/metric.
+    /// Receives the [`CollectionSchema`] so backends can read per-vector settings
+    /// (e.g. Milvus's metric from the distance). Callers that need to block until
+    /// the change reconverges should call [`wait_for_indexing`]
+    /// (`VectorStore::wait_for_indexing`) afterward, same as the
+    /// `enable_indexing`/`wait_for_indexing` split. Backends that can't patch in
+    /// place and have nothing to rebuild must still implement this (e.g. no-op).
+    async fn reindex(&self, schema: &CollectionSchema) -> Result<(), StoreError>;
 
     /// Delete the collection if it exists. A no-op if it doesn't.
     async fn delete_collection(&self) -> Result<(), StoreError>;

--- a/crates/nova-load/src/stores/qdrant.rs
+++ b/crates/nova-load/src/stores/qdrant.rs
@@ -519,6 +519,84 @@ impl From<Point> for PointStruct {
     }
 }
 
+impl QdrantStore {
+    /// Sanity check: confirm the collection's live config reflects the HNSW and
+    /// optimizer index params we requested. Every field set in config must match
+    /// what `collection_info` reports; unset fields are skipped (Qdrant keeps its
+    /// defaults). Runs after indexing settles in `wait_for_indexing`.
+    async fn verify_params(&self) -> Result<(), StoreError> {
+        if self.params.hnsw.is_none() && self.params.optimizers.is_none() {
+            return Ok(());
+        }
+        let config = self
+            .client
+            .collection_info(self.collection_name.as_str())
+            .await?
+            .result
+            .and_then(|r| r.config);
+
+        if let Some(want) = &self.params.hnsw {
+            let live = config.as_ref().and_then(|c| c.hnsw_config.clone()).unwrap_or_default();
+            self.check_u64("hnsw.m", want.m, live.m)?;
+            self.check_u64("hnsw.ef_construct", want.ef_construct, live.ef_construct)?;
+            self.check_u64(
+                "hnsw.full_scan_threshold",
+                want.full_scan_threshold,
+                live.full_scan_threshold,
+            )?;
+            self.check_u64(
+                "hnsw.max_indexing_threads",
+                want.max_indexing_threads,
+                live.max_indexing_threads,
+            )?;
+            self.check_u64("hnsw.payload_m", want.payload_m, live.payload_m)?;
+            if let Some(w) = want.on_disk
+                && live.on_disk != Some(w)
+            {
+                return Err(StoreError::Other(format!(
+                    "sanity check FAILED on {self} hnsw.on_disk: requested {w} but live \
+                     config has {:?}",
+                    live.on_disk
+                )));
+            }
+        }
+
+        if let Some(want) = &self.params.optimizers {
+            let live = config.as_ref().and_then(|c| c.optimizer_config.clone()).unwrap_or_default();
+            self.check_u64(
+                "optimizers.indexing_threshold",
+                want.indexing_threshold,
+                live.indexing_threshold,
+            )?;
+            self.check_u64(
+                "optimizers.default_segment_number",
+                want.default_segment_number,
+                live.default_segment_number,
+            )?;
+            self.check_u64(
+                "optimizers.max_segment_size",
+                want.max_segment_size,
+                live.max_segment_size,
+            )?;
+            self.check_u64("optimizers.memmap_threshold", want.memmap_threshold, live.memmap_threshold)?;
+        }
+
+        tracing::info!("{self} index params verified against live collection config");
+        Ok(())
+    }
+
+    fn check_u64(&self, field: &str, want: Option<u64>, got: Option<u64>) -> Result<(), StoreError> {
+        if let Some(w) = want
+            && got != Some(w)
+        {
+            return Err(StoreError::Other(format!(
+                "sanity check FAILED on {self} {field}: requested {w} but live config has {got:?}"
+            )));
+        }
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl VectorStore for QdrantStore {
     async fn ensure_collection(&self, schema: &CollectionSchema) -> Result<(), StoreError> {
@@ -570,7 +648,7 @@ impl VectorStore for QdrantStore {
         Ok(())
     }
 
-    async fn enable_indexing(&self) -> Result<(), StoreError> {
+    async fn enable_indexing(&self, _schema: &CollectionSchema) -> Result<(), StoreError> {
         let threshold = self
             .params
             .optimizers
@@ -617,6 +695,10 @@ impl VectorStore for QdrantStore {
             if is_green {
                 let since = *green_since.get_or_insert_with(Instant::now);
                 if since.elapsed() >= GREEN_HOLD {
+                    // Sanity-check the live config against the requested index
+                    // params. Runs after `since` (the converged instant we
+                    // return), so it's not counted in the caller's build timing.
+                    self.verify_params().await?;
                     return Ok(since);
                 }
             } else {
@@ -627,7 +709,7 @@ impl VectorStore for QdrantStore {
         }
     }
 
-    async fn reindex(&self) -> Result<(), StoreError> {
+    async fn reindex(&self, _schema: &CollectionSchema) -> Result<(), StoreError> {
         let builder = build_update_collection(&self.collection_name, &self.params)
             .map_err(|e| StoreError::Other(e.to_string()))?;
         self.client.update_collection(builder).await?;

--- a/docs/loading/overview.md
+++ b/docs/loading/overview.md
@@ -205,6 +205,24 @@ JSON-string columns that parse to a dict are automatically unpacked into the pay
 4. **Deferred indexing** -- HNSW construction is disabled during load, then built in one pass
 5. **Per-file resilience** -- each file's download + read is retried (`file_retries`, default 3) with exponential backoff; a file that still fails is logged and **skipped** so one bad object can't abort the whole load. `max_failed_files` caps how many skips are tolerated before aborting.
 
+## Indexing time in the logs
+
+After the upload each backend logs `indexing finished: index_seconds=…` (and `reindex`
+logs `reindex timing: index_seconds=…`). **These numbers are not directly comparable
+across backends** — each vector store accounts for indexing time differently, so treat
+`index_seconds` as a within-backend signal (e.g. comparing index/quantization variants
+on the same store via `reindex`), not an apples-to-apples cross-system benchmark:
+
+- **Qdrant / Milvus** — `index_seconds` is a distinct *post-upload* index build, timed
+  directly (Qdrant defers HNSW during load then builds it in one pass; Milvus builds the
+  index after inserting). Milvus additionally logs a separate `load_seconds` for pulling
+  the built index into memory — a step Qdrant and Elasticsearch have no equivalent of.
+- **Elasticsearch** — builds the HNSW graph *inline during ingestion*, so there is no
+  separate build phase to time. `index_seconds` there is Elasticsearch's own `index_time`
+  stat (a fused ingest+build figure); the parenthetical `merge-settle` is only how long
+  the post-load wait for background merges took (usually ~0). The ingestion cost itself
+  shows up in the loader's throughput lines (`… pts/s`).
+
 ## Tuning
 
 | Parameter | Default | Guidance |


### PR DESCRIPTION
# nova-load: make Milvus + Elasticsearch backends functional; unify indexing lifecycle

## Summary

The feature-gated `elastic` and `milvus` load backends (from PR #28) had
bit-rotted against the `VectorStore` trait — they were missing indexing-lifecycle
methods the trait had grown since, so they didn't even compile behind their
features (default-feature CI never built them). This PR gets both working
end-to-end against live instances and, along the way, brings **all three**
backends (Qdrant / Milvus / Elasticsearch) to **similar indexing
semantics**: each reaches a genuine steady state before declaring "done", each
sanity-checks that the index config it asked for is what the store actually
built, and each reports a timing figure appropriate to how it builds indexes.

All work was validated against local Docker instances (Milvus 2.4.15,
Elasticsearch 8.15, Qdrant): loads, distributed `prepare`/`load`/`finalize`,
reindexes, kNN self-hit queries, and a negative test proving the sanity checks
actually fail on a mismatch. 57 unit tests pass; both default and
`--features elastic,milvus` builds are clean.

## Motivation

- The elastic/milvus backends didn't compile — `enable_indexing`,
  `wait_for_indexing`, `reindex`, `defer_indexing` were absent.
- Even where they "worked," semantics were wrong or misleading: Milvus mapped
  cosine → inner-product (the SDK enum has no `COSINE`), Elasticsearch's
  "wait for indexing" was a bare `_refresh` (which does **not** mean indexing
  reached a steady state), and there was no confirmation that a requested index
  config was actually applied.

## Cross-cutting changes

- **Trait**: `enable_indexing(&self, &CollectionSchema)` and
  `reindex(&self, &CollectionSchema)` now receive the schema so backends can read
  per-vector settings (metric, dims). `finalize`/`reindex` build the schema
  without resolving dims (nothing creates fields in those phases), so they no
  longer need to reach the datasource.
- **Per-backend sanity check**: after indexing converges, each backend re-reads
  the live index config and confirms it matches what was requested. A mismatch is
  a hard `sanity check FAILED …` error, not a silent pass.
- **Timing**: a `report_index_time` trait method emits one `indexing finished:
  index_seconds=…` line per backend (and `reindex timing: index_seconds=…` for
  reindex). The label is uniform, but the number is **not** cross-comparable —
  each store accounts for indexing time differently (see the caveat below), which
  is documented both in code (the `report_index_time` doc comment) and in
  `docs/loading/overview.md`.

## Milvus (`crates/nova-load/src/stores/milvus_store.rs`)

Reworked into a bulk-load shape and moved index create/describe/drop + progress
to Milvus's **REST API**, because the vendored `milvus-sdk-rust 0.1.0` is too old
for two things: its `MetricType` enum has no `COSINE` (and its
`From<IndexDescription>` would *panic* on one), and its proto drops
`pending_index_rows`. Everything else (collection create / insert / flush / load)
still uses the gRPC SDK.

- **Unindexed load**: `ensure_collection` creates the collection with **no index**
  (no per-insert index cost); `enable_indexing` flushes and builds the index; then
  the collection is explicitly **loaded** into memory so it's queryable.
- **Real COSINE + configurable index**: `index_type` (default `AUTOINDEX`) and
  `index_params` (e.g. `{M, efConstruction}` / `{nlist}`) are passed through to
  the REST index-create; distance maps to the true metric (`cosine → COSINE`,
  `euclid → L2`, `dot → IP`).
- **Steady-state wait**: `wait_for_indexing` polls REST `indexes/describe` until
  every index is `Finished` **and** `pending_index_rows == 0`, held for 30s
  (Milvus can report "done" then keep indexing). Handles the empty-collection and
  transient-stale cases; bounded by a timeout.
- **Separate load timing**: the index build is `index_seconds`; pulling the built
  index into memory is a separate `load_seconds` line.
- **reindex**: release → drop → rebuild with the configured type/params, then
  reload. Logs the known Milvus drop+rebuild perf-regression note
  (milvus-io/milvus discussions/47149).
- **Verification**: `index_type`/`metric_type` via REST describe, plus build
  params (`M`/`efConstruction`/`nlist`) read from a **raw gRPC `DescribeIndex`**
  (REST omits them; the raw KV list carries them and avoids the COSINE-panic path).

## Elasticsearch (`crates/nova-load/src/stores/elastic.rs`)

- **Genuine steady state**: `wait_for_indexing` no longer just refreshes — it
  refreshes, then polls `_stats` `merges.current` until background merges settle
  to 0 (held 5s), the ES analog of Qdrant's green status / Milvus's pending rows.
- **Inline-build timing**: ES builds the HNSW graph inline during ingest, so it
  reports ES's own `index_time_in_millis` as `index_seconds` (with the post-load
  merge-settle shown parenthetically). Documented that ES has no "defer indexing
  during upload" knob — `defer_indexing` sets `refresh_interval: -1` (reduces
  flush churn), the recommended bulk-load setting.
- **Configurable `index_options`** on the `dense_vector` mapping (e.g.
  `{type: int8_hnsw, m, ef_construction}`).
- **reindex** (in-place): Update Mapping with the new `index_options` (ES enforces
  legality, e.g. HNSW `m` may only increase) + an async force-merge to re-encode
  existing vectors. Changing the immutable `similarity`/`dims` errors clearly
  ("needs a new index + the `_reindex` API").
- **Verification**: re-reads the live mapping and subset-checks `similarity` +
  every configured `index_options` key.

## Qdrant (`crates/nova-load/src/stores/qdrant.rs`)

- **Verification** added (`verify_params`): after the collection reaches green,
  re-reads `collection_info` and confirms the requested HNSW
  (`m`/`ef_construct`/`full_scan_threshold`/`max_indexing_threads`/`on_disk`/`payload_m`)
  and optimizer overrides match the live config. Wait/reindex behavior otherwise
  unchanged.

## Dependency

- Adds `reqwest` (`rustls-tls`, `json`), **optional and gated behind the `milvus`
  feature** — used only for Milvus's REST calls. Already present transitively, so
  no default-build impact; default build stays reqwest-free at runtime.

## The cross-system timing caveat

`index_seconds` is a **within-backend** signal, not an apples-to-apples benchmark:

- **Qdrant / Milvus** build the index as a distinct post-upload step we time
  directly (Milvus also reports a separate `load_seconds`).
- **Elasticsearch** builds inline during ingest, so `index_seconds` is ES's own
  fused ingest+build stat; ingestion cost really shows up in the loader's
  throughput (`… pts/s`).

## Testing (all against live Docker instances)

- **Milvus**: single-node `run`, distributed `prepare`/`load`/`finalize`, reindex
  (IVF_FLAT → HNSW), real COSINE, `index_seconds` + `load_seconds`, queryable with
  no manual load. HNSW `{M, efConstruction}` and IVF `{nlist}` params verified via
  gRPC; AUTOINDEX verifies type+metric only.
- **Elasticsearch**: `run` + reindex (hnsw m 16→32, int8_hnsw), merges-settled
  wait (200k-doc load confirmed the merge detection fires during a force-merge),
  `index_time` reporting, immutable-similarity guard.
- **Qdrant**: `run` + reindex (m 16→32), full 6-field HNSW param verification.
- **Negative test**: loaded Milvus with `M=16`, re-ran with `M=32 recreate:false`
  → `sanity check FAILED … requested M=32 but built index reports M=16` (reads the
  store's actual reported value, independent of the request).
- **Queries**: kNN self-hit returns the query point at score ~1.0 on all three.
- 57 unit tests pass; `cargo build -p nova-load` and
  `cargo build -p nova-load --features elastic,milvus` both clean.

## Notes / follow-ups

- Milvus's raw-gRPC param read is unauthenticated (best-effort with a warn
  fallback); authenticated Milvus would verify type+metric only. Fine for the
  current experimental scope.
- Building with `--features milvus` requires `protoc` (the milvus SDK's build
  script compiles protos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
