### PR TITLE
Worktree multivector bf

### DIFF
--- a/docs/brute-force/multivector-maxsim.md
+++ b/docs/brute-force/multivector-maxsim.md
@@ -75,6 +75,25 @@ never pays it.
   `exact=True`, asserted to match nova-bf's top-K ids **and** scores (boundary-aware
   tolerance) for both dot and cosine. Skips cleanly without docker/`qdrant-client`.
 
+## Known, benign divergence from Qdrant (cosine, sub-normal magnitudes)
+
+Under `cosine`, nova-bf L2-normalizes every token down to a `1e-12` floor —
+the mathematically exact, scale-invariant cosine. Qdrant applies a **low-norm
+guard**: a token vector whose norm is above ~`1e-3` is normalized as expected,
+but below that Qdrant leaves it *unnormalized* and scores the raw dot instead
+(verified by a magnitude sweep on a live `MAX_SIM` cosine collection: a doc
+equal to the query direction scores `≈1.0` down to magnitude `1e-3`, then
+`≈magnitude` from `1e-4` on down). So for any token with norm in roughly
+`(0, 1e-3)` the two engines diverge — nova gives the true cosine, Qdrant gives
+~0.
+
+This never manifests on real data: dense/ColBERT token vectors have O(1)
+magnitudes, far above the guard. An *exactly*-zero token agrees (both → 0).
+`dot` is unaffected (no normalization). nova deliberately does **not** replicate
+Qdrant's threshold — it's undocumented, version-specific, and matching it would
+make nova less correct for the realistic case. The unit test
+`test_cosine_is_scale_invariant` pins nova's chosen semantics.
+
 ## Profiling & performance
 
 CPU-only box (no GPU here; `torch.cuda.is_available()` is False). Representative

--- a/docs/brute-force/multivector-maxsim.md
+++ b/docs/brute-force/multivector-maxsim.md
@@ -160,17 +160,44 @@ matmul-bound (irreducible exact-MaxSim FLOPs, optimally laid out) and the one
 non-trivial auxiliary reduction already uses the fastest available primitive.
 The only landed change is a memory reduction that is time-neutral here.
 
-### Likely GPU-specific findings (NOT validated on this box)
+### GPU validation — live A10G run (measured, not hypothesized)
 
-- The matmul will collapse to a small fraction on a GPU (cuBLAS / tensor-core
-  friendly), which will make the **segment-max the dominant cost on GPU**.
-- `scatter_reduce_(amax)` on GPU uses atomics with per-doc contention
-  (~tokens/doc-way). The **pad-to-max + dense `.amax(dim)`** variant — which
-  loses badly on CPU — has *no atomic contention* and may well **win on GPU**.
-  It is a good experiment to run on real hardware; it was deliberately **not**
-  landed here because it regresses 3× on CPU (the path tests and small runs use)
-  and cannot be validated without a GPU.
-- Prefer the **largest** `multivector_query_block` / `multivector_batch_size`
-  that fits VRAM: smaller query blocks add ~16% overhead (measured at block=4)
-  from extra Python-loop iterations and kernel launches, with no memory benefit
-  beyond the bound they enforce.
+Launched a single **g5.xlarge (NVIDIA A10G, 24 GB)** via SkyPilot, CUDA 13.0 /
+`torch 2.13.0+cu130`, ran the BRANCH (synced workdir, `PYTHONPATH=src` — never
+master), then tore the instance down.
+
+**Correctness on GPU — all green:** the 23 multivector unit tests (whose
+`run_compute` executes on `cuda`), the **2 live-Qdrant `MAX_SIM` parity tests**
+(dot + cosine, exact search), and the profiler's own dot+cosine × tilings
+spot-check (including a zero-token doc) all pass on the real GPU + CUDA path.
+
+**Component split at D=1024 — the CPU/GPU flip the hypotheses predicted:**
+
+| component | CPU (D=1024) | GPU A10G (D=1024) |
+|---|--:|--:|
+| matmul `Q @ C.T` | 94% | **65.7%** (13.5 ms) |
+| segment-max `scatter_reduce(amax)` | 6% | **34.1%** (7.0 ms) |
+| segment-sum `index_add_` | ~0% | 0.2% (0.04 ms) |
+
+cuBLAS collapses the matmul's share from 94% → 66%, so — as predicted —
+**segment-max becomes the prominent secondary cost on GPU** (34%).
+
+**The `pad-to-max + dense .amax` hypothesis: CONFIRMED on GPU.** It ran **6.03 ms
+vs scatter_reduce's 7.02 ms — ~14% faster** on the segment-max (bit-equivalent),
+the exact *opposite* of CPU (where it lost 3×). No atomic contention on GPU is
+the reason. **Still not landed as the default**, though: the win is ~14% of a
+34% component (~5% end-to-end), and the padded buffer is `block_q_tokens ×
+n_rows × max_tokens_per_doc` — fine here (`max_tok`=49, mean 40) but a real
+corpus with a long doc-length tail (mean 80, max 512) blows that buffer up ~6×
+and wastes the amax on mostly-`-inf` padding. `scatter_reduce` stays the robust
+default (no skew blowup, works on CPU + GPU); pad+amax is a good **opt-in / adaptive**
+follow-up for GPU runs on tight token-length distributions.
+
+**The removed host-sync guard — validated:** the `bool((counts==0).any())` guard
+(dropped in Round 3) cost **0.037 ms/call vs 0.026 ms/call** unconditional
+(~30% on that op) on GPU, confirming it was a real per-query-block device→host
+sync. Neutral on CPU, small but real win on GPU — the reason it was worth removing.
+
+**Tiling:** `query_block=None` (45 ms) is fastest; smaller blocks are marginally
+slower (48 ms at block=8) — same as CPU. The knobs are for memory-bounding only;
+prefer the largest that fits VRAM.

--- a/docs/brute-force/multivector-maxsim.md
+++ b/docs/brute-force/multivector-maxsim.md
@@ -1,0 +1,157 @@
+# Multivector (ColBERT / late-interaction MaxSim) ground truth in nova-bf
+
+nova-bf now computes exact top-K ground truth for **multivector** searches —
+ColBERT-style late interaction, scored with **MaxSim**:
+
+```
+score(query q, doc d) = Σ over q's tokens ( max over d's tokens ( q_tok · d_tok ) )
+```
+
+This matches Qdrant's `MultiVectorComparator::MaxSim` (dot by default; cosine
+normalizes every token first). It sits alongside the existing `dense` and
+`sparse` vector types and reuses the same read-once / share-across-searches
+engine — see the module docstring in `compute.py`.
+
+## Config
+
+```yaml
+corpus:
+  path: s3://…/pubmed/bge-m3
+  multivector_column: multivector_embedding   # list<list<float32>>: outer=doc, inner=token
+queries:
+  path: …/queries
+  multivector_column: multivector_embedding
+params:
+  # MaxSim has TWO memory axes (the per-slice score matrix is
+  # block_query_tokens × slice_doc_tokens), so BOTH are tiled:
+  multivector_batch_size: 2000     # docs per corpus-row slice
+  multivector_query_block: 16      # queries per query-axis tile (whole queries only)
+  # …or let a target element-count for that matrix derive both:
+  # multivector_token_budget: 50_000_000
+searches:
+  - name: mv
+    vector_type: multivector
+    metric: dot            # dot (Qdrant default) | cosine ; euclidean rejected
+    k: 1000
+```
+
+On-disk format is exactly what `nova-embed` writes
+(`MULTIVECTOR_EMBEDDING_TYPE = list<list<float32>>`). A null or zero-token doc
+decodes to a zero-width span and becomes a **non-candidate** (`-inf`), the same
+way a zero-overlap doc is a non-candidate in the sparse path — Qdrant's inverted
+MaxSim never surfaces a doc with no vectors either.
+
+## How it stays inside the existing engine
+
+The whole design principle is that `MultiVectorBatchSlice.score()` returns the
+**same `(n_q × n_rows)` score matrix** every other slice type returns, so
+`_merge_topk`, the shared per-file loop, filters (uniform + per-query), coalescing,
+and `merge` all work unchanged. All the ragged/tiling machinery is hidden inside
+`.score()`:
+
+1. `P = Q_block_tokens @ C_slice_tokens.T` — the token×token dot products.
+2. **segment-max** over each doc's tokens (`scatter_reduce_(amax)`, columns
+   grouped by doc) → `(block_tokens × n_rows)`.
+3. **segment-sum** over each query's tokens (`index_add_` straight into the
+   output view) → `(block_queries × n_rows)`.
+
+Unlike dense/sparse, the query axis **must** be tiled too: `P` is token×token, so
+the naïve all-queries × whole-file product blows up far faster than a pooled
+matmul. `multivector_batch_size` bounds the doc-token axis, `multivector_query_block`
+the query-token axis. `cosine` L2-normalizes every token before the matmul — a
+genuinely separate matmul, not a scalar rescale of the dot result (normalizing
+changes each token's per-token argmax), so it's opt-in cost; a `dot`-only run
+never pays it.
+
+## Validation
+
+- **Unit tests** (`tests/test_compute_multivector.py`): a hand-computed MaxSim
+  pinned exactly; tiling-invariance across `multivector_batch_size ×
+  multivector_query_block` (including tile=1 and tile>data) for dot and cosine;
+  null/empty docs as non-candidates; a uniform filter; the `make_point_id` path;
+  the token-budget auto-derivation; plus decoder tests (null/empty/sliced arrays).
+- **Live-Qdrant parity** (`tests/test_qdrant_multivector_parity.py`): a random
+  multivector dataset upserted into a Qdrant `MAX_SIM` collection, searched with
+  `exact=True`, asserted to match nova-bf's top-K ids **and** scores (boundary-aware
+  tolerance) for both dot and cosine. Skips cleanly without docker/`qdrant-client`.
+
+## Profiling & performance
+
+CPU-only box (no GPU here; `torch.cuda.is_available()` is False). Representative
+synthetic corpus, `OMP_NUM_THREADS=4`. Times are per-op, isolated.
+
+### Where the time goes (one scored slice: ~1.5k query tokens × ~158k doc tokens → 4000 docs)
+
+| component | time | share |
+|---|--:|--:|
+| `matmul` `Q @ C.T` | 348 ms | **75%** |
+| segment-max `scatter_reduce_(amax)` | 118 ms | 25% |
+| segment-sum | 0.3 ms | ~0% |
+| index building (`repeat_interleave`) | 0.1 ms | ~0% |
+
+`score()` end-to-end is 467 ms — i.e. **essentially all of it is the matmul plus
+the segment-max**, with no measurable overhead on top. End-to-end `run_compute`
+(24k docs, 8 files, k=100) is 3.9 s, of which `score()` is 2.9 s; decode
+(~65 ms/file) and IO overlap on the reader threads and do not bottleneck.
+
+### The matmul is irreducible, and grows with dim
+
+Exact MaxSim requires every (query-token, doc-token) dot product — there is no
+correctness-preserving way to skip any. And its share **grows** at production
+embedding width:
+
+| dim D | matmul | segment-max |
+|--:|--:|--:|
+| 128 | 71% | 29% |
+| 384 | 84% | 16% |
+| **1024** (BGE-M3 colbert) | **94%** | 6% |
+
+At the real embedding dim the score path is **94% matmul**. BLAS already handles
+the transposed-view RHS optimally: `Q @ C.T` (view) == `Q @ C.T.contiguous()`
+within noise, and the contiguous form additionally pays a 25 ms transpose — so
+there is nothing to win there.
+
+### What was tried for the 6–25% segment-max, and rejected
+
+| alternative | result |
+|---|---|
+| `torch.segment_reduce(max)` (contiguous segments) | **3× slower** on CPU (350 vs 116 ms) |
+| pad-to-max-tokens + `.amax(dim=2)` | **3× slower** on CPU (365 vs 118 ms) **and** ~1.2 GB scratch |
+
+`scatter_reduce_(amax)` is the fastest CPU primitive for this ragged reduction,
+so it stays.
+
+### The change that was landed
+
+**Segment-sum via `index_add_` written straight into the output view**, instead
+of allocating a separate `(block_queries × n_rows)` buffer and copying it in.
+
+- Verified bit-equivalent to the previous `scatter_reduce_(sum)` path.
+- CPU time: **neutral** (segment-sum is <1% of the total; the component itself is
+  ~7% faster, 0.246 → 0.229 ms — noise end-to-end).
+- **The reason it's worth it is memory, for the GPU target**: at scale
+  (`n_q`=100k, a large corpus batch) that eliminated temporary equals the
+  output-slice size — a multi-GB transient on the GPU. Removing it gives the
+  tiling knobs more headroom.
+
+### Honest bottom line
+
+On this CPU box there is **no meaningful speedup available**: the path is
+matmul-bound (irreducible exact-MaxSim FLOPs, optimally laid out) and the one
+non-trivial auxiliary reduction already uses the fastest available primitive.
+The only landed change is a memory reduction that is time-neutral here.
+
+### Likely GPU-specific findings (NOT validated on this box)
+
+- The matmul will collapse to a small fraction on a GPU (cuBLAS / tensor-core
+  friendly), which will make the **segment-max the dominant cost on GPU**.
+- `scatter_reduce_(amax)` on GPU uses atomics with per-doc contention
+  (~tokens/doc-way). The **pad-to-max + dense `.amax(dim)`** variant — which
+  loses badly on CPU — has *no atomic contention* and may well **win on GPU**.
+  It is a good experiment to run on real hardware; it was deliberately **not**
+  landed here because it regresses 3× on CPU (the path tests and small runs use)
+  and cannot be validated without a GPU.
+- Prefer the **largest** `multivector_query_block` / `multivector_batch_size`
+  that fits VRAM: smaller query blocks add ~16% overhead (measured at block=4)
+  from extra Python-loop iterations and kernel launches, with no memory benefit
+  beyond the bound they enforce.

--- a/docs/brute-force/multivector-maxsim.md
+++ b/docs/brute-force/multivector-maxsim.md
@@ -201,3 +201,41 @@ sync. Neutral on CPU, small but real win on GPU — the reason it was worth remo
 **Tiling:** `query_block=None` (45 ms) is fastest; smaller blocks are marginally
 slower (48 ms at block=8) — same as CPU. The knobs are for memory-bounding only;
 prefer the largest that fits VRAM.
+
+### GPU optimization sweep — realistic scale (A10G), what to land
+
+A second A10G run benchmarked the two candidate optimizations at realistic
+ColBERT scale (D=1024, ~356k doc-tokens/slice), measuring speed, memory, and —
+critically for a GT tool — whether they preserve the ranking / Qdrant parity.
+
+**(a) Matmul precision — the 66% lever. TF32 landed as opt-in; bf16 rejected.**
+
+| matmul | time | speedup | median rel err | top-100 vs f32 | Qdrant parity |
+|---|--:|--:|--:|--:|--:|
+| f32 (default) | 41.9 ms | 1.0× | — | — | ✅ |
+| **TF32** | 24.0 ms | **1.75×** | 2.9e-4 | **100/100** | ✅ **still passes** |
+| bf16 | 15.9 ms | 2.63× | 2.9e-3 | 100/100 | (not run) |
+
+TF32 is 1.75× on the matmul (~1.4× on the score path) and — decisively — the
+**live-Qdrant MaxSim parity test still passes with TF32 enabled**, with zero
+top-100 ranking change. It is now exposed as **`params.allow_tf32`** (default
+**off** — GT stays bit-exact f32; on = the measured speedup at ~3e-4 relative
+error). bf16 is faster still but its `max|Δ|` was 0.75 (8-bit mantissa) — too
+coarse to trust for exact GT, so it is not exposed.
+
+**(b) Segment-max `pad+amax` — rejected.** The earlier "14% faster on GPU"
+held only at an artificially small `max_tok` (49). At realistic doc-length
+distributions it does not survive:
+
+| distribution | max_tok | scatter_reduce | pad+amax |
+|---|--:|--:|--:|
+| tight (mean 120) | 168 | 26.8 ms / 8.1 GB | 25.7 ms / 10.2 GB (1.04×, 1.3× mem) |
+| **skewed (mean 80, 5% tail→512)** | 512 | 20.7 ms / 7.6 GB | **37.9 ms / 13.9 GB (0.55×, 1.8× mem)** |
+
+Real corpora have a doc-length tail, so `pad+amax` is a wash at best and **1.8×
+slower + 1.8× more memory** under skew (it pads every doc to the longest and
+`amax`es over mostly-`-inf`). `scatter_reduce` stays the default; `pad+amax` is
+**not** landed.
+
+Net: the one landed GPU optimization is the opt-in `allow_tf32` knob (~1.4× on
+the score path when enabled), plus the already-landed host-sync removal.

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -133,7 +133,7 @@ from nova_bf.config import BruteForceConfig, Filter, FilterCondition, SearchSpec
 from nova_bf.filters import _condition_mask, _match_any_membership, _static_first, evaluate
 from nova_bf.dates import convert_table_date_columns, normalize_date_fields
 from nova_bf.ids import make_point_id
-from nova_bf.io import ParquetFile, Store, dense_to_2d, sparse_to_coo_parts
+from nova_bf.io import ParquetFile, Store, dense_to_2d, multivector_to_ragged, sparse_to_coo_parts
 from nova_bf.results import build_result_table, partial_dir, result_name, warn_if_short
 
 logger = logging.getLogger(__name__)
@@ -405,6 +405,76 @@ def _compact_sparse_rows(
     new_row_offsets = np.concatenate(([0], np.cumsum(np.diff(row_offsets)[orig_rows]))).astype(np.int64)
     new_norms = norms[orig_rows] if norms is not None else None
     return new_row_offsets, new_indices, new_values, new_norms, orig_rows
+
+
+def load_queries_multivector(
+    store: Store, qcfg, filter_cols: list[str] = (),
+) -> tuple[np.ndarray, np.ndarray, list[str], dict[str, list], dict[str, np.ndarray]]:
+    """Multivector analog of `load_queries`/`load_queries_sparse`: reads the
+    `list<list<float32>>` column from every query file and stacks all queries'
+    token vectors into one flat `(total_query_tokens, D)` matrix plus a
+    length-`n_q+1` token-offset array (`doc_offsets` semantics, query side).
+    Queries are few, so holding every query token on the GPU at once is cheap;
+    the query axis is tiled at SCORE time (`multivector_query_block`), not
+    here. Returns `(flat_tokens, q_offsets, ids, payload, filter_vals)`."""
+    cols = [qcfg.multivector_column]
+    if qcfg.id_column:
+        cols.append(qcfg.id_column)
+    cols += [c for c in qcfg.payload_fields if c not in cols]
+    cols += [c for c in filter_cols if c not in cols]
+
+    tokens_parts: list[np.ndarray] = []
+    counts_parts: list[np.ndarray] = []  # tokens per query, per file
+    dim = 0
+    ids: list[str] = []
+    payload: dict[str, list] = {c: [] for c in qcfg.payload_fields}
+    filter_vals: dict[str, list] = {c: [] for c in filter_cols}
+    q_date_fmts = normalize_date_fields(qcfg.date_fields)
+    for f in store.list_parquets():
+        table = store.read_columns(f.read_path, cols)
+        d = table.to_pydict()  # ORIGINAL values — payload/id keep their source form
+        conv = convert_table_date_columns(table, q_date_fmts)
+        doc_offsets, flat = multivector_to_ragged(conv[qcfg.multivector_column])
+        if flat.shape[1] > 0:
+            dim = flat.shape[1]
+        tokens_parts.append(flat)
+        counts_parts.append(np.diff(doc_offsets))
+        n = len(doc_offsets) - 1
+        if qcfg.id_column:
+            ids += [str(x) for x in d[qcfg.id_column]]
+        else:
+            ids += [make_point_id(f.key, r) for r in range(n)]
+        for c in qcfg.payload_fields:
+            payload[c] += d[c]
+        for c in filter_cols:
+            filter_vals[c] += conv[c].to_pylist()
+
+    # A file whose queries are all zero-token decodes to a (0, 0) `flat`; drop
+    # those empty shards before concat so the width is the real token dim, and
+    # fall back to a (0, dim) empty matrix if EVERY query is zero-token.
+    nonempty = [t for t in tokens_parts if t.shape[0] > 0]
+    flat_tokens = (
+        np.concatenate(nonempty, axis=0) if nonempty else np.zeros((0, dim), np.float32)
+    )
+    counts = np.concatenate(counts_parts) if counts_parts else np.zeros(0, np.int64)
+    q_offsets = np.concatenate(([0], np.cumsum(counts))).astype(np.int64)
+    return flat_tokens, q_offsets, ids, payload, {c: _to_query_array(v) for c, v in filter_vals.items()}
+
+
+def _compact_multivector_rows(
+    doc_offsets: np.ndarray, flat_tokens: np.ndarray, keep: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Row-level filter compaction for ragged multivector parts — the
+    token-granular analog of `_compact_sparse_rows`. Whole per-doc token spans
+    are gathered by offset; dropped docs' tokens are dropped too, but surviving
+    docs' TRUE file-row numbers are preserved via `orig_rows` (the same
+    invariant `make_point_id`/`id_column` resolution rely on). Returns
+    `(new_doc_offsets, new_flat_tokens, orig_rows)`."""
+    orig_rows = np.nonzero(keep)[0]
+    tok_keep = np.repeat(keep, np.diff(doc_offsets))
+    new_flat = flat_tokens[tok_keep]
+    new_doc_offsets = np.concatenate(([0], np.cumsum(np.diff(doc_offsets)[orig_rows]))).astype(np.int64)
+    return new_doc_offsets, new_flat, orig_rows
 
 
 def _remap_sparse_file(
@@ -803,6 +873,174 @@ def _concat_sparse_batches(batches: list[SparseCorpusBatch]) -> SparseCorpusBatc
     )
 
 
+@dataclass
+class MultiVectorQuery:
+    """The query side of a multivector (MaxSim) search, held on-device: every
+    query's token vectors stacked into one `(total_query_tokens, D)` matrix
+    (`flat`) plus a length-`n_q+1` token-offset array (`offsets`), so query `q`'s
+    tokens are `flat[offsets[q]:offsets[q+1]]`. This is what a spec's `Q` is for
+    a multivector search — passed through `_process_batch_group` unchanged to
+    `MultiVectorBatchSlice.score`, which tiles the query axis by whole queries
+    (`query_block`) to bound the per-slice score matrix. `n_q` is stored
+    explicitly because a trailing run of zero-token queries makes it
+    unrecoverable from `flat` alone."""
+
+    flat: object      # torch.Tensor (total_query_tokens, D)
+    offsets: object   # torch.Tensor (n_q + 1,) int64, on device
+    n_q: int
+    query_block: int | None  # queries per query-axis tile (None = all at once)
+
+
+def _segment_max_over_cols(P, col_group, n_groups: int):
+    """`P` is `(rows, n_cols)`; `col_group` maps each column to a group id in
+    `[0, n_groups)`. Returns `(rows, n_groups)` where entry `(r, g)` is the MAX
+    of `P[r, cols-in-group-g]`, or `-inf` for a group with no columns (a
+    zero-token doc — its `-inf` propagates through the later sum, marking it a
+    non-candidate exactly like the sparse no-overlap gate). Ragged segment-max
+    via `scatter_reduce_(amax)`, which runs on CPU and GPU alike."""
+    import torch
+
+    out = torch.full((P.shape[0], n_groups), float("-inf"), dtype=P.dtype, device=P.device)
+    idx = col_group.unsqueeze(0).expand(P.shape[0], -1)
+    out.scatter_reduce_(1, idx, P, reduce="amax", include_self=True)
+    return out
+
+
+class MultiVectorCorpusBatch:
+    """Decoded multivector corpus tokens for one file, ragged: `flat_tokens`
+    is `(total_tokens, D)` and `doc_offsets` (length `n_rows+1`) delimits each
+    doc's token span. Exposes the same `.n_rows`/`.nbytes`/`.compact`/
+    `.transfer` surface as `Dense`/`SparseCorpusBatch` so `run_compute`'s
+    per-file loop never branches on vector_type. `query_block` is carried
+    run-wide (like sparse `vocab`/`need_row_norms`) so `.transfer()` needs no
+    extra args and the slice knows how to tile the query axis."""
+
+    def __init__(self, doc_offsets: np.ndarray, flat_tokens: np.ndarray, query_block: int | None):
+        self.doc_offsets = doc_offsets
+        self.flat_tokens = flat_tokens
+        self.query_block = query_block
+
+    @property
+    def n_rows(self) -> int:
+        return len(self.doc_offsets) - 1
+
+    @property
+    def nbytes(self) -> int:
+        return int(self.flat_tokens.nbytes)
+
+    def compact(self, keep: np.ndarray) -> tuple["MultiVectorCorpusBatch", np.ndarray]:
+        doc_offsets, flat_tokens, orig_rows = _compact_multivector_rows(
+            self.doc_offsets, self.flat_tokens, keep
+        )
+        return MultiVectorCorpusBatch(doc_offsets, flat_tokens, self.query_block), orig_rows
+
+    def transfer(self, r0: int, r1: int, device: str) -> "MultiVectorBatchSlice":
+        import torch
+
+        t0, t1 = int(self.doc_offsets[r0]), int(self.doc_offsets[r1])
+        # doc_offsets for this slice, rebased so the slice's first token is 0.
+        local_off = torch.from_numpy(
+            (self.doc_offsets[r0 : r1 + 1] - t0).astype(np.int64, copy=False)
+        ).to(device, non_blocking=True)
+        flat = torch.from_numpy(self.flat_tokens[t0:t1]).to(device, non_blocking=True)
+        return MultiVectorBatchSlice(flat, local_off, self.query_block)
+
+
+@dataclass
+class MultiVectorBatchSlice:
+    """One on-device slice of a multivector corpus batch. `score()` computes
+    the MaxSim score matrix `(n_q, n_rows)` — the SAME shape every other
+    slice type returns, so `_merge_topk`, the shared loop, and merge all work
+    unchanged.
+
+    MaxSim(q, d) = sum over q's tokens of (max over d's tokens of q_tok . d_tok).
+    Computed per query-axis tile (whole queries only — a query's tokens never
+    split across tiles) so the intermediate `(block_query_tokens ×
+    slice_doc_tokens)` product `P` stays bounded (see `params.
+    multivector_query_block` / `multivector_batch_size`): P is the ONLY
+    matmul-sized intermediate, and unlike the pooled dense/sparse paths it's
+    token×token, which is why the query axis MUST be tiled too. Two ragged
+    segment reductions fold P down: max over each doc's tokens
+    (`_segment_max_over_cols`), then sum over each query's tokens (an
+    `index_add_` straight into the output view). A zero-token doc's `-inf`
+    survives both, marking it a non-candidate.
+
+    `dot` (Qdrant's default) uses the raw tokens; `cosine` L2-normalizes every
+    token (query and corpus) FIRST — genuinely a separate matmul, not a
+    scalar rescale of the dot result, because normalizing changes each token's
+    per-token argmax. The scoring runs once per distinct metric via
+    `_process_batch_group`'s `score_cache`, so a dot-only run never pays the
+    cosine normalization."""
+
+    flat: object       # torch.Tensor (slice_total_tokens, D)
+    doc_offsets: object  # torch.Tensor (n_rows + 1,) int64, rebased to 0
+    query_block: int | None = None
+
+    @property
+    def n_rows(self) -> int:
+        return self.doc_offsets.shape[0] - 1
+
+    def score(self, Q: "MultiVectorQuery", metric: str, q_norms=None):
+        import torch
+        import torch.nn.functional as F
+
+        dev = self.flat.device
+        n_rows = self.n_rows
+        n_q = Q.n_q
+        out = torch.full((n_q, n_rows), float("-inf"), dtype=self.flat.dtype, device=dev)
+        if n_rows == 0 or self.flat.shape[0] == 0:
+            return out  # no corpus tokens in this slice — every doc a non-candidate
+
+        C = F.normalize(self.flat, dim=1) if metric == "cosine" else self.flat
+        # Each corpus token column -> its doc id, for the segment-max.
+        col_doc = torch.repeat_interleave(
+            torch.arange(n_rows, device=dev), self.doc_offsets.diff()
+        )
+        qoff = Q.offsets
+        block = Q.query_block or n_q
+        for qs in range(0, n_q, block):
+            qe = min(qs + block, n_q)
+            t0, t1 = int(qoff[qs]), int(qoff[qe])
+            if t1 == t0:
+                continue  # every query in this block is zero-token; leave -inf
+            Qb = Q.flat[t0:t1]
+            if metric == "cosine":
+                Qb = F.normalize(Qb, dim=1)
+            P = Qb @ C.T                                   # (block_q_tokens, slice_doc_tokens)
+            M = _segment_max_over_cols(P, col_doc, n_rows)  # (block_q_tokens, n_rows)
+            # Segment-SUM over each query's tokens, written STRAIGHT into this
+            # block's output rows (zeroed first): `index_add_` into the `out`
+            # view avoids a separate `(block_queries × n_rows)` temporary — at
+            # scale (n_q=100k, a large corpus batch) that temporary equals the
+            # output-slice size, a multi-GB transient on the GPU. Init 0, so a
+            # zero-token query (no rows land on it) stays 0; a non-candidate
+            # doc's `-inf` in `M` sums to `-inf`, surviving as a non-candidate.
+            row_q = torch.repeat_interleave(
+                torch.arange(qe - qs, device=dev), qoff[qs : qe + 1].diff()
+            )
+            dest = out[qs:qe]
+            dest.zero_()
+            dest.index_add_(0, row_q, M)
+        return out
+
+
+def _concat_multivector_batches(batches: list["MultiVectorCorpusBatch"]) -> "MultiVectorCorpusBatch":
+    """Concatenate several files' (already union-compacted) multivector batches
+    into one — the ragged analog of `_concat_sparse_batches`. `flat_tokens` is a
+    plain per-token concatenation; `doc_offsets` are shifted by the running
+    token total and their duplicate leading `0` dropped, exactly as CSR
+    row_offsets are. `query_block` is fixed run-wide, so the first batch's copy
+    is authoritative."""
+    flat = np.concatenate([b.flat_tokens for b in batches], axis=0)
+    offsets_parts = [batches[0].doc_offsets]
+    running = int(batches[0].doc_offsets[-1])
+    for b in batches[1:]:
+        offsets_parts.append(b.doc_offsets[1:] + running)
+        running += int(b.doc_offsets[-1])
+    doc_offsets = np.concatenate(offsets_parts).astype(np.int64)
+    return MultiVectorCorpusBatch(doc_offsets, flat, batches[0].query_block)
+
+
 def _merge_topk(top_scores, top_enc, batch_scores, encoded_rows, k: int):
     """Fold one batch's `(n_q, n_candidate_rows)` score matrix into a spec's
     running `(top_scores, top_enc)` top-k state: top-k the batch on its own
@@ -833,6 +1071,39 @@ def _merge_topk(top_scores, top_enc, batch_scores, encoded_rows, k: int):
     new_top_scores, idx = torch.topk(merged_s, k=k, dim=1)
     del merged_s
     return new_top_scores, merged_e.gather(1, idx)
+
+
+def _sample_mean_doc_tokens(store: Store, mine: list, column: str) -> float:
+    """Mean tokens-per-doc from this worker's FIRST corpus file (a metadata-
+    cheap, single-file read) — used only to derive multivector tile sizes from
+    `multivector_token_budget`. Returns 1.0 if the worker has no files or the
+    sample is empty (a safe floor: it just makes the derived doc-tile larger)."""
+    if not mine:
+        return 1.0
+    table = store.read_columns(mine[0][1].read_path, [column])
+    doc_offsets, _ = multivector_to_ragged(table[column])
+    n = len(doc_offsets) - 1
+    total = int(doc_offsets[-1])
+    return total / n if n > 0 and total > 0 else 1.0
+
+
+def _resolve_multivector_tiles(
+    budget: int, mean_q_tokens: float, mean_doc_tokens: float,
+    configured_bs: int | None, configured_qb: int | None,
+) -> tuple[int | None, int | None]:
+    """Derive `(multivector_batch_size, multivector_query_block)` from a target
+    peak element count for the per-slice score matrix `P = (block_query_tokens
+    × slice_doc_tokens)`. Split geometrically — aim each axis near
+    `sqrt(budget)` elements — then convert tokens back to items via the two
+    means. An explicitly-configured knob is passed through untouched; only a
+    `None` knob is filled in. Every derived value is floored at 1 (a
+    zero/negative tile would empty the batch loop)."""
+    import math
+
+    axis = math.sqrt(max(1, budget))
+    bs = configured_bs if configured_bs is not None else max(1, int(axis / max(1e-9, mean_doc_tokens)))
+    qb = configured_qb if configured_qb is not None else max(1, int(axis / max(1e-9, mean_q_tokens)))
+    return bs, qb
 
 
 def _resolve_vt_batch_size(configured: int | None, k_floor: int, vt: str) -> int | None:
@@ -1510,6 +1781,7 @@ def run_compute(
     _validate_query_filter_cols(qstore, query_filter_cols)
     Q_np_by_vt: dict[str, np.ndarray] = {}
     query_vocab = None  # sparse only: sorted distinct query token ids (see _build_query_vocab)
+    mv_q_offsets = None  # multivector only: (n_q+1,) query-token offsets (see load_queries_multivector)
     # Sparse no-overlap gate state (see _zero_gate_file_ok/_QueryIndicator):
     # query-side flags fixed run-wide; the indicator holder is shared by every
     # file's batch and builds its CSR lazily, only if a signed file appears.
@@ -1535,6 +1807,19 @@ def run_compute(
             q_pos = Q_np[Q_np > 0]
             sparse_q_min_pos = float(q_pos.min()) if q_pos.size else float("inf")
             del q_pos
+        elif vt == "multivector":
+            # Q_np is the flat (total_query_tokens, D) token matrix — its
+            # `.shape[1]` is the token dim, keeping the dim log / consistency
+            # check below identical to dense. The per-query token offsets ride
+            # alongside in `mv_q_offsets`.
+            Q_np, mv_q_offsets, q_ids, q_payload, q_filter_vals = load_queries_multivector(
+                qstore, cfg.queries, query_filter_cols
+            )
+            if Q_np.shape[0] == 0 and len(q_ids) > 0:
+                logger.warning(
+                    "multivector queries have zero tokens total (every query decoded empty) — "
+                    "every corpus row will score 0; check queries.multivector_column is correct."
+                )
         else:
             Q_np, q_ids, q_payload, q_filter_vals = load_queries(qstore, cfg.queries, query_filter_cols)
         Q_np_by_vt[vt] = Q_np
@@ -1549,7 +1834,7 @@ def run_compute(
             # would silently let through and misattribute query N's dense vector
             # to query M's sparse vector (or id/payload) in the output.
             raise RuntimeError(
-                f"queries.{'sparse_column' if vt == 'sparse' else 'dense_column'} produced "
+                f"queries.{vt}_column produced "
                 f"query ids that don't match a different vector_type's load for the same "
                 f"query set (first mismatch at row "
                 f"{next((i for i, (a, b) in enumerate(zip(q_ids, query_ids)) if a != b), min(len(q_ids), len(query_ids)))}"
@@ -1590,6 +1875,28 @@ def run_compute(
         )
         mine = mine[:max_files]
 
+    # Multivector tile sizes: resolve the two knobs once. When
+    # `multivector_token_budget` is set it fills in whichever of
+    # `multivector_batch_size`/`multivector_query_block` was left None (an
+    # explicit knob always wins), deriving from the mean tokens-per-query (from
+    # the loaded queries) and mean tokens-per-doc (sampled cheaply from this
+    # worker's first corpus file). See `_resolve_multivector_tiles`.
+    mv_batch_size = cfg.params.multivector_batch_size
+    mv_query_block = cfg.params.multivector_query_block
+    if "multivector" in vts_needed and cfg.params.multivector_token_budget is not None:
+        mean_q_tok = float(mv_q_offsets[-1]) / max(1, n_q) if n_q else 1.0
+        mean_doc_tok = _sample_mean_doc_tokens(cstore, mine, cfg.corpus.multivector_column)
+        mv_batch_size, mv_query_block = _resolve_multivector_tiles(
+            cfg.params.multivector_token_budget, mean_q_tok, mean_doc_tok,
+            mv_batch_size, mv_query_block,
+        )
+        logger.info(
+            "multivector token_budget=%d -> batch_size=%s query_block=%s "
+            "(mean tokens/query=%.1f, tokens/doc=%.1f)",
+            cfg.params.multivector_token_budget, mv_batch_size, mv_query_block,
+            mean_q_tok, mean_doc_tok,
+        )
+
     # 3. per-spec GPU state: each spec gets its own running (top_scores, top_enc)
     #    pair, but every spec of the same vector_type shares ONE raw query
     #    matrix regardless of metric. A cosine spec divides its score matrix
@@ -1598,13 +1905,25 @@ def run_compute(
     #    double the biggest resident tensor on the GPU (n_q × vocab floats:
     #    7.2 GiB at 100k queries × 18k vocab, which is what OOM'd the
     #    dot+cosine fineweb run on a 24 GB A10G).
-    Q_gpu_by_vt = {
-        vt: torch.tensor(Q_np_by_vt[vt], dtype=torch.float32, device=device) for vt in vts_needed
-    }
+    Q_gpu_by_vt: dict[str, object] = {}
+    for vt in vts_needed:
+        flat = torch.tensor(Q_np_by_vt[vt], dtype=torch.float32, device=device)
+        if vt == "multivector":
+            # The token matrix + offsets + tile size, wrapped so a spec's `Q`
+            # carries everything `MultiVectorBatchSlice.score` needs.
+            Q_gpu_by_vt[vt] = MultiVectorQuery(
+                flat, torch.tensor(mv_q_offsets, dtype=torch.int64, device=device),
+                n_q, mv_query_block,
+            )
+        else:
+            Q_gpu_by_vt[vt] = flat
     q_norms_by_vt: dict[str, object] = {}
     spec_Q, spec_q_norms, spec_top_scores, spec_top_enc = [], [], [], []
     for s in specs:
-        if s.metric == "cosine":
+        # Multivector cosine normalizes each TOKEN inside score() (not a
+        # per-query scalar divide like dense/sparse), so it needs no `q_norms`
+        # — and Q here is a MultiVectorQuery, not a tensor with .norm().
+        if s.metric == "cosine" and s.vector_type != "multivector":
             if s.vector_type not in q_norms_by_vt:
                 # clamp matches F.normalize's eps — a zero query scores 0
                 # everywhere instead of NaN (and its no-overlap gate already
@@ -1666,7 +1985,11 @@ def run_compute(
     for i, s in enumerate(specs):
         vt_spec_idxs[s.vector_type].append(i)
 
-    vt_configured_batch = {"dense": cfg.params.dense_batch_size, "sparse": cfg.params.sparse_batch_size}
+    vt_configured_batch = {
+        "dense": cfg.params.dense_batch_size,
+        "sparse": cfg.params.sparse_batch_size,
+        "multivector": mv_batch_size,  # already merged with the token-budget derivation
+    }
     has_baseline: dict[str, bool] = {}
     vt_batch_size: dict[str, int | None] = {}
     vt_union_filters: dict[str, list[Filter]] = {}
@@ -1727,6 +2050,7 @@ def run_compute(
     # merge is commutative in the SCORES it produces, but not in which of
     # several EXACTLY tied candidates a run picks.
     dense_col, sparse_col = cfg.corpus.dense_column, cfg.corpus.sparse_column
+    multivector_col = cfg.corpus.multivector_column
     id_col = cfg.corpus.id_column  # None → derive make_point_id(file_key, row) at decode
     # Union of every spec's filter fields — read_cols below stays exactly (and only)
     # the columns some spec actually references, same guarantee the single-search
@@ -1736,6 +2060,7 @@ def run_compute(
     read_cols = list(dict.fromkeys(
         ([dense_col] if "dense" in vts_needed else [])
         + ([sparse_col] if "sparse" in vts_needed else [])
+        + ([multivector_col] if "multivector" in vts_needed else [])
         + ([id_col] if id_col else [])
         + filter_cols
     ))
@@ -1804,6 +2129,8 @@ def run_compute(
                 arrs: dict[str, object] = {}
                 if "dense" in vts_needed:
                     arrs["dense"] = dense_to_2d(table[dense_col])
+                if "multivector" in vts_needed:
+                    arrs["multivector"] = multivector_to_ragged(table[multivector_col])
                 if "sparse" in vts_needed:
                     sp_offsets, sp_idx, sp_val = sparse_to_coo_parts(table[sparse_col])
                     # Norms and the zero-score gate BEFORE remap: both are
@@ -1923,6 +2250,16 @@ def run_compute(
                         batches["dense"], batch_orig_rows["dense"] = b.compact(
                             _union_keep(vt_union_filters["dense"], keeps)
                         )
+                if "multivector" in vts_needed:
+                    mv_offsets, mv_flat = arrs["multivector"]
+                    b = MultiVectorCorpusBatch(mv_offsets, mv_flat, mv_query_block)
+                    raw_stats["multivector"] = (b.n_rows, b.nbytes)
+                    if has_baseline["multivector"]:
+                        batches["multivector"], batch_orig_rows["multivector"] = b, None
+                    else:
+                        batches["multivector"], batch_orig_rows["multivector"] = b.compact(
+                            _union_keep(vt_union_filters["multivector"], keeps)
+                        )
                 if "sparse" in vts_needed:
                     sp_offsets, sp_idx, sp_val, sp_norms, sp_gate = arrs["sparse"]
                     b = SparseCorpusBatch(
@@ -2000,7 +2337,11 @@ def run_compute(
         buf = coalesce_buf[vt]
         if not buf:
             return 0.0
-        concat = _concat_dense_batches if vt == "dense" else _concat_sparse_batches
+        concat = {
+            "dense": _concat_dense_batches,
+            "sparse": _concat_sparse_batches,
+            "multivector": _concat_multivector_batches,
+        }[vt]
         combined_batch = concat([entry[1] for entry in buf])
         encoded_ids = np.concatenate([
             file_gidx * MAX_ROWS_PER_FILE + orig_rows for file_gidx, _, orig_rows, _ in buf

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -1793,6 +1793,17 @@ def run_compute(
     device = "cuda" if torch.cuda.is_available() else "cpu"
     if device == "cpu":
         logger.warning("No GPU detected — brute force on CPU will be slow.")
+    # Opt-in TF32 tensor-core matmuls (see ParamsConfig.allow_tf32). CUDA-only;
+    # torch's flag is a no-op on CPU, but gate on device anyway so the log is
+    # honest. OFF by default keeps GT bit-exact f32 (matching Qdrant).
+    if cfg.params.allow_tf32 and device == "cuda":
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+        logger.warning(
+            "params.allow_tf32=True: TF32 matmuls enabled (CUDA) — ~1.75x faster "
+            "multivector/dense matmul, but scores are NOT bit-exact f32 (~3e-4 "
+            "relative error). Ensure this can't perturb your recall numbers."
+        )
 
     # 1. queries — loaded once per DISTINCT vector_type needed across all specs
     #    (queries files are small, so no need to dedupe further than that).

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -1002,7 +1002,7 @@ class MultiVectorBatchSlice:
             qe = min(qs + block, n_q)
             t0, t1 = int(qoff[qs]), int(qoff[qe])
             if t1 == t0:
-                continue  # every query in this block is zero-token; leave -inf
+                continue  # every query in this block is zero-token -> left -inf (see below)
             Qb = Q.flat[t0:t1]
             if metric == "cosine":
                 Qb = F.normalize(Qb, dim=1)
@@ -1012,15 +1012,28 @@ class MultiVectorBatchSlice:
             # block's output rows (zeroed first): `index_add_` into the `out`
             # view avoids a separate `(block_queries × n_rows)` temporary — at
             # scale (n_q=100k, a large corpus batch) that temporary equals the
-            # output-slice size, a multi-GB transient on the GPU. Init 0, so a
-            # zero-token query (no rows land on it) stays 0; a non-candidate
+            # output-slice size, a multi-GB transient on the GPU. A non-candidate
             # doc's `-inf` in `M` sums to `-inf`, surviving as a non-candidate.
-            row_q = torch.repeat_interleave(
-                torch.arange(qe - qs, device=dev), qoff[qs : qe + 1].diff()
-            )
+            counts = qoff[qs + 1 : qe + 1] - qoff[qs:qe]   # tokens per query in this block
+            row_q = torch.repeat_interleave(torch.arange(qe - qs, device=dev), counts)
             dest = out[qs:qe]
             dest.zero_()
             dest.index_add_(0, row_q, M)
+            # A ZERO-TOKEN query has no tokens to score, so it retrieves nothing:
+            # mark it a non-candidate (-inf) EVERYWHERE — identical to a whole
+            # zero-token block (the `continue` above) and to the sparse
+            # zero-support gate. Without this, a zero-token query sharing a block
+            # with a non-empty one would keep the `dest.zero_()` value (0.0
+            # against every doc) and its top-K would fill with arbitrary tied
+            # 0.0-score rows — AND the result would depend on how `query_block`
+            # happens to tile the query axis (a pure performance knob), breaking
+            # tiling-invariance. Qdrant rejects zero-token multivector queries
+            # outright; nova-bf instead returns them cleanly as "no hits".
+            # Unconditional (no `.any()` guard): when no query is zero-token the
+            # mask is all-False and this is a no-op scatter — cheaper than the
+            # `bool(...)` guard, which would force a device->host sync every
+            # query block on the GPU.
+            dest[counts == 0] = float("-inf")
         return out
 
 
@@ -1031,7 +1044,17 @@ def _concat_multivector_batches(batches: list["MultiVectorCorpusBatch"]) -> "Mul
     token total and their duplicate leading `0` dropped, exactly as CSR
     row_offsets are. `query_block` is fixed run-wide, so the first batch's copy
     is authoritative."""
-    flat = np.concatenate([b.flat_tokens for b in batches], axis=0)
+    # Skip zero-ROW token arrays before concatenating: an all-zero-token corpus
+    # shard decodes to a width-0 `(0, 0)` `flat_tokens` (the decoder can't infer
+    # D with no tokens — see `multivector_to_ragged`), which would otherwise make
+    # `np.concatenate(..., axis=1-mismatch)` throw against real `(m, D)` shards.
+    # A zero-row array contributes no tokens anyway; its docs still exist as rows
+    # and ride along via `doc_offsets` below (they score `-inf`, non-candidates).
+    # This mirrors `load_queries_multivector`'s own `nonempty` guard on the query
+    # side. If EVERY part is empty the group has no tokens at all, so the width is
+    # irrelevant (`MultiVectorBatchSlice.score` short-circuits on 0 tokens).
+    flat_parts = [b.flat_tokens for b in batches if b.flat_tokens.shape[0] > 0]
+    flat = np.concatenate(flat_parts, axis=0) if flat_parts else batches[0].flat_tokens
     offsets_parts = [batches[0].doc_offsets]
     running = int(batches[0].doc_offsets[-1])
     for b in batches[1:]:
@@ -1884,6 +1907,13 @@ def run_compute(
     mv_batch_size = cfg.params.multivector_batch_size
     mv_query_block = cfg.params.multivector_query_block
     if "multivector" in vts_needed and cfg.params.multivector_token_budget is not None:
+        if mv_batch_size is not None and mv_query_block is not None:
+            logger.warning(
+                "multivector_token_budget=%d is set but BOTH multivector_batch_size "
+                "and multivector_query_block are also set explicitly — the budget has "
+                "nothing to derive and is ignored (explicit knobs win).",
+                cfg.params.multivector_token_budget,
+            )
         mean_q_tok = float(mv_q_offsets[-1]) / max(1, n_q) if n_q else 1.0
         mean_doc_tok = _sample_mean_doc_tokens(cstore, mine, cfg.corpus.multivector_column)
         mv_batch_size, mv_query_block = _resolve_multivector_tiles(

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -909,10 +909,17 @@ class MultiVectorQuery:
     `MultiVectorBatchSlice.score`, which tiles the query axis by whole queries
     (`query_block`) to bound the per-slice score matrix. `n_q` is stored
     explicitly because a trailing run of zero-token queries makes it
-    unrecoverable from `flat` alone."""
+    unrecoverable from `flat` alone.
 
-    flat: object      # torch.Tensor (total_query_tokens, D)
-    offsets: object   # torch.Tensor (n_q + 1,) int64, on device
+    `offsets` (device) drives the on-device segment reductions; `offsets_cpu`
+    (the same values, host numpy) drives the Python block-loop slicing so
+    `int(offsets[qs])` never forces a per-block CUDA→CPU sync (see `score`).
+    This object is the SINGLE source of `query_block` — the corpus batch/slice
+    deliberately don't carry it (it's a query-axis concept, not a corpus one)."""
+
+    flat: object       # torch.Tensor (total_query_tokens, D)
+    offsets: object    # torch.Tensor (n_q + 1,) int64, ON DEVICE — for reductions
+    offsets_cpu: object  # np.ndarray (n_q + 1,) int64 — for host block-loop slicing (no sync)
     n_q: int
     query_block: int | None  # queries per query-axis tile (None = all at once)
 
@@ -937,14 +944,13 @@ class MultiVectorCorpusBatch:
     is `(total_tokens, D)` and `doc_offsets` (length `n_rows+1`) delimits each
     doc's token span. Exposes the same `.n_rows`/`.nbytes`/`.compact`/
     `.transfer` surface as `Dense`/`SparseCorpusBatch` so `run_compute`'s
-    per-file loop never branches on vector_type. `query_block` is carried
-    run-wide (like sparse `vocab`/`need_row_norms`) so `.transfer()` needs no
-    extra args and the slice knows how to tile the query axis."""
+    per-file loop never branches on vector_type. Query-axis tiling
+    (`query_block`) lives on the query object (`MultiVectorQuery`), NOT here —
+    a corpus batch has no business knowing how the query set is tiled."""
 
-    def __init__(self, doc_offsets: np.ndarray, flat_tokens: np.ndarray, query_block: int | None):
+    def __init__(self, doc_offsets: np.ndarray, flat_tokens: np.ndarray):
         self.doc_offsets = doc_offsets
         self.flat_tokens = flat_tokens
-        self.query_block = query_block
 
     @property
     def n_rows(self) -> int:
@@ -958,7 +964,7 @@ class MultiVectorCorpusBatch:
         doc_offsets, flat_tokens, orig_rows = _compact_multivector_rows(
             self.doc_offsets, self.flat_tokens, keep
         )
-        return MultiVectorCorpusBatch(doc_offsets, flat_tokens, self.query_block), orig_rows
+        return MultiVectorCorpusBatch(doc_offsets, flat_tokens), orig_rows
 
     def transfer(self, r0: int, r1: int, device: str) -> "MultiVectorBatchSlice":
         import torch
@@ -969,7 +975,7 @@ class MultiVectorCorpusBatch:
             (self.doc_offsets[r0 : r1 + 1] - t0).astype(np.int64, copy=False)
         ).to(device, non_blocking=True)
         flat = torch.from_numpy(self.flat_tokens[t0:t1]).to(device, non_blocking=True)
-        return MultiVectorBatchSlice(flat, local_off, self.query_block)
+        return MultiVectorBatchSlice(flat, local_off)
 
 
 @dataclass
@@ -1000,33 +1006,48 @@ class MultiVectorBatchSlice:
 
     flat: object       # torch.Tensor (slice_total_tokens, D)
     doc_offsets: object  # torch.Tensor (n_rows + 1,) int64, rebased to 0
-    query_block: int | None = None
 
     @property
     def n_rows(self) -> int:
         return self.doc_offsets.shape[0] - 1
 
     def score(self, Q: "MultiVectorQuery", metric: str, q_norms=None):
+        # `q_norms` is unused: it's the per-query cosine scalar the dense/sparse
+        # slices take, but multivector cosine normalizes each TOKEN (not a
+        # per-query rescale), so there's no scalar to apply. The parameter stays
+        # for the uniform `slice.score(Q, metric, q_norms)` interface the shared
+        # loop calls across every vector_type.
         import torch
         import torch.nn.functional as F
 
+        if metric not in ("dot", "cosine"):
+            raise ValueError(
+                f"multivector metric must be 'dot' or 'cosine', got {metric!r}"
+            )
         dev = self.flat.device
         n_rows = self.n_rows
         n_q = Q.n_q
         out = torch.full((n_q, n_rows), float("-inf"), dtype=self.flat.dtype, device=dev)
         if n_rows == 0 or self.flat.shape[0] == 0:
             return out  # no corpus tokens in this slice — every doc a non-candidate
+        if Q.flat.shape[0] and Q.flat.shape[1] != self.flat.shape[1]:
+            raise ValueError(
+                f"multivector token dim mismatch: query D={Q.flat.shape[1]} vs "
+                f"corpus D={self.flat.shape[1]} — the query and corpus multivector "
+                "columns must share one token dimension"
+            )
 
         C = F.normalize(self.flat, dim=1) if metric == "cosine" else self.flat
         # Each corpus token column -> its doc id, for the segment-max.
         col_doc = torch.repeat_interleave(
             torch.arange(n_rows, device=dev), self.doc_offsets.diff()
         )
-        qoff = Q.offsets
+        qoff = Q.offsets            # device — feeds the on-device reductions below
+        qoff_cpu = Q.offsets_cpu    # host — feeds the Python block-loop bounds (no CUDA sync)
         block = Q.query_block or n_q
         for qs in range(0, n_q, block):
             qe = min(qs + block, n_q)
-            t0, t1 = int(qoff[qs]), int(qoff[qe])
+            t0, t1 = int(qoff_cpu[qs]), int(qoff_cpu[qe])  # host read: no per-block device sync
             if t1 == t0:
                 continue  # every query in this block is zero-token -> left -inf (see below)
             Qb = Q.flat[t0:t1]
@@ -1068,8 +1089,7 @@ def _concat_multivector_batches(batches: list["MultiVectorCorpusBatch"]) -> "Mul
     into one — the ragged analog of `_concat_sparse_batches`. `flat_tokens` is a
     plain per-token concatenation; `doc_offsets` are shifted by the running
     token total and their duplicate leading `0` dropped, exactly as CSR
-    row_offsets are. `query_block` is fixed run-wide, so the first batch's copy
-    is authoritative."""
+    row_offsets are."""
     # Skip zero-ROW token arrays before concatenating: an all-zero-token corpus
     # shard decodes to a width-0 `(0, 0)` `flat_tokens` (the decoder can't infer
     # D with no tokens — see `multivector_to_ragged`), which would otherwise make
@@ -1087,7 +1107,7 @@ def _concat_multivector_batches(batches: list["MultiVectorCorpusBatch"]) -> "Mul
         offsets_parts.append(b.doc_offsets[1:] + running)
         running += int(b.doc_offsets[-1])
     doc_offsets = np.concatenate(offsets_parts).astype(np.int64)
-    return MultiVectorCorpusBatch(doc_offsets, flat, batches[0].query_block)
+    return MultiVectorCorpusBatch(doc_offsets, flat)
 
 
 def _merge_topk(top_scores, top_enc, batch_scores, encoded_rows, k: int):
@@ -1976,11 +1996,13 @@ def run_compute(
     for vt in vts_needed:
         flat = torch.tensor(Q_np_by_vt[vt], dtype=torch.float32, device=device)
         if vt == "multivector":
-            # The token matrix + offsets + tile size, wrapped so a spec's `Q`
-            # carries everything `MultiVectorBatchSlice.score` needs.
+            # The token matrix + offsets (device for reductions, host for the
+            # block-loop bounds) + tile size, wrapped so a spec's `Q` carries
+            # everything `MultiVectorBatchSlice.score` needs.
+            off_cpu = np.ascontiguousarray(mv_q_offsets, dtype=np.int64)
             Q_gpu_by_vt[vt] = MultiVectorQuery(
-                flat, torch.tensor(mv_q_offsets, dtype=torch.int64, device=device),
-                n_q, mv_query_block,
+                flat, torch.tensor(off_cpu, dtype=torch.int64, device=device),
+                off_cpu, n_q, mv_query_block,
             )
         else:
             Q_gpu_by_vt[vt] = flat
@@ -2319,7 +2341,7 @@ def run_compute(
                         )
                 if "multivector" in vts_needed:
                     mv_offsets, mv_flat = arrs["multivector"]
-                    b = MultiVectorCorpusBatch(mv_offsets, mv_flat, mv_query_block)
+                    b = MultiVectorCorpusBatch(mv_offsets, mv_flat)
                     raw_stats["multivector"] = (b.n_rows, b.nbytes)
                     if has_baseline["multivector"]:
                         batches["multivector"], batch_orig_rows["multivector"] = b, None

--- a/python/nova-bf/src/nova_bf/compute.py
+++ b/python/nova-bf/src/nova_bf/compute.py
@@ -434,14 +434,30 @@ def load_queries_multivector(
         table = store.read_columns(f.read_path, cols)
         d = table.to_pydict()  # ORIGINAL values — payload/id keep their source form
         conv = convert_table_date_columns(table, q_date_fmts)
-        doc_offsets, flat = multivector_to_ragged(conv[qcfg.multivector_column])
+        # Decode the multivector column from the ORIGINAL table (date conversion
+        # only ever touches declared date columns, never a vector column — but
+        # reading it straight from `table` removes any doubt); `conv` feeds only
+        # the filter fields, which may be date-normalized.
+        doc_offsets, flat = multivector_to_ragged(table[qcfg.multivector_column])
         if flat.shape[1] > 0:
+            if dim and flat.shape[1] != dim:
+                raise ValueError(
+                    f"queries.{qcfg.multivector_column} token dim mismatch: file "
+                    f"{f.key!r} has D={flat.shape[1]} but an earlier file had D={dim} "
+                    "— every query file must share one token dimension"
+                )
             dim = flat.shape[1]
         tokens_parts.append(flat)
         counts_parts.append(np.diff(doc_offsets))
         n = len(doc_offsets) - 1
         if qcfg.id_column:
-            ids += [str(x) for x in d[qcfg.id_column]]
+            col_ids = d[qcfg.id_column]
+            if any(x is None for x in col_ids):
+                raise ValueError(
+                    f"queries.id_column {qcfg.id_column!r} has null value(s) in {f.key!r} "
+                    "— query ids must be present (a null would become the string 'None')"
+                )
+            ids += [str(x) for x in col_ids]
         else:
             ids += [make_point_id(f.key, r) for r in range(n)]
         for c in qcfg.payload_fields:
@@ -451,13 +467,23 @@ def load_queries_multivector(
 
     # A file whose queries are all zero-token decodes to a (0, 0) `flat`; drop
     # those empty shards before concat so the width is the real token dim, and
-    # fall back to a (0, dim) empty matrix if EVERY query is zero-token.
+    # fall back to a (0, dim) empty matrix if EVERY query is zero-token. Zero-
+    # token queries are NOT lost — their zero counts stay in `counts_parts`, so
+    # they keep their (zero-width) slot in `q_offsets` (and score -inf).
     nonempty = [t for t in tokens_parts if t.shape[0] > 0]
     flat_tokens = (
         np.concatenate(nonempty, axis=0) if nonempty else np.zeros((0, dim), np.float32)
     )
     counts = np.concatenate(counts_parts) if counts_parts else np.zeros(0, np.int64)
-    q_offsets = np.concatenate(([0], np.cumsum(counts))).astype(np.int64)
+    q_offsets = np.concatenate(([0], np.cumsum(counts, dtype=np.int64)))
+    # Alignment invariants (cheap; a violation means a decode/loader bug upstream,
+    # which would otherwise misattribute one query's vectors to another's id).
+    n_q = len(q_offsets) - 1
+    assert len(ids) == n_q, f"query id count {len(ids)} != query count {n_q}"
+    assert int(q_offsets[-1]) == flat_tokens.shape[0], (
+        f"query offsets end at {int(q_offsets[-1])} but token matrix has "
+        f"{flat_tokens.shape[0]} rows"
+    )
     return flat_tokens, q_offsets, ids, payload, {c: _to_query_array(v) for c, v in filter_vals.items()}
 
 

--- a/python/nova-bf/src/nova_bf/config.py
+++ b/python/nova-bf/src/nova_bf/config.py
@@ -201,6 +201,19 @@ class ParamsConfig(BaseModel):
     # `multivector_query_block` you left as None; an explicitly-set knob always
     # wins over the derived value. None (default) = no auto-derivation.
     multivector_token_budget: int | None = Field(default=None, gt=0)
+    # Allow TF32 tensor-core matmuls on Ampere+ GPUs (CUDA only — a no-op on
+    # CPU). OFF by default so ground truth stays bit-for-bit f32, matching
+    # Qdrant's f32 scoring exactly. When on, the score matmul runs in TF32
+    # (10-bit mantissa): measured on an A10G it makes the multivector matmul
+    # ~1.75x faster (the matmul is ~66% of GPU score time, so ~1.4x on the
+    # score path), with ~3e-4 median relative error — ranking-preserving in
+    # testing (top-100 overlap 100/100 vs f32) and the live-Qdrant MaxSim
+    # parity test still passes with it enabled. It is NOT bit-exact, so enable
+    # it only for a run where you've confirmed that ~3e-4-scale score error
+    # can't perturb the recall numbers you compute against this GT (e.g. no
+    # pathological score ties at your k). Affects every vector_type's dense
+    # matmul (dense scoring, multivector MaxSim); sparse SpMM is unaffected.
+    allow_tf32: bool = False
     # `merge` reduces the W per-rank partials in row-batches of this many queries,
     # streaming the result to disk so the full output never sits in RAM (that's what
     # let the old merge OOM at 1M queries). Peak host memory is ~(this × W × k)

--- a/python/nova-bf/src/nova_bf/config.py
+++ b/python/nova-bf/src/nova_bf/config.py
@@ -55,6 +55,14 @@ class CorpusConfig(BaseModel):
     # of dense_column by a search whose `vector_type` is "sparse" —
     # same schema nova-embed writes and nova-load reads (see docs/embedding).
     sparse_column: str = "sparse_embedding"
+    # list<list<float32>> column (outer list = one doc, inner list = one D-dim
+    # token vector) read instead of dense_column by a search whose
+    # `vector_type` is "multivector" (ColBERT / late-interaction MaxSim) — the
+    # same schema nova-embed writes (see nova_embed.storage.writer's
+    # MULTIVECTOR_EMBEDDING_TYPE) and nova-load reads. Named to match the
+    # dense_/sparse_ convention above; nova-embed itself names the column after
+    # the output entry, so set this to that column when it differs.
+    multivector_column: str = "multivector_embedding"
     # If set, hit_ids are taken verbatim from this already-unique column (e.g.
     # fineweb's `id` = "<urn:uuid:...>") — transparent for public data, and
     # resolvable without reconstructing the loader's hashing. If unset (default),
@@ -95,6 +103,9 @@ class QueriesConfig(BaseModel):
     path: str
     dense_column: str = "dense_embedding"
     sparse_column: str = "sparse_embedding"
+    # list<list<float32>> query column for a multivector search — see
+    # CorpusConfig.multivector_column.
+    multivector_column: str = "multivector_embedding"
     # If set, use this column as the query id verbatim; otherwise derive
     # make_point_id(queries_file_key, row) — same scheme as the corpus.
     id_column: str | None = None
@@ -166,6 +177,30 @@ class ParamsConfig(BaseModel):
     # silent all-empty run downstream.
     dense_batch_size: int | None = Field(default=None, gt=0)
     sparse_batch_size: int | None = Field(default=None, gt=0)
+    # Multivector (MaxSim) has TWO memory axes, not one: the per-slice score
+    # matrix is `(block_query_tokens × corpus_doc_tokens)`, and BOTH the corpus
+    # rows (docs) and the queries are tiled to bound its peak. Unlike
+    # dense/sparse, the naive whole-file × all-queries product is
+    # token×token — it blows up far faster than a pooled-vector matmul, so
+    # tiling the query axis too is mandatory, not optional.
+    #   multivector_batch_size  = docs per corpus-row slice (bounds doc-token
+    #                             count per slice; None = whole file at once)
+    #   multivector_query_block = queries per query-axis tile — a WHOLE number
+    #                             of queries per block, never splitting one
+    #                             query's tokens across blocks (None = all
+    #                             queries at once)
+    # `gt=0` for the same reason dense/sparse have it (a non-positive step
+    # silently empties the batch loop — see dense_batch_size).
+    multivector_batch_size: int | None = Field(default=None, gt=0)
+    multivector_query_block: int | None = Field(default=None, gt=0)
+    # Optional convenience: instead of hand-tuning the two knobs above, give a
+    # target peak element count for the per-slice `(block_query_tokens ×
+    # doc_tokens)` score matrix and let the run derive both tile sizes from the
+    # corpus/query mean tokens-per-item (both measured cheaply at load). When
+    # set, it fills in whichever of `multivector_batch_size`/
+    # `multivector_query_block` you left as None; an explicitly-set knob always
+    # wins over the derived value. None (default) = no auto-derivation.
+    multivector_token_budget: int | None = Field(default=None, gt=0)
     # `merge` reduces the W per-rank partials in row-batches of this many queries,
     # streaming the result to disk so the full output never sits in RAM (that's what
     # let the old merge OOM at 1M queries). Peak host memory is ~(this × W × k)
@@ -429,15 +464,20 @@ class SearchSpec(BaseModel):
     name: str | None = None
     k: int = 1000
     metric: Literal["cosine", "dot", "euclidean"] = "cosine"
-    vector_type: Literal["dense", "sparse"] = "dense"
+    vector_type: Literal["dense", "sparse", "multivector"] = "dense"
     filter: Filter | None = None
 
     @model_validator(mode="after")
-    def _no_sparse_euclidean(self) -> "SearchSpec":
-        if self.vector_type == "sparse" and self.metric == "euclidean":
+    def _no_euclidean_for_non_dense(self) -> "SearchSpec":
+        # euclidean only makes sense on a single pooled vector per item. Sparse
+        # retrieval only ever uses dot/cosine; multivector MaxSim is a sum of
+        # per-token dot (or cosine) maxima — an L2 distance between two ragged
+        # token SETS has no MaxSim analog (and Qdrant's multivector comparator
+        # is dot/cosine MaxSim only).
+        if self.vector_type in ("sparse", "multivector") and self.metric == "euclidean":
             raise ValueError(
-                "metric='euclidean' is not supported with vector_type='sparse' "
-                "(sparse retrieval only ever uses dot/cosine) — use 'dot' or 'cosine'"
+                f"metric='euclidean' is not supported with vector_type="
+                f"'{self.vector_type}' — use 'dot' or 'cosine'"
                 + (f" (search {self.name!r})" if self.name else "")
             )
         return self

--- a/python/nova-bf/src/nova_bf/io.py
+++ b/python/nova-bf/src/nova_bf/io.py
@@ -105,6 +105,43 @@ def dense_to_2d(col: pa.ChunkedArray) -> np.ndarray:
     return np.ascontiguousarray(flat.reshape(n, dim), dtype=np.float32)
 
 
+def multivector_to_ragged(col: pa.ChunkedArray) -> tuple[np.ndarray, np.ndarray]:
+    """A `list<list<float32>>` column (one doc = outer entry, one D-dim token
+    vector = inner entry) → `(doc_offsets, flat_tokens)`.
+
+    Same flatten-the-Arrow-buffer-once approach as `dense_to_2d`/
+    `sparse_to_coo_parts` — no per-row/per-token Python. `doc_offsets` is
+    length n+1 (token-index prefix sums; doc `i`'s tokens are rows
+    `doc_offsets[i]:doc_offsets[i+1]` of `flat_tokens`), `flat_tokens` is the
+    `(total_tokens, D)` float32 matrix of every token across every doc,
+    concatenated in doc order. This is the exact ragged analog of CSR's
+    `(row_offsets, values)`.
+
+    A null outer entry (nova-embed's `on_empty_input="null"`) or a non-null
+    but empty inner list both decode to a zero-width span (`doc_offsets[i] ==
+    doc_offsets[i+1]`) — i.e. a zero-token doc, which the compute path treats
+    as a non-candidate (`-inf`), the same way the sparse path treats a
+    zero-overlap doc. The outer/inner buffer offsets are honored explicitly so
+    a sliced Arrow array (buffer offset != 0) decodes correctly rather than
+    silently misaligning tokens to docs."""
+    col = col.combine_chunks()  # ChunkedArray -> a single ListArray
+    n = len(col)
+    if n == 0:
+        return np.zeros(1, dtype=np.int64), np.zeros((0, 0), dtype=np.float32)
+    outer_off = col.offsets.to_numpy(zero_copy_only=False).astype(np.int64)  # (n+1,), token indices
+    inner = col.values  # ListArray, one entry per token across all docs
+    tok_lo, tok_hi = int(outer_off[0]), int(outer_off[-1])
+    doc_offsets = (outer_off - tok_lo).astype(np.int64)
+    if tok_hi == tok_lo:
+        # every doc is null/empty — no tokens anywhere in this file
+        return doc_offsets, np.zeros((0, 0), dtype=np.float32)
+    inner_off = inner.offsets.to_numpy(zero_copy_only=False).astype(np.int64)
+    dim = int(inner_off[tok_lo + 1] - inner_off[tok_lo])  # uniform token width
+    val_lo, val_hi = int(inner_off[tok_lo]), int(inner_off[tok_hi])
+    flat = inner.values.to_numpy(zero_copy_only=False)[val_lo:val_hi]
+    return doc_offsets, np.ascontiguousarray(flat.reshape(tok_hi - tok_lo, dim), dtype=np.float32)
+
+
 def sparse_to_coo_parts(col: pa.ChunkedArray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """A `struct<indices: list<uint32>, values: list<float32>>` column → CSR parts.
 

--- a/python/nova-bf/src/nova_bf/io.py
+++ b/python/nova-bf/src/nova_bf/io.py
@@ -121,25 +121,59 @@ def multivector_to_ragged(col: pa.ChunkedArray) -> tuple[np.ndarray, np.ndarray]
     but empty inner list both decode to a zero-width span (`doc_offsets[i] ==
     doc_offsets[i+1]`) — i.e. a zero-token doc, which the compute path treats
     as a non-candidate (`-inf`), the same way the sparse path treats a
-    zero-overlap doc. The outer/inner buffer offsets are honored explicitly so
-    a sliced Arrow array (buffer offset != 0) decodes correctly rather than
-    silently misaligning tokens to docs."""
+    zero-overlap doc.
+
+    Robustness (all O(1) / O(n_docs), so the hot corpus path is unaffected):
+    - The validity bitmap, not the offsets, decides a null doc's token count.
+      Arrow does NOT guarantee a null list slot has equal adjacent offsets, so
+      trusting the offsets alone could count a null doc's stray physical span
+      as real tokens (nova-embed writes zero-span nulls, so this only guards
+      against arrays from other producers / some slice+concat paths).
+    - Buffer offsets (outer/inner) are honored so a sliced Arrow array (logical
+      offset != 0) decodes correctly rather than misaligning tokens to docs.
+    - Wrong-shape input fails loudly: a dense `list<float32>` column, or token
+      floats containing nulls (which would silently become NaN and poison
+      scoring), raise a clear error instead of an obscure one downstream.
+
+    The token width D is taken from the first token; per-token width variance
+    is left to `reshape` to catch (an O(total_tokens) uniformity scan would tax
+    the corpus path, and nova-embed emits a uniform width by construction)."""
     col = col.combine_chunks()  # ChunkedArray -> a single ListArray
     n = len(col)
     if n == 0:
         return np.zeros(1, dtype=np.int64), np.zeros((0, 0), dtype=np.float32)
+    if not (pa.types.is_list(col.type) or pa.types.is_large_list(col.type)):
+        raise TypeError(f"multivector column must be a list of token vectors, got {col.type}")
+    inner = col.values  # child ListArray: one entry per token across all docs
+    if not (pa.types.is_list(inner.type) or pa.types.is_large_list(inner.type)):
+        raise TypeError(
+            f"multivector column must nest list<float32> token vectors; inner type is "
+            f"{inner.type} (a flat list<float32> is a DENSE vector — use vector_type=dense)"
+        )
     outer_off = col.offsets.to_numpy(zero_copy_only=False).astype(np.int64)  # (n+1,), token indices
-    inner = col.values  # ListArray, one entry per token across all docs
-    tok_lo, tok_hi = int(outer_off[0]), int(outer_off[-1])
-    doc_offsets = (outer_off - tok_lo).astype(np.int64)
-    if tok_hi == tok_lo:
-        # every doc is null/empty — no tokens anywhere in this file
+    lengths = np.diff(outer_off)  # physical span (token count) per doc
+    interspersed = False
+    if col.null_count:
+        valid = np.asarray(col.is_valid())  # (n,) bool
+        interspersed = not bool((lengths[~valid] == 0).all())  # a null slot carrying real tokens?
+        lengths = np.where(valid, lengths, 0)  # a null doc is always zero-token
+    doc_offsets = np.concatenate(([0], np.cumsum(lengths, dtype=np.int64)))
+    if int(doc_offsets[-1]) == 0:
+        # every doc null/empty — no tokens, so D is unknowable from the data
         return doc_offsets, np.zeros((0, 0), dtype=np.float32)
+    if inner.values.null_count:  # O(1) when there's no validity bitmap (the norm)
+        raise ValueError(
+            "multivector token values contain nulls — a token vector must be fully "
+            "populated float32 (a null would decode to NaN and poison scoring)"
+        )
     inner_off = inner.offsets.to_numpy(zero_copy_only=False).astype(np.int64)
-    dim = int(inner_off[tok_lo + 1] - inner_off[tok_lo])  # uniform token width
+    tok_lo, tok_hi = int(outer_off[0]), int(outer_off[-1])
+    dim = int(inner_off[tok_lo + 1] - inner_off[tok_lo])  # token width, from the first token
     val_lo, val_hi = int(inner_off[tok_lo]), int(inner_off[tok_hi])
-    flat = inner.values.to_numpy(zero_copy_only=False)[val_lo:val_hi]
-    return doc_offsets, np.ascontiguousarray(flat.reshape(tok_hi - tok_lo, dim), dtype=np.float32)
+    phys = inner.values.to_numpy(zero_copy_only=False)[val_lo:val_hi].reshape(tok_hi - tok_lo, dim)
+    if interspersed:  # rare: drop the stray tokens a null slot physically carried
+        phys = phys[np.repeat(valid, np.diff(outer_off))]
+    return doc_offsets, np.ascontiguousarray(phys, dtype=np.float32)
 
 
 def sparse_to_coo_parts(col: pa.ChunkedArray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:

--- a/python/nova-bf/tests/test_compute_multivector.py
+++ b/python/nova-bf/tests/test_compute_multivector.py
@@ -323,6 +323,31 @@ def test_cosine_is_scale_invariant(tmp_path):
                 assert abs(got[qi][di] - base[qi][di]) < 1e-3, f"scale={scale} q{qi} d{di} score drift"
 
 
+def test_allow_tf32_flag_roundtrips_and_is_correct(ds):
+    """`params.allow_tf32` is accepted and a run with it set still produces the
+    exact ranking. On this CPU box it's a no-op (torch's TF32 flag is CUDA-only),
+    so results must be identical to the default run — this pins the plumbing;
+    the actual TF32 speedup + ranking-preservation + Qdrant parity were measured
+    live on an A10G (see docs/brute-force/multivector-maxsim.md)."""
+    base = _run(ds["tmp"], ds["cdir"], ds["qpath"], metric="dot", k=8)
+    out = ds["tmp"] / "out_tf32"
+    out.mkdir(exist_ok=True)
+    cfg_text = f"""
+corpus: {{path: {ds["cdir"]}, multivector_column: multivector_embedding, id_column: id}}
+queries: {{path: {ds["qpath"]}, multivector_column: multivector_embedding, id_column: qid}}
+output: {{path: {out}}}
+params: {{io_workers: 2, allow_tf32: true}}
+searches:
+  - {{name: mv, k: 8, metric: dot, vector_type: multivector}}
+"""
+    p = ds["tmp"] / "cfg_tf32.yaml"
+    p.write_text(cfg_text)
+    t = pq.read_table(run_compute(load_config(str(p)))["mv"]).to_pydict()
+    got = {int(q): [int(i) for i in hi] for q, hi in zip(t["query_id"], t["hit_ids"])}
+    for qi in base:
+        assert got[qi] == list(base[qi].keys())
+
+
 def test_decoder_null_empty_and_slice():
     D = 3
     inner = pa.ListArray.from_arrays(

--- a/python/nova-bf/tests/test_compute_multivector.py
+++ b/python/nova-bf/tests/test_compute_multivector.py
@@ -196,8 +196,9 @@ def test_handcomputed_maxsim_exact():
     #   q0.d0 = 1, q0.d1 = 2  -> max 2
     #   q1.d0 = 2, q1.d1 = 0  -> max 2
     # MaxSim = 2 + 2 = 4
-    batch = MultiVectorCorpusBatch(np.array([0, 2], np.int64), d, None)
-    Q = MultiVectorQuery(torch.tensor(q), torch.tensor(np.array([0, 2], np.int64)), 1, None)
+    batch = MultiVectorCorpusBatch(np.array([0, 2], np.int64), d)
+    qoff = np.array([0, 2], np.int64)
+    Q = MultiVectorQuery(torch.tensor(q), torch.tensor(qoff), qoff, 1, None)
     sc = batch.transfer(0, 1, "cpu").score(Q, "dot")
     assert sc.shape == (1, 1)
     assert abs(float(sc[0, 0]) - 4.0) < 1e-6

--- a/python/nova-bf/tests/test_compute_multivector.py
+++ b/python/nova-bf/tests/test_compute_multivector.py
@@ -54,12 +54,17 @@ def _mv_array(docs: list[np.ndarray], nulls: set[int] = frozenset()) -> pa.Array
 
 def _ref_maxsim(q: np.ndarray, d: np.ndarray, metric: str) -> float:
     """Reference MaxSim for one (query, doc) token-set pair — the definition,
-    written out literally. Zero-token doc -> non-candidate (-inf)."""
+    written out literally. A zero-token doc OR a zero-token query is a
+    non-candidate (-inf): a query with no tokens has nothing to score, so it
+    retrieves nothing (matching nova-bf and the sparse zero-support gate).
+    Cosine normalizes with the same 1e-12 floor `torch.nn.functional.normalize`
+    uses, so a zero-magnitude token becomes a zero vector (contributes 0), not a
+    0/0 NaN."""
     if len(d) == 0 or len(q) == 0:
-        return float("-inf") if len(d) == 0 else 0.0
+        return float("-inf")
     if metric == "cosine":
-        q = q / np.linalg.norm(q, axis=1, keepdims=True)
-        d = d / np.linalg.norm(d, axis=1, keepdims=True)
+        q = q / np.maximum(np.linalg.norm(q, axis=1, keepdims=True), 1e-12)
+        d = d / np.maximum(np.linalg.norm(d, axis=1, keepdims=True), 1e-12)
     return float(sum(max(float(qt @ dt) for dt in d) for qt in q))
 
 
@@ -286,6 +291,38 @@ searches:
 # ---------------------------------------------------------------------------
 # decoder unit tests
 # ---------------------------------------------------------------------------
+def test_cosine_is_scale_invariant(tmp_path):
+    """nova-bf's cosine MaxSim is the mathematically exact, scale-invariant
+    cosine: scaling any doc's (or query's) token magnitudes leaves the cosine
+    ranking and scores unchanged (normalization floor 1e-12). This pins the
+    intentional semantics that diverge from Qdrant's low-norm guard only for
+    sub-~1e-3-norm vectors (see docs/brute-force/multivector-maxsim.md) — a
+    regime real embeddings never reach."""
+    rng = np.random.default_rng(21)
+    cdir = tmp_path / "corpus"
+    cdir.mkdir()
+    cdocs = [rng.standard_normal((int(rng.integers(1, 5)), DIM)).astype(np.float32) for _ in range(15)]
+    qdocs = [rng.standard_normal((3, DIM)).astype(np.float32) for _ in range(4)]
+
+    def run_with_scale(scale):
+        scaled = [d * scale for d in cdocs]
+        pq.write_table(pa.table({"multivector_embedding": _mv_array(scaled),
+                                 "id": pa.array([str(i) for i in range(len(scaled))])}),
+                       str(cdir / "c0.parquet"))
+        qpath = tmp_path / "q.parquet"
+        pq.write_table(pa.table({"multivector_embedding": _mv_array(qdocs),
+                                 "qid": pa.array([str(i) for i in range(len(qdocs))])}), str(qpath))
+        return _run(tmp_path, str(cdir), str(qpath), metric="cosine", k=10)
+
+    base = run_with_scale(1.0)
+    for scale in (0.01, 100.0):
+        got = run_with_scale(scale)
+        for qi in base:
+            assert list(got[qi].keys()) == list(base[qi].keys()), f"scale={scale} q{qi} ranking drift"
+            for di in base[qi]:
+                assert abs(got[qi][di] - base[qi][di]) < 1e-3, f"scale={scale} q{qi} d{di} score drift"
+
+
 def test_decoder_null_empty_and_slice():
     D = 3
     inner = pa.ListArray.from_arrays(
@@ -304,6 +341,208 @@ def test_decoder_null_empty_and_slice():
     off2, flat2 = multivector_to_ragged(pa.chunked_array([outer.slice(2, 2)]))
     assert off2.tolist() == [0, 1, 1]                # doc2 (1 tok), doc3 (empty)
     assert np.array_equal(flat2, np.array([[6.0, 7.0, 8.0]], np.float32))
+
+
+def test_zero_token_query_is_tiling_invariant_noncandidate(tmp_path):
+    """A zero-token (empty/null) query has nothing to score → it must retrieve
+    NOTHING (all -inf), identically regardless of how `query_block` tiles the
+    query axis. Regression for the bug where a zero-token query sharing a block
+    with a non-empty one scored 0.0 (candidate) while a whole zero-token block
+    scored -inf — making the GT depend on a pure performance knob."""
+    rng = np.random.default_rng(3)
+    cdir = tmp_path / "corpus"
+    cdir.mkdir()
+    cdocs = [rng.standard_normal((int(rng.integers(1, 5)), DIM)).astype(np.float32) for _ in range(12)]
+    pq.write_table(pa.table({"multivector_embedding": _mv_array(cdocs),
+                             "id": pa.array([str(i) for i in range(12)])}),
+                   str(cdir / "c0.parquet"))
+    # queries: q0 non-empty, q1 ZERO-token, q2 non-empty, q3 zero-token
+    qdocs = [rng.standard_normal((3, DIM)).astype(np.float32),
+             np.zeros((0, DIM), np.float32),
+             rng.standard_normal((2, DIM)).astype(np.float32),
+             np.zeros((0, DIM), np.float32)]
+    qpath = tmp_path / "q.parquet"
+    pq.write_table(pa.table({"multivector_embedding": _mv_array(qdocs),
+                             "qid": pa.array([str(i) for i in range(4)])}), str(qpath))
+
+    runs = {qb: _run(tmp_path, str(cdir), str(qpath), metric="dot", k=12, qb=qb)
+            for qb in (None, 1, 2, 3, 4)}
+    # zero-token queries q1, q3 -> NO hits, in every tiling
+    for qb, got in runs.items():
+        assert got[1] == {}, f"qb={qb}: zero-token q1 should retrieve nothing, got {got[1]}"
+        assert got[3] == {}, f"qb={qb}: zero-token q3 should retrieve nothing, got {got[3]}"
+    # non-empty queries identical across all tilings
+    base = runs[None]
+    for qb, got in runs.items():
+        for qi in (0, 2):
+            assert list(got[qi].keys()) == list(base[qi].keys()), f"qb={qb} q{qi} ids drift"
+
+
+def test_all_empty_corpus_shard_coalesced(tmp_path):
+    """A corpus shard that is ENTIRELY zero-token docs must not crash a
+    coalesced run (uniform filter + multivector_batch_size set), and its docs
+    must be non-candidates. Regression for the `_concat_multivector_batches`
+    width-0 concat crash."""
+    rng = np.random.default_rng(5)
+    cdir = tmp_path / "corpus"
+    cdir.mkdir()
+    # file 0: real docs (cat=a/b); file 1: ALL null/empty docs; file 2: real docs
+    def write(fi, docs, nulls, cats, base):
+        pq.write_table(pa.table({
+            "multivector_embedding": _mv_array(docs, nulls=nulls),
+            "id": pa.array([str(base + i) for i in range(len(docs))]),
+            "cat": pa.array(cats),
+        }), str(cdir / f"c{fi}.parquet"))
+    f0 = [rng.standard_normal((int(rng.integers(1, 5)), DIM)).astype(np.float32) for _ in range(5)]
+    write(0, f0, set(), ["a" if i % 2 else "b" for i in range(5)], 0)
+    f1 = [np.zeros((0, DIM), np.float32) for _ in range(4)]     # ALL empty (2 null, 2 empty-list)
+    write(1, f1, {0, 1}, ["a"] * 4, 5)
+    f2 = [rng.standard_normal((int(rng.integers(1, 5)), DIM)).astype(np.float32) for _ in range(6)]
+    write(2, f2, set(), ["a" if i % 2 else "b" for i in range(6)], 9)
+
+    qdocs = [rng.standard_normal((3, DIM)).astype(np.float32) for _ in range(4)]
+    qpath = tmp_path / "q.parquet"
+    pq.write_table(pa.table({"multivector_embedding": _mv_array(qdocs),
+                             "qid": pa.array([str(i) for i in range(4)])}), str(qpath))
+
+    filter_yaml = ("    filter:\n      must:\n        - field: cat\n          match: a\n")
+    # multivector_batch_size set -> coalescing path; k >= corpus so a candidate is
+    # missing ONLY if it's a non-candidate or filtered out.
+    got = _run(tmp_path, str(cdir), str(qpath), metric="dot", k=100, bs=8, filter_yaml=filter_yaml)
+    cdocs = f0 + f1 + f2
+    cats = (["a" if i % 2 else "b" for i in range(5)] + ["a"] * 4
+            + ["a" if i % 2 else "b" for i in range(6)])
+    empty_ids = {5, 6, 7, 8}
+    for qi in range(4):
+        assert not (set(got[qi]) & empty_ids), f"q{qi} surfaced empty-shard docs"
+        keep = {i for i, c in enumerate(cats) if c == "a"} - empty_ids
+        assert set(got[qi]) == keep, f"q{qi} candidate set mismatch"
+        ref = _ref_topk(qdocs, cdocs, "dot", 100,
+                        keep={i for i, c in enumerate(cats) if c == "a"})
+        for di in ref[qi]:
+            assert abs(got[qi][di] - ref[qi][di]) < 1e-3
+
+
+def test_coalescing_uniform_filter_parity(ds):
+    """Same as the uniform-filter test but WITH multivector_batch_size set, so
+    the cross-file coalescing path (`_flush_coalesce_group` +
+    `_concat_multivector_batches`) actually executes."""
+    filter_yaml = ("    filter:\n      must:\n        - field: lang\n          match: eng\n")
+    got = _run(ds["tmp"], ds["cdir"], ds["qpath"], metric="dot", k=8, bs=3, filter_yaml=filter_yaml)
+    ref = _ref_topk(ds["qdocs"], ds["cdocs"], "dot", 8,
+                    keep={i for i, l in enumerate(ds["langs"]) if l == "eng"})
+    for qi in ref:
+        assert list(got[qi].keys()) == list(ref[qi].keys())
+        for di in ref[qi]:
+            assert abs(got[qi][di] - ref[qi][di]) < 1e-3
+
+
+def test_multivector_and_dense_shared_run(tmp_path):
+    """A dense spec and a multivector spec in ONE run share corpus IO/decode —
+    each must still produce its own independent, correct ranking."""
+    rng = np.random.default_rng(11)
+    cdir = tmp_path / "corpus"
+    cdir.mkdir()
+    M = 40
+    cdocs = [rng.standard_normal((int(rng.integers(1, 5)), DIM)).astype(np.float32) for _ in range(M)]
+    dense_c = rng.standard_normal((M, DIM)).astype(np.float32)
+    pq.write_table(pa.table({
+        "multivector_embedding": _mv_array(cdocs),
+        "dense_embedding": pa.array(dense_c.tolist(), type=pa.list_(pa.float32())),
+        "id": pa.array([str(i) for i in range(M)]),
+    }), str(cdir / "c0.parquet"))
+    NQ = 5
+    qmv = [rng.standard_normal((3, DIM)).astype(np.float32) for _ in range(NQ)]
+    dense_q = rng.standard_normal((NQ, DIM)).astype(np.float32)
+    qpath = tmp_path / "q.parquet"
+    pq.write_table(pa.table({
+        "multivector_embedding": _mv_array(qmv),
+        "dense_embedding": pa.array(dense_q.tolist(), type=pa.list_(pa.float32())),
+        "qid": pa.array([str(i) for i in range(NQ)]),
+    }), str(qpath))
+    out = tmp_path / "out"
+    out.mkdir()
+    cfg_text = f"""
+corpus: {{path: {cdir}, multivector_column: multivector_embedding, dense_column: dense_embedding, id_column: id}}
+queries: {{path: {qpath}, multivector_column: multivector_embedding, dense_column: dense_embedding, id_column: qid}}
+output: {{path: {out}}}
+params: {{io_workers: 2, multivector_query_block: 2}}
+searches:
+  - {{name: mv, k: 10, metric: dot, vector_type: multivector}}
+  - {{name: dn, k: 10, metric: dot, vector_type: dense}}
+"""
+    p = tmp_path / "cfg.yaml"
+    p.write_text(cfg_text)
+    res = run_compute(load_config(str(p)))
+    # multivector spec
+    tm = pq.read_table(res["mv"]).to_pydict()
+    gm = {int(q): {int(i): s for i, s in zip(hi, hs)}
+          for q, hi, hs in zip(tm["query_id"], tm["hit_ids"], tm["hit_scores"])}
+    rm = _ref_topk(qmv, cdocs, "dot", 10)
+    for qi in rm:
+        assert list(gm[qi].keys()) == list(rm[qi].keys())
+        for di in rm[qi]:
+            assert abs(gm[qi][di] - rm[qi][di]) < 1e-3
+    # dense spec: independent dot-product ranking
+    td = pq.read_table(res["dn"]).to_pydict()
+    gd = {int(q): [int(i) for i in hi] for q, hi in zip(td["query_id"], td["hit_ids"])}
+    for qi in range(NQ):
+        sc = dense_c @ dense_q[qi]
+        ref = [int(o) for o in np.argsort(-sc, kind="stable")[:10]]
+        assert gd[qi] == ref, f"dense q{qi} ranking mismatch"
+
+
+def test_per_query_filter_multivector(tmp_path):
+    """A per-query filter (`match_from_query`) with a multivector search — the
+    per-query cell-mask path — selects each query's own admissible docs."""
+    rng = np.random.default_rng(13)
+    cdir = tmp_path / "corpus"
+    cdir.mkdir()
+    M = 30
+    cdocs = [rng.standard_normal((int(rng.integers(1, 5)), DIM)).astype(np.float32) for _ in range(M)]
+    tenant = [i % 3 for i in range(M)]
+    pq.write_table(pa.table({
+        "multivector_embedding": _mv_array(cdocs),
+        "id": pa.array([str(i) for i in range(M)]),
+        "tenant": pa.array(tenant),
+    }), str(cdir / "c0.parquet"))
+    NQ = 4
+    qmv = [rng.standard_normal((3, DIM)).astype(np.float32) for _ in range(NQ)]
+    want_tenant = [0, 1, 2, 0]
+    qpath = tmp_path / "q.parquet"
+    pq.write_table(pa.table({
+        "multivector_embedding": _mv_array(qmv),
+        "qid": pa.array([str(i) for i in range(NQ)]),
+        "want": pa.array(want_tenant),
+    }), str(qpath))
+    out = tmp_path / "out"
+    out.mkdir()
+    cfg_text = f"""
+corpus: {{path: {cdir}, multivector_column: multivector_embedding, id_column: id}}
+queries: {{path: {qpath}, multivector_column: multivector_embedding, id_column: qid}}
+output: {{path: {out}}}
+params: {{io_workers: 2}}
+searches:
+  - name: mv
+    k: 100
+    metric: dot
+    vector_type: multivector
+    filter:
+      must:
+        - field: tenant
+          match_from_query: want
+"""
+    p = tmp_path / "cfg.yaml"
+    p.write_text(cfg_text)
+    t = pq.read_table(run_compute(load_config(str(p)))["mv"]).to_pydict()
+    got = {int(q): {int(i): s for i, s in zip(hi, hs)}
+           for q, hi, hs in zip(t["query_id"], t["hit_ids"], t["hit_scores"])}
+    for qi in range(NQ):
+        keep = {i for i in range(M) if tenant[i] == want_tenant[qi]}
+        assert set(got[qi]) == keep, f"q{qi} tenant filter: got {set(got[qi])} want {keep}"
+        ref = _ref_topk(qmv, cdocs, "dot", 100, keep=keep)
+        for di in ref[qi]:
+            assert abs(got[qi][di] - ref[qi][di]) < 1e-3
 
 
 def test_decoder_all_null_and_empty_column():

--- a/python/nova-bf/tests/test_compute_multivector.py
+++ b/python/nova-bf/tests/test_compute_multivector.py
@@ -570,6 +570,69 @@ searches:
             assert abs(got[qi][di] - ref[qi][di]) < 1e-3
 
 
+def test_decoder_null_doc_with_physical_span_is_zero_token():
+    """A NULL outer entry must be a zero-token doc even if Arrow gives its slot
+    a non-empty physical offset span — the validity bitmap wins, not the
+    offsets. Regression for trusting offsets over the null mask."""
+    D = 2
+    inner = pa.ListArray.from_arrays(
+        pa.array([0, 2, 4, 6, 8], type=pa.int32()),
+        pa.array(np.arange(8, dtype=np.float32), type=pa.float32()),
+    )  # 4 tokens
+    # doc0 = tokens[0:2], doc1 = NULL but offsets claim [2:4], doc2 = tokens[4:4]
+    outer = pa.ListArray.from_arrays(
+        pa.array([0, 2, 4, 4], type=pa.int32()), inner, mask=pa.array([False, True, False]))
+    off, flat = multivector_to_ragged(pa.chunked_array([outer]))
+    assert (off[2] - off[1]) == 0, "null doc must be zero-token regardless of its span"
+    # the stray tokens the null slot physically carried are excluded
+    assert flat.shape[0] == 2 and off.tolist() == [0, 2, 2, 2]
+    assert np.array_equal(flat, np.arange(4, dtype=np.float32).reshape(2, 2))
+
+
+def test_decoder_rejects_dense_and_null_token_values():
+    dense = pa.array([[1.0, 2.0, 3.0]], type=pa.list_(pa.float32()))
+    with pytest.raises(TypeError, match="DENSE|list of token"):
+        multivector_to_ragged(pa.chunked_array([dense]))
+    # a null float inside a token vector must not silently become NaN
+    inner = pa.ListArray.from_arrays(pa.array([0, 2], type=pa.int32()),
+                                     pa.array([1.0, None], type=pa.float32()))
+    outer = pa.ListArray.from_arrays(pa.array([0, 1], type=pa.int32()), inner)
+    with pytest.raises(ValueError, match="null"):
+        multivector_to_ragged(pa.chunked_array([outer]))
+
+
+def test_cross_file_dim_mismatch_raises(tmp_path):
+    """Two query files with different token dims must fail with a clear message,
+    not a generic numpy concat error."""
+    def mv_dim(docs, d):  # dim-aware builder (the shared _mv_array hardcodes DIM)
+        tc = [len(x) for x in docs]; total = sum(tc)
+        flat = np.concatenate([x.reshape(-1) for x in docs]).astype(np.float32)
+        inner = pa.ListArray.from_arrays(pa.array(np.arange(0, total * d + 1, d, dtype=np.int32)),
+                                         pa.array(flat, type=pa.float32()))
+        off = np.concatenate([[0], np.cumsum(tc)]).astype(np.int32)
+        return pa.ListArray.from_arrays(pa.array(off), inner)
+    rng = np.random.default_rng(0)
+    cdir = tmp_path / "corpus"; cdir.mkdir()
+    pq.write_table(pa.table({"multivector_embedding": mv_dim([rng.standard_normal((2, DIM)).astype(np.float32)], DIM),
+                             "id": pa.array(["0"])}), str(cdir / "c0.parquet"))
+    qdir = tmp_path / "q"; qdir.mkdir()
+    pq.write_table(pa.table({"multivector_embedding": mv_dim([rng.standard_normal((2, DIM)).astype(np.float32)], DIM),
+                             "qid": pa.array(["0"])}), str(qdir / "q0.parquet"))
+    pq.write_table(pa.table({"multivector_embedding": mv_dim([rng.standard_normal((2, DIM + 1)).astype(np.float32)], DIM + 1),
+                             "qid": pa.array(["1"])}), str(qdir / "q1.parquet"))
+    out = tmp_path / "out"; out.mkdir()
+    cfg = f"""
+corpus: {{path: {cdir}, multivector_column: multivector_embedding, id_column: id}}
+queries: {{path: {qdir}, multivector_column: multivector_embedding, id_column: qid}}
+output: {{path: {out}}}
+params: {{io_workers: 1}}
+searches: [{{name: mv, k: 1, metric: dot, vector_type: multivector}}]
+"""
+    p = tmp_path / "cfg.yaml"; p.write_text(cfg)
+    with pytest.raises(ValueError, match="token dim mismatch"):
+        run_compute(load_config(str(p)))
+
+
 def test_decoder_all_null_and_empty_column():
     D = 4
     inner = pa.ListArray.from_arrays(pa.array([0], type=pa.int32()),

--- a/python/nova-bf/tests/test_compute_multivector.py
+++ b/python/nova-bf/tests/test_compute_multivector.py
@@ -1,0 +1,321 @@
+"""Correctness tests for the multivector (ColBERT / late-interaction MaxSim)
+brute-force compute path.
+
+Mirrors test_compute_sparse.py's fixture/ground-truth pattern, but over
+``list<list<float32>>`` columns — the same on-disk schema nova-embed writes
+(see nova_embed.storage.writer.MULTIVECTOR_EMBEDDING_TYPE) and nova-load reads.
+
+Ground truth is computed independently, in plain numpy, from the tiny synthetic
+corpus/queries — a literal double loop over query tokens (max over doc tokens,
+summed) — NOT by re-deriving nova_bf's tiled/segment-reduction logic, so these
+tests catch divergence between the two. A zero-token (null or empty) doc is a
+non-candidate: it never appears in the ground-truth ranking, exactly as Qdrant's
+inverted MaxSim would never surface a doc with no vectors.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")  # the compute phase needs torch (install nova-bf[dev])
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from nova_bf.compute import run_compute
+from nova_bf.config import load_config
+from nova_bf.io import multivector_to_ragged
+
+DIM = 8
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+def _mv_array(docs: list[np.ndarray], nulls: set[int] = frozenset()) -> pa.Array:
+    """A list of per-doc ``(n_tokens, DIM)`` arrays -> a ``list<list<float32>>``
+    Arrow array. A doc index in ``nulls`` becomes a NULL outer entry (spans no
+    tokens); an empty ``(0, DIM)`` array becomes a non-null empty inner list.
+    Both are zero-token docs."""
+    tok_counts = [0 if i in nulls else len(d) for i, d in enumerate(docs)]
+    total = sum(tok_counts)
+    flat = (
+        np.concatenate([d.reshape(-1) for i, d in enumerate(docs) if i not in nulls and len(d)])
+        if any(tok_counts) else np.empty(0, np.float32)
+    )
+    inner = pa.ListArray.from_arrays(
+        pa.array(np.arange(0, total * DIM + 1, DIM, dtype=np.int32)),
+        pa.array(flat.astype(np.float32), type=pa.float32()),
+    )
+    outer_off = np.concatenate([[0], np.cumsum(tok_counts)]).astype(np.int32)
+    mask = pa.array([i in nulls for i in range(len(docs))]) if nulls else None
+    return pa.ListArray.from_arrays(pa.array(outer_off), inner, mask=mask)
+
+
+def _ref_maxsim(q: np.ndarray, d: np.ndarray, metric: str) -> float:
+    """Reference MaxSim for one (query, doc) token-set pair — the definition,
+    written out literally. Zero-token doc -> non-candidate (-inf)."""
+    if len(d) == 0 or len(q) == 0:
+        return float("-inf") if len(d) == 0 else 0.0
+    if metric == "cosine":
+        q = q / np.linalg.norm(q, axis=1, keepdims=True)
+        d = d / np.linalg.norm(d, axis=1, keepdims=True)
+    return float(sum(max(float(qt @ dt) for dt in d) for qt in q))
+
+
+def _ref_topk(qdocs, cdocs, metric, k, keep=None):
+    """Independent per-query top-k ids+scores. `keep` (optional) is a set of
+    admissible corpus ids (a filter)."""
+    out = {}
+    for qi, q in enumerate(qdocs):
+        scores = []
+        for di, d in enumerate(cdocs):
+            if keep is not None and di not in keep:
+                scores.append(float("-inf"))
+            else:
+                scores.append(_ref_maxsim(q, d, metric))
+        scores = np.array(scores)
+        order = [int(o) for o in np.argsort(-scores, kind="stable") if scores[o] > -np.inf][:k]
+        out[qi] = {di: scores[di] for di in order}
+    return out
+
+
+def _run(tmp, cdir, qpath, *, metric="dot", k=5, bs=None, qb=None,
+         filter_yaml="", id_cols=True):
+    out = tmp / "out"
+    out.mkdir(exist_ok=True)
+    params = ["io_workers: 2"]
+    if bs is not None:
+        params.append(f"multivector_batch_size: {bs}")
+    if qb is not None:
+        params.append(f"multivector_query_block: {qb}")
+    cfg_text = f"""
+corpus:
+  path: {cdir}
+  multivector_column: multivector_embedding
+  {"id_column: id" if id_cols else ""}
+queries:
+  path: {qpath}
+  multivector_column: multivector_embedding
+  {"id_column: qid" if id_cols else ""}
+output:
+  path: {out}
+params: {{{", ".join(params)}}}
+searches:
+  - name: mv
+    k: {k}
+    metric: {metric}
+    vector_type: multivector
+{filter_yaml}
+"""
+    p = tmp / "cfg.yaml"
+    p.write_text(cfg_text)
+    t = pq.read_table(run_compute(load_config(str(p)))["mv"]).to_pydict()
+    # Keyed by query ROW position (output rows are in query-file order), so it
+    # works whether hit/query ids are row-index strings (id_cols) or opaque
+    # make_point_id UUIDs. `cast` int-decodes hit ids only when they're indices.
+    cast = int if id_cols else (lambda x: x)
+    return {
+        qi: {cast(i): s for i, s in zip(hi, hs)}
+        for qi, (hi, hs) in enumerate(zip(t["hit_ids"], t["hit_scores"]))
+    }
+
+
+# ---------------------------------------------------------------------------
+# fixture
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def ds(tmp_path_factory):
+    rng = np.random.default_rng(7)
+    tmp = tmp_path_factory.mktemp("bf_mv")
+    cdir = tmp / "corpus"
+    cdir.mkdir()
+    # 3 files with row counts that don't divide typical batch sizes; a mix of
+    # token counts, plus deliberate null and empty (zero-token) docs.
+    sizes = [6, 5, 4]
+    cdocs, langs = [], []
+    g = 0
+    # which global doc indices are null / empty
+    null_ids = {2, 9}
+    empty_ids = {7}
+    for fi, n in enumerate(sizes):
+        docs, file_nulls = [], set()
+        for r in range(n):
+            gid = g + r
+            if gid in null_ids or gid in empty_ids:
+                docs.append(np.zeros((0, DIM), np.float32))
+                if gid in null_ids:
+                    file_nulls.add(r)
+            else:
+                docs.append(rng.standard_normal((int(rng.integers(1, 6)), DIM)).astype(np.float32))
+        arr = _mv_array(docs, nulls=file_nulls)
+        ids = [str(g + r) for r in range(n)]
+        lang = ["eng" if (g + r) % 2 == 0 else "fra" for r in range(n)]
+        pq.write_table(
+            pa.table({"multivector_embedding": arr,
+                      "id": pa.array(ids), "lang": pa.array(lang)}),
+            str(cdir / f"c{fi}.parquet"),
+        )
+        cdocs.extend(docs)
+        langs.extend(lang)
+        g += n
+
+    # queries: a few with 1..4 tokens
+    qdocs = [rng.standard_normal((int(rng.integers(1, 5)), DIM)).astype(np.float32) for _ in range(6)]
+    pq.write_table(
+        pa.table({"multivector_embedding": _mv_array(qdocs),
+                  "qid": pa.array([str(i) for i in range(len(qdocs))])}),
+        str(tmp / "q.parquet"),
+    )
+    return {
+        "tmp": tmp, "cdir": str(cdir), "qpath": str(tmp / "q.parquet"),
+        "cdocs": cdocs, "qdocs": qdocs, "langs": langs,
+        "null_ids": null_ids, "empty_ids": empty_ids,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. exact segment-reduction pinning on a hand-computed case
+# ---------------------------------------------------------------------------
+def test_handcomputed_maxsim_exact():
+    """A tiny fully-worked example: pin the segment-max (over doc tokens) then
+    segment-sum (over query tokens) against hand arithmetic, not just the
+    numpy reference."""
+    import torch
+    from nova_bf.compute import MultiVectorCorpusBatch, MultiVectorQuery
+
+    # doc0: two tokens; query: two tokens; DIM=2, plain integers -> exact
+    d = np.array([[1.0, 0.0], [0.0, 2.0]], np.float32)          # doc0 tokens
+    q = np.array([[1.0, 1.0], [2.0, 0.0]], np.float32)          # query tokens
+    # dot products:
+    #   q0.d0 = 1, q0.d1 = 2  -> max 2
+    #   q1.d0 = 2, q1.d1 = 0  -> max 2
+    # MaxSim = 2 + 2 = 4
+    batch = MultiVectorCorpusBatch(np.array([0, 2], np.int64), d, None)
+    Q = MultiVectorQuery(torch.tensor(q), torch.tensor(np.array([0, 2], np.int64)), 1, None)
+    sc = batch.transfer(0, 1, "cpu").score(Q, "dot")
+    assert sc.shape == (1, 1)
+    assert abs(float(sc[0, 0]) - 4.0) < 1e-6
+
+
+@pytest.mark.parametrize("metric", ["dot", "cosine"])
+@pytest.mark.parametrize("bs,qb", [(None, None), (1, 1), (3, 2), (2, 4), (1000, 1000)])
+def test_tiling_invariance(ds, metric, bs, qb):
+    """Same ranking + scores regardless of corpus-row tile (`bs`) and
+    query-axis tile (`qb`), including tile=1 and tile>data — the whole point of
+    hiding tiling inside `.score()`."""
+    got = _run(ds["tmp"], ds["cdir"], ds["qpath"], metric=metric, k=8, bs=bs, qb=qb)
+    ref = _ref_topk(ds["qdocs"], ds["cdocs"], metric, 8)
+    for qi in ref:
+        assert list(got[qi].keys()) == list(ref[qi].keys()), (
+            f"{metric} bs={bs} qb={qb} q{qi} ids: got {list(got[qi])} ref {list(ref[qi])}")
+        for di in ref[qi]:
+            assert abs(got[qi][di] - ref[qi][di]) < 1e-3
+
+
+def test_null_and_empty_docs_are_noncandidates(ds):
+    """Every null / zero-token doc must be absent from every query's results —
+    with k >= corpus size so the ONLY reason to be missing is being a
+    non-candidate."""
+    n_corpus = len(ds["cdocs"])
+    got = _run(ds["tmp"], ds["cdir"], ds["qpath"], metric="dot", k=n_corpus + 5)
+    bad = ds["null_ids"] | ds["empty_ids"]
+    for qi, hits in got.items():
+        assert not (set(hits) & bad), f"q{qi} surfaced non-candidate docs {set(hits) & bad}"
+        # everything else IS a candidate, so exactly the candidates appear
+        assert set(hits) == set(range(n_corpus)) - bad
+
+
+def test_uniform_filter_parity(ds):
+    """A uniform `must match lang=eng` filter selects the same candidate set the
+    reference does, with identical MaxSim scores."""
+    keep = {i for i, l in enumerate(ds["langs"]) if l == "eng"} \
+        - (ds["null_ids"] | ds["empty_ids"])
+    filter_yaml = (
+        "    filter:\n"
+        "      must:\n"
+        "        - field: lang\n"
+        "          match: eng\n"
+    )
+    got = _run(ds["tmp"], ds["cdir"], ds["qpath"], metric="dot", k=8, filter_yaml=filter_yaml)
+    ref = _ref_topk(ds["qdocs"], ds["cdocs"], "dot", 8,
+                    keep={i for i, l in enumerate(ds["langs"]) if l == "eng"})
+    for qi in ref:
+        assert list(got[qi].keys()) == list(ref[qi].keys())
+        for di in ref[qi]:
+            assert abs(got[qi][di] - ref[qi][di]) < 1e-3
+        assert set(got[qi]) <= keep
+
+
+def test_make_point_id_path(ds):
+    """Without an id_column, hits resolve via make_point_id(file_key, row) — the
+    ranking (by resolved order within each query) must still match; we compare
+    the SCORE multiset per query since ids are now opaque strings."""
+    got = _run(ds["tmp"], ds["cdir"], ds["qpath"], metric="dot", k=8, id_cols=False)
+    ref = _ref_topk(ds["qdocs"], ds["cdocs"], "dot", 8)
+    for qi in ref:
+        gs = sorted(got[qi].values())
+        rs = sorted(ref[qi].values())
+        assert len(gs) == len(rs)
+        assert np.allclose(gs, rs, atol=1e-3)
+
+
+def test_token_budget_autoderives_tiles(ds):
+    """`multivector_token_budget` fills in both tile knobs and still produces the
+    exact same ranking as the untiled run."""
+    out = ds["tmp"] / "out"
+    out.mkdir(exist_ok=True)
+    cfg_text = f"""
+corpus: {{path: {ds["cdir"]}, multivector_column: multivector_embedding, id_column: id}}
+queries: {{path: {ds["qpath"]}, multivector_column: multivector_embedding, id_column: qid}}
+output: {{path: {out}}}
+params: {{io_workers: 2, multivector_token_budget: 64}}
+searches:
+  - {{name: mv, k: 8, metric: dot, vector_type: multivector}}
+"""
+    p = ds["tmp"] / "cfg_tb.yaml"
+    p.write_text(cfg_text)
+    t = pq.read_table(run_compute(load_config(str(p)))["mv"]).to_pydict()
+    got = {int(q): {int(i): s for i, s in zip(hi, hs)}
+           for q, hi, hs in zip(t["query_id"], t["hit_ids"], t["hit_scores"])}
+    ref = _ref_topk(ds["qdocs"], ds["cdocs"], "dot", 8)
+    for qi in ref:
+        assert list(got[qi].keys()) == list(ref[qi].keys())
+
+
+# ---------------------------------------------------------------------------
+# decoder unit tests
+# ---------------------------------------------------------------------------
+def test_decoder_null_empty_and_slice():
+    D = 3
+    inner = pa.ListArray.from_arrays(
+        pa.array([0, 3, 6, 9], type=pa.int32()),
+        pa.array(np.arange(9, dtype=np.float32), type=pa.float32()),
+    )
+    # doc0: 2 tok, doc1: null, doc2: 1 tok, doc3: empty
+    outer = pa.ListArray.from_arrays(
+        pa.array([0, 2, 2, 3, 3], type=pa.int32()), inner,
+        mask=pa.array([False, True, False, False]),
+    )
+    off, flat = multivector_to_ragged(pa.chunked_array([outer]))
+    assert off.tolist() == [0, 2, 2, 3, 3]
+    assert flat.shape == (3, D)
+    # a sliced array (buffer offset != 0) still decodes correctly
+    off2, flat2 = multivector_to_ragged(pa.chunked_array([outer.slice(2, 2)]))
+    assert off2.tolist() == [0, 1, 1]                # doc2 (1 tok), doc3 (empty)
+    assert np.array_equal(flat2, np.array([[6.0, 7.0, 8.0]], np.float32))
+
+
+def test_decoder_all_null_and_empty_column():
+    D = 4
+    inner = pa.ListArray.from_arrays(pa.array([0], type=pa.int32()),
+                                     pa.array([], type=pa.float32()))
+    alln = pa.ListArray.from_arrays(pa.array([0, 0, 0], type=pa.int32()), inner,
+                                    mask=pa.array([True, True]))
+    off, flat = multivector_to_ragged(pa.chunked_array([alln]))
+    assert off.tolist() == [0, 0, 0]
+    assert flat.shape[0] == 0
+    empty = pa.array([], type=pa.list_(pa.list_(pa.float32())))
+    off2, flat2 = multivector_to_ragged(pa.chunked_array([empty]))
+    assert off2.tolist() == [0]
+    assert flat2.shape[0] == 0

--- a/python/nova-bf/tests/test_qdrant_multivector_parity.py
+++ b/python/nova-bf/tests/test_qdrant_multivector_parity.py
@@ -1,0 +1,190 @@
+"""Live-Qdrant parity for multivector (ColBERT / late-interaction MaxSim) GT.
+
+Confirms nova-bf's MaxSim ranking selects EXACTLY the same top-K points, with
+matching scores, as Qdrant's native multivector MaxSim comparator on the same
+data — for both `dot` (Qdrant's default) and `cosine` (per-token L2
+normalization). Qdrant runs with `exact=True` so it computes the true MaxSim
+ranking, not an HNSW approximation.
+
+Scores are compared position-agnostically with a boundary-aware tolerance: an
+id present in one engine's top-K but not the other's is only accepted when its
+score sits within tolerance of the K-th score (a genuine boundary near-tie
+between two engines' independent float32 reductions), never when it's a real
+disagreement inside the ranking.
+
+Skipped automatically unless `qdrant-client` is importable AND a Qdrant server
+is reachable (env `QDRANT_URL`, default http://localhost:6333). Inert in the
+default `pytest` run / CI; active wherever a live Qdrant exists.
+
+Run it explicitly:
+    uv run --with qdrant-client --directory python/nova-bf --extra dev \
+        pytest -q tests/test_qdrant_multivector_parity.py
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("qdrant_client")
+import pyarrow as pa
+import pyarrow.parquet as pq
+from qdrant_client import QdrantClient, models
+
+from nova_bf.compute import run_compute
+from nova_bf.config import load_config
+
+QDRANT_URL = os.environ.get("QDRANT_URL", "http://localhost:6333")
+DIM = 16
+M = 400        # corpus points
+N_Q = 10       # queries
+K = 50         # top-K (< M, so this is a real ranking, not set equality)
+TOK_LO, TOK_HI = 2, 9   # tokens per doc / query (Qdrant rejects zero-token multivectors)
+
+
+@pytest.fixture(scope="module")
+def client():
+    try:
+        c = QdrantClient(url=QDRANT_URL, timeout=30)
+        c.get_collections()
+    except Exception as e:  # pragma: no cover - environment gate
+        pytest.skip(f"no reachable Qdrant at {QDRANT_URL}: {e}")
+    return c
+
+
+def _mv_array(docs: list[np.ndarray]) -> pa.Array:
+    """list of (n_tokens, DIM) arrays -> list<list<float32>> Arrow column."""
+    tok_counts = [len(d) for d in docs]
+    total = sum(tok_counts)
+    flat = np.concatenate([d.reshape(-1) for d in docs]).astype(np.float32)
+    inner = pa.ListArray.from_arrays(
+        pa.array(np.arange(0, total * DIM + 1, DIM, dtype=np.int32)),
+        pa.array(flat, type=pa.float32()),
+    )
+    outer_off = np.concatenate([[0], np.cumsum(tok_counts)]).astype(np.int32)
+    return pa.ListArray.from_arrays(pa.array(outer_off), inner)
+
+
+@pytest.fixture(scope="module")
+def data(tmp_path_factory):
+    rng = np.random.default_rng(20260724)
+    tmp = tmp_path_factory.mktemp("qmvparity")
+    cdocs = [rng.standard_normal((int(rng.integers(TOK_LO, TOK_HI)), DIM)).astype(np.float32)
+             for _ in range(M)]
+    qdocs = [rng.standard_normal((int(rng.integers(TOK_LO, TOK_HI)), DIM)).astype(np.float32)
+             for _ in range(N_Q)]
+
+    cdir = tmp / "corpus"
+    cdir.mkdir()
+    pq.write_table(pa.table({
+        "multivector_embedding": _mv_array(cdocs),
+        "id": pa.array([str(i) for i in range(M)]),
+    }), str(cdir / "c0.parquet"))
+    pq.write_table(pa.table({
+        "multivector_embedding": _mv_array(qdocs),
+        "qid": pa.array([str(i) for i in range(N_Q)]),
+    }), str(tmp / "queries.parquet"))
+
+    return {"tmp": tmp, "cdir": str(cdir), "qpath": str(tmp / "queries.parquet"),
+            "cdocs": cdocs, "qdocs": qdocs}
+
+
+def _collection(client, data, distance):
+    name = f"nova_bf_mv_parity_{uuid.uuid4().hex[:8]}"
+    client.create_collection(
+        name,
+        vectors_config=models.VectorParams(
+            size=DIM, distance=distance,
+            multivector_config=models.MultiVectorConfig(
+                comparator=models.MultiVectorComparator.MAX_SIM),
+        ),
+    )
+    client.upsert(name, points=[
+        models.PointStruct(id=i, vector=d.tolist()) for i, d in enumerate(data["cdocs"])
+    ], wait=True)
+    return name
+
+
+def _qdrant_topk(client, name, data):
+    out = {}
+    for qi in range(N_Q):
+        pts = client.query_points(
+            name, query=data["qdocs"][qi].tolist(), limit=K,
+            search_params=models.SearchParams(exact=True), with_payload=False,
+        ).points
+        out[qi] = {int(p.id): float(p.score) for p in pts}
+    return out
+
+
+def _nova(data, metric):
+    out = data["tmp"] / f"out_{metric}"
+    out.mkdir(exist_ok=True)
+    cfg_text = f"""
+corpus:
+  path: {data["cdir"]}
+  multivector_column: multivector_embedding
+  id_column: id
+queries:
+  path: {data["qpath"]}
+  multivector_column: multivector_embedding
+  id_column: qid
+output:
+  path: {out}
+params:
+  io_workers: 2
+  multivector_batch_size: 128
+  multivector_query_block: 4
+searches:
+  - name: mv
+    k: {K}
+    metric: {metric}
+    vector_type: multivector
+"""
+    p = data["tmp"] / f"cfg_{metric}.yaml"
+    p.write_text(cfg_text)
+    t = pq.read_table(run_compute(load_config(str(p)))["mv"]).to_pydict()
+    return {int(q): {int(i): float(s) for i, s in zip(hi, hs)}
+            for q, hi, hs in zip(t["query_id"], t["hit_ids"], t["hit_scores"])}
+
+
+def _assert_parity(nova, qd, metric):
+    for qi in range(N_Q):
+        n, q = nova[qi], qd[qi]
+        # K-th (worst) score per engine — the boundary a near-tie can straddle.
+        n_floor = min(n.values())
+        q_floor = min(q.values())
+        tol = 1e-3
+        # scores must match for every id both engines returned
+        for i in set(n) & set(q):
+            assert abs(n[i] - q[i]) <= tol * (1 + abs(q[i])), (
+                f"{metric} q{qi} id={i}: nova={n[i]} qdrant={q[i]}")
+        # an id only one engine returned must be a boundary near-tie, not a
+        # real ranking disagreement
+        for i in set(n) - set(q):
+            assert abs(n[i] - q_floor) <= tol * (1 + abs(q_floor)), (
+                f"{metric} q{qi} nova-only id={i} score={n[i]} not at qdrant "
+                f"boundary {q_floor}")
+        for i in set(q) - set(n):
+            assert abs(q[i] - n_floor) <= tol * (1 + abs(n_floor)), (
+                f"{metric} q{qi} qdrant-only id={i} score={q[i]} not at nova "
+                f"boundary {n_floor}")
+
+
+def test_multivector_dot_parity(client, data):
+    name = _collection(client, data, models.Distance.DOT)
+    try:
+        _assert_parity(_nova(data, "dot"), _qdrant_topk(client, name, data), "dot")
+    finally:
+        client.delete_collection(name)
+
+
+def test_multivector_cosine_parity(client, data):
+    name = _collection(client, data, models.Distance.COSINE)
+    try:
+        _assert_parity(_nova(data, "cosine"), _qdrant_topk(client, name, data), "cosine")
+    finally:
+        client.delete_collection(name)


### PR DESCRIPTION
# nova-bf: multivector (ColBERT / late-interaction MaxSim) exact ground truth

Adds a third `vector_type` — **`multivector`** — to `nova-bf`, computing exact
top-K late-interaction **MaxSim** ground truth alongside the existing `dense`
and `sparse` paths, and validated to match Qdrant's `MaxSim` comparator on real
GPU hardware.

```
score(query q, doc d) = Σ over q's tokens ( max over d's tokens ( q_tok · d_tok ) )
```

`dot` is the default; `cosine` L2-normalizes every token first. This matches
`crates/nova-load`'s `MultiVectorComparator::MaxSim`.

## Design — it slots into the existing engine

The whole engine (per-file loop, filters, cross-file coalescing, top-K merge,
the `merge` phase) is built around one contract: a batch of corpus rows produces
an `(n_queries × n_rows)` score matrix. The entire multivector design hides all
the ragged MaxSim math inside **`MultiVectorBatchSlice.score()`**, which returns
exactly that matrix — so nothing else in the engine needed to change
(`merge.py` is untouched).

Inside `score()`, per query-axis tile:

1. `P = Q_block_tokens @ C_slice_tokens.T` — the token×token dot products.
2. segment-**max** over each doc's tokens (`scatter_reduce(amax)`).
3. segment-**sum** over each query's tokens (`index_add_` into the output view).

Unlike dense/sparse, **both** axes are tiled (`P` is token×token, so it blows up
fast): `multivector_batch_size` bounds the doc-token axis,
`multivector_query_block` the query-token axis. A null/empty doc decodes to a
zero-token span and scores `-inf` (non-candidate), exactly as the sparse path
treats a zero-overlap doc; a zero-token query likewise retrieves nothing.

Files:
- `io.py` — `multivector_to_ragged()` decoder for Arrow `list<list<float32>>`.
- `config.py` — `multivector` vector_type; `multivector_column`; the tiling
  knobs + `multivector_token_budget`; opt-in `allow_tf32`.
- `compute.py` — `MultiVectorCorpusBatch` / `MultiVectorBatchSlice` /
  `MultiVectorQuery`, `load_queries_multivector`, ragged compaction + coalescing,
  and all reader/consumer wiring.

## Config

```yaml
corpus:  { path: …, multivector_column: multivector_embedding }
queries: { path: …, multivector_column: multivector_embedding }
params:
  multivector_batch_size: 2000     # docs per corpus slice
  multivector_query_block: 16      # queries per query tile
  # multivector_token_budget: 50_000_000   # …or derive both from a target
  # allow_tf32: false              # opt-in GPU speedup (see below)
searches:
  - { name: mv, vector_type: multivector, metric: dot, k: 1000 }
```

## Correctness

- **Unit tests** (`tests/test_compute_multivector.py`): hand-computed MaxSim
  pinned exactly; tiling-invariance across batch × query-block sizes (incl.
  tile=1 and tile>data) for dot + cosine; null/empty docs as non-candidates;
  zero-token queries; uniform + per-query filters; cross-file coalescing;
  multivector + dense in one shared-IO run; `make_point_id` path; cosine
  scale-invariance; decoder edge cases (null/empty/sliced arrays,
  null-doc-with-span, dense-input rejection, null-scalar rejection).
- **Live-Qdrant parity** (`tests/test_qdrant_multivector_parity.py`): a random
  dataset upserted into a Qdrant `MAX_SIM` collection, `exact=True` search,
  asserted to match nova-bf's top-K **ids and scores** (dot + cosine). Skips
  cleanly without docker/`qdrant-client`.
- Both pass on CPU **and** on a live A10G (CUDA 13 / torch 2.13), plus a
  96-run adversarial edge-case battery vs live Qdrant (heavy ties, asymmetric
  token counts, a 200-token doc, tiny/large magnitudes, k≥corpus).

## Performance (profiled on CPU + a live A10G)

The path is **matmul-bound** — the token×token products are irreducible exact
FLOPs (94% of score time at D=1024 on CPU, 66% on GPU once cuBLAS is involved);
the segment reductions already use the fastest primitive (`scatter_reduce(amax)`
beat `torch.segment_reduce` and `pad+amax` in benchmarks — `pad+amax` is 1.8×
slower and uses 1.8× the memory under realistic doc-length skew).

The one landed speedup is **opt-in `params.allow_tf32`** (default **off** so GT
stays bit-exact f32): measured **1.75×** on the GPU matmul (~1.4× on the score
path), ranking-preserving, and the live-Qdrant parity test still passes with it
on. Details + numbers in `docs/brute-force/multivector-maxsim.md`.

## Review & hardening

Beyond the initial implementation, this branch includes fixes from a 3-round
adversarial self-review, a live GPU optimization sweep, and two external code
audits:

- **Zero-token query was tiling-dependent** (scored `0.0` in the default path
  vs `-inf` when block-isolated) — now `-inf` everywhere, tiling-invariant.
- **All-zero-token corpus shard crashed coalesced runs** (width-0 concat) —
  now guarded.
- Decoder/query-loader hardening: null outer entries decided by the validity
  bitmap (not offsets); clear errors for dense-instead-of-multivector, null
  token floats, cross-file dim mismatch, null ids; alignment asserts.
- `score()`: removed a per-query-block CUDA→CPU sync (host-side offsets for the
  loop bounds); clear errors for unknown metric / dim mismatch; removed a dead
  duplicate `query_block` field.

## Known / non-blocking notes

- **Cosine sub-`1e-3`-norm divergence:** Qdrant applies an undocumented low-norm
  guard; nova-bf gives the true scale-invariant cosine. Never occurs on real
  O(1)-magnitude embeddings; documented, deliberately not replicated.
- **GPU sum non-determinism:** `index_add_` on CUDA uses atomic adds, so scores
  can differ ~1e-6 run-to-run (ranking/ids are stable; ties break by id). Bit-
  reproducible GPU *scores* would need `use_deterministic_algorithms(True)` at
  a perf cost — can add as opt-in if wanted.
- `merge.py` needed no changes (vector-type-agnostic), confirmed.

## Commits

- `f365dee` multivector implementation + CPU profiling writeup
- `da36588` adversarial-review fixes (2 bugs) + edge tests
- `8b86154` measured A10G GPU profiling + validation
- `4ae92bd` opt-in TF32 matmul (A10G-measured); pad+amax rejected
- `3c9a3c6` decoder/query-loader hardening (external audit)
- `11df879` score() review fixes (GPU sync, guards, dead field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
