### PR TITLE
Add recovery logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "nova-inspect"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "clap",
  "duckdb",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "nova-load"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "async-trait",
  "clap",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "nova-storm"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
     "crates/nova-load",
     "crates/nova-inspect",
 ]
-version = "0.0.10"
+version = "0.0.11"
 
 # Shrink debug-build artifacts (the `target/` dir was filling the disk). These are
 # profile keys, so they must live under [profile.*], not [workspace].

--- a/configs/loader/example.yaml
+++ b/configs/loader/example.yaml
@@ -2,6 +2,9 @@
 #   nova-load configs/loader/test.yaml
 # For distributed loading, shard the corpus across jobs with CLI flags:
 #   nova-load configs/loader/test.yaml --num-jobs 25 --job-rank $SKYPILOT_JOB_RANK
+# If a worker dies mid-load, rerun it with --continue to resume where it
+# stopped (probes the store for its slice's progress; safe to pass on every
+# rank, even finished ones — see docs/loading "Resuming an interrupted load").
 # (workers should also pass --no-manage-indexing so only the master creates the
 # collection). Resources/dispatch are an orchestration concern now, not part of
 # this file — the loader rejects unknown top-level keys.

--- a/crates/nova-inspect/Cargo.toml
+++ b/crates/nova-inspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-inspect"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2024"
 repository = "https://github.com/qdrant-labs/supernova"
 

--- a/crates/nova-load/Cargo.toml
+++ b/crates/nova-load/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-load"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2024"
 repository = "https://github.com/qdrant-labs/supernova"
 

--- a/crates/nova-load/src/engine.rs
+++ b/crates/nova-load/src/engine.rs
@@ -151,16 +151,7 @@ impl ReadJob {
     }
 
     fn read_id(&self, col: &dyn Array, row: usize) -> Result<PointId, EngineError> {
-        if let Some(a) = col.as_any().downcast_ref::<StringArray>() {
-            return Ok(PointId::String(a.value(row).to_string()));
-        }
-        if let Some(a) = col.as_any().downcast_ref::<Int64Array>() {
-            return Ok(PointId::Integer(a.value(row) as u64));
-        }
-        if let Some(a) = col.as_any().downcast_ref::<UInt64Array>() {
-            return Ok(PointId::Integer(a.value(row)));
-        }
-        Err(self.schema_err(format!("id column must be string or integer, got {:?}", col.data_type())))
+        id_at(col, row).map_err(|detail| self.schema_err(detail))
     }
 
     /// Coerce one shard-key cell into a [`ShardKeyValue`]. Strict on purpose:
@@ -273,6 +264,50 @@ impl ReadJob {
     fn schema_err(&self, detail: String) -> EngineError {
         EngineError::Schema { file: self.filename.clone(), detail }
     }
+}
+
+/// Read a point id out of an arrow column, or describe why the type is wrong
+/// (the caller attaches file context).
+fn id_at(col: &dyn Array, row: usize) -> Result<PointId, String> {
+    if let Some(a) = col.as_any().downcast_ref::<StringArray>() {
+        return Ok(PointId::String(a.value(row).to_string()));
+    }
+    if let Some(a) = col.as_any().downcast_ref::<Int64Array>() {
+        return Ok(PointId::Integer(a.value(row) as u64));
+    }
+    if let Some(a) = col.as_any().downcast_ref::<UInt64Array>() {
+        return Ok(PointId::Integer(a.value(row)));
+    }
+    Err(format!("id column must be string or integer, got {:?}", col.data_type()))
+}
+
+/// Evaluate `id_expression` for one VIRTUAL row — `filename` bound to the
+/// given name, `file_row_number` to `row` — with the loader macros registered
+/// and NO file access. This only succeeds when the expression is a pure
+/// function of those two pseudo-columns (like the default
+/// `vf_point_id(filename, file_row_number)`); an expression referencing any
+/// real data column fails to bind, and the caller falls back to reading the
+/// file. Used by the `--continue` resume probe to compute a file's first
+/// point id without downloading it. Blocking — call from `spawn_blocking`.
+pub fn eval_virtual_id(
+    filename: &str,
+    row: i64,
+    id_expression: &str,
+) -> Result<PointId, EngineError> {
+    let conn = Connection::open_in_memory()?;
+    register_macros(&conn)?;
+    let sql = format!(
+        "SELECT {id_expression} AS __id \
+         FROM (SELECT '{}' AS filename, {row}::BIGINT AS file_row_number)",
+        esc_str(filename),
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let batch = stmt.query_arrow(params![])?.next().ok_or_else(|| EngineError::Schema {
+        file: filename.to_string(),
+        detail: "virtual id evaluation returned no rows".into(),
+    })?;
+    id_at(batch.column(0).as_ref(), 0)
+        .map_err(|detail| EngineError::Schema { file: filename.to_string(), detail })
 }
 
 /// Infer dense/multivector dimensions from the first point of a file. An
@@ -541,5 +576,23 @@ mod tests {
             detail.contains("must return a string or integer"),
             "unexpected detail: {detail}"
         );
+    }
+
+    /// The virtual evaluation matches a real file read for the default id
+    /// expression — so `--continue` resume probes need no download at all.
+    #[test]
+    fn virtual_id_matches_file_read_for_row_expressions() {
+        let points = read_points(None).unwrap();
+        let virt =
+            eval_virtual_id("f.parquet", 0, "vf_point_id(filename, file_row_number)").unwrap();
+        assert_eq!(virt, points[0].id);
+    }
+
+    /// Column-referencing id expressions can't bind against the virtual row —
+    /// the resume probe falls back to reading the file.
+    #[test]
+    fn virtual_id_rejects_column_expressions() {
+        assert!(eval_virtual_id("f.parquet", 0, "substr(id, 11, 36)").is_err());
+        assert!(eval_virtual_id("f.parquet", 0, "label").is_err());
     }
 }

--- a/crates/nova-load/src/lib.rs
+++ b/crates/nova-load/src/lib.rs
@@ -15,7 +15,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use config::{LoadConfig, LoaderConfig, VectorSpec};
 use plan::Partition;
 use sources::{DataSource, DataSourceConfig, FileRef};
-use stores::{CollectionSchema, Point, StoreError, VectorStore};
+use stores::{CollectionSchema, Point, PointId, StoreError, VectorStore};
 
 #[derive(Debug, thiserror::Error)]
 pub enum LoadError {
@@ -57,6 +57,7 @@ pub async fn run(config: LoadConfig) -> Result<(), LoadError> {
         &config.loader,
         all_files,
         Partition::single(),
+        0,
     )
     .await?;
 
@@ -82,9 +83,37 @@ pub async fn prepare(config: LoadConfig) -> Result<(), LoadError> {
 
 /// Worker step: load this worker's slice of the files. Assumes the collection
 /// already exists (run `prepare` first) and does NOT manage indexing.
-pub async fn load(config: LoadConfig, partition: Partition) -> Result<(), LoadError> {
+///
+/// With `resume` (the `--continue` flag), first find where a previous run of
+/// this same slice stopped — a binary search probing the store for each
+/// file's first point id — and skip the files already fully loaded. Safe to
+/// pass unconditionally: against a fresh collection every probe misses and
+/// the whole slice loads; on a finished worker only the final file is redone
+/// (upserts are idempotent). Requires the same corpus and `--num-jobs` as the
+/// interrupted run, and a deterministic `id_expression`.
+pub async fn load(config: LoadConfig, partition: Partition, resume: bool) -> Result<(), LoadError> {
     let store = config.vectorstore.connect().await?;
     let all_files = config.datasource.list_files().await?;
+
+    let skip_files = if resume {
+        let slice = plan::partition(&all_files, partition);
+        let start = resume_start(store.as_ref(), &config.datasource, &slice).await?;
+        if start > 0 {
+            tracing::info!(
+                "--continue: resuming at file {start}/{} of this slice (`{}`); {start} file(s) \
+                 probe as loaded and are skipped — the boundary file itself is re-upserted, \
+                 since the previous run may have died mid-file (idempotent)",
+                slice.len(),
+                slice[start].key,
+            );
+        } else {
+            tracing::info!("--continue: no prior progress found for this slice; loading all of it");
+        }
+        start
+    } else {
+        0
+    };
+
     let n = load_files(
         store.as_ref(),
         &config.datasource,
@@ -92,10 +121,111 @@ pub async fn load(config: LoadConfig, partition: Partition) -> Result<(), LoadEr
         &config.loader,
         all_files,
         partition,
+        skip_files,
     )
     .await?;
     tracing::info!("worker {}/{} done: {n} points", partition.rank, partition.num_jobs);
     Ok(())
+}
+
+/// Where a previous run of this worker's slice stopped: the index of the
+/// first file to (re)load. Files complete strictly in order within a worker
+/// (see `load_files`), so the loaded files form a prefix of the slice and a
+/// binary search over "does this file's first point exist in the store" finds
+/// the boundary in ~log2(slice) probes.
+///
+/// Returns the boundary *inclusive*: the last loaded-looking file is
+/// re-uploaded rather than skipped, because batches within a file land out of
+/// order — the file in flight at the moment of death can have its first
+/// batch stored while later ones are missing. One file of redundant,
+/// idempotent work buys the no-gaps guarantee.
+async fn resume_start(
+    store: &dyn VectorStore,
+    datasource: &DataSourceConfig,
+    files: &[FileRef],
+) -> Result<usize, LoadError> {
+    let id_expression = datasource.reader().id_expression.clone();
+    let probe = async |i: usize| -> Result<bool, LoadError> {
+        let file = &files[i];
+        let loaded = match first_point_id(datasource, file, &id_expression).await? {
+            Some(id) => store.point_exists(&id).await?,
+            // An empty file has no first row to probe; calling it "not loaded"
+            // errs early (re-scanning it is free — it has no points).
+            None => false,
+        };
+        tracing::info!(
+            "--continue probe: file[{i}] `{}` → {}",
+            file.key,
+            if loaded { "loaded" } else { "not loaded" },
+        );
+        Ok(loaded)
+    };
+    Ok(bisect_last_loaded(files.len(), probe).await?.unwrap_or(0))
+}
+
+/// The id of `file`'s first row (row 0), or `None` for an empty file. Tries
+/// the no-IO virtual evaluation first — id expressions over only `filename` /
+/// `file_row_number` (the default `vf_point_id`) never touch the file — and
+/// falls back to downloading the file and reading a single row when the
+/// expression references real data columns.
+async fn first_point_id(
+    datasource: &DataSourceConfig,
+    file: &FileRef,
+    id_expression: &str,
+) -> Result<Option<PointId>, LoadError> {
+    let (key, expr) = (file.key.clone(), id_expression.to_string());
+    let virtual_id = tokio::task::spawn_blocking(move || engine::eval_virtual_id(&key, 0, &expr))
+        .await?;
+    if let Ok(id) = virtual_id {
+        return Ok(Some(id));
+    }
+
+    let local = datasource.fetch(file).await?;
+    let read_job = engine::ReadJob {
+        path: local.path().to_path_buf(),
+        filename: local.source.key.clone(),
+        vectors: HashMap::new(), // id only — no vectors, no payload
+        payload: HashMap::new(),
+        id_expression: id_expression.to_string(),
+        shard_key_expr: None,
+        limit: Some(1),
+    };
+    let points = tokio::task::spawn_blocking(move || read_job.run()).await??;
+    Ok(points.into_iter().next().map(|p| p.id))
+}
+
+/// Find the greatest index in `0..n` whose probe reports "loaded", assuming
+/// the loaded indexes form a prefix (`probe` is monotone true→false). `None`
+/// when index 0 already misses. Costs at most `2 + log2(n)` probes.
+///
+/// A stray miss inside the loaded prefix (a file the original run *skipped*
+/// after exhausting its retries) leaves the search landing on some
+/// loaded-probing index at or before the true boundary. Everything from the
+/// result onward gets (re)loaded, so nothing the original run had loaded or
+/// hadn't reached is ever skipped; a file the original run skipped stays
+/// skipped — the same outcome (and warning) the original run already
+/// reported.
+async fn bisect_last_loaded<F>(n: usize, mut probe: F) -> Result<Option<usize>, LoadError>
+where
+    F: AsyncFnMut(usize) -> Result<bool, LoadError>,
+{
+    if n == 0 || !probe(0).await? {
+        return Ok(None);
+    }
+    if probe(n - 1).await? {
+        return Ok(Some(n - 1));
+    }
+    // Invariant: probe(lo) == true, probe(hi) == false.
+    let (mut lo, mut hi) = (0usize, n - 1);
+    while hi - lo > 1 {
+        let mid = lo + (hi - lo) / 2;
+        if probe(mid).await? {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    Ok(Some(lo))
 }
 
 /// Master step: re-enable indexing and wait for it to settle. Run once, after
@@ -264,6 +394,7 @@ async fn load_files(
     loader: &LoaderConfig,
     all_files: Vec<FileRef>,
     partition: Partition,
+    skip_files: usize,
 ) -> Result<u64, LoadError> {
     let batch_size = loader.batch_size.max(1);
     let concurrency = loader.concurrency.max(1);
@@ -280,7 +411,10 @@ async fn load_files(
     let sharding = shard_key_expr.is_some();
 
     let total_files = all_files.len();
-    let files = plan::partition(&all_files, partition);
+    let mut files = plan::partition(&all_files, partition);
+    // `--continue` resume: the first `skip_files` of this slice probed as
+    // already loaded (see `resume_start`).
+    files.drain(..skip_files.min(files.len()));
     if files.is_empty() {
         tracing::warn!(
             "worker {}/{} has no files of {total_files} to load (more workers than files?)",
@@ -574,6 +708,51 @@ mod tests {
             let first = &chunk[0].shard_key;
             assert!(chunk.iter().all(|p| p.shard_key == *first), "chunk mixes shard keys");
         }
+    }
+
+    async fn bisect(states: &[bool]) -> Option<usize> {
+        bisect_last_loaded(states.len(), async |i| Ok(states[i])).await.unwrap()
+    }
+
+    /// Every prefix length resolves to its exact boundary (resume-inclusive).
+    #[tokio::test]
+    async fn bisect_finds_the_loaded_prefix_boundary() {
+        assert_eq!(bisect(&[]).await, None);
+        assert_eq!(bisect(&[false]).await, None);
+        assert_eq!(bisect(&[true]).await, Some(0));
+        assert_eq!(bisect(&[true, false]).await, Some(0));
+        assert_eq!(bisect(&[true, true, false, false, false]).await, Some(1));
+        for k in 0..=33 {
+            let states: Vec<bool> = (0..33).map(|i| i < k).collect();
+            let want = if k == 0 { None } else { Some(k - 1) };
+            assert_eq!(bisect(&states).await, want, "prefix length {k}");
+        }
+    }
+
+    /// A miss poked into the prefix (a file the original run skipped after
+    /// retries) must leave the result on a loaded-probing index at or before
+    /// the true boundary — never past it.
+    #[tokio::test]
+    async fn bisect_with_skipped_file_stays_at_or_before_the_boundary() {
+        let states = [true, false, true, true, false, false];
+        let got = bisect(&states).await.expect("prefix starts loaded");
+        assert!(got <= 3, "resume index {got} is past the true boundary");
+        assert!(states[got], "resume index {got} must probe as loaded");
+    }
+
+    #[tokio::test]
+    async fn bisect_probe_count_is_logarithmic() {
+        use std::cell::Cell;
+        let (n, boundary) = (1024usize, 700usize); // loaded prefix 0..700
+        let calls = Cell::new(0usize);
+        let got = bisect_last_loaded(n, async |i| {
+            calls.set(calls.get() + 1);
+            Ok(i < boundary)
+        })
+        .await
+        .unwrap();
+        assert_eq!(got, Some(boundary - 1));
+        assert!(calls.get() <= 2 + n.ilog2() as usize, "{} probes for n={n}", calls.get());
     }
 
     /// Numbers sort before keywords (enum variant order) — the exact order is

--- a/crates/nova-load/src/main.rs
+++ b/crates/nova-load/src/main.rs
@@ -53,6 +53,15 @@ struct LoadArgs {
     /// This job's index, in `[0, num_jobs)`. Each job loads its own slice.
     #[arg(long, default_value_t = 0)]
     job_rank: usize,
+    /// Resume an interrupted load: binary-search this worker's slice, probing
+    /// the store for each file's first point id, and skip the files already
+    /// fully loaded (the boundary file is re-upserted — idempotent). Safe to
+    /// pass unconditionally: a fresh collection loads from scratch and a
+    /// finished worker redoes only its final file. Requires the same corpus
+    /// and --num-jobs as the interrupted run, and a deterministic
+    /// id_expression. (Ignored by `inspect`.)
+    #[arg(long = "continue", visible_alias = "resume", default_value_t = false)]
+    resume: bool,
 }
 
 impl LoadArgs {
@@ -97,7 +106,7 @@ async fn run(command: Command) -> Result<(), ExitCode> {
                 eprintln!("error: {e}");
                 ExitCode::FAILURE
             })?;
-            nova_load::load(load_config(&a.config)?, partition).await
+            nova_load::load(load_config(&a.config)?, partition, a.resume).await
         }
         Command::Inspect(a) => {
             let partition = a.partition().map_err(|e| {

--- a/crates/nova-load/src/stores/elastic.rs
+++ b/crates/nova-load/src/stores/elastic.rs
@@ -506,6 +506,14 @@ impl VectorStore for ElasticStore {
         Ok(())
     }
 
+    async fn point_exists(&self, _id: &PointId) -> Result<bool, StoreError> {
+        // The `--continue` resume probe is Qdrant-only for now; implementing
+        // it here needs a cheap get-by-id (doable, just untested).
+        Err(StoreError::Other(
+            "`--continue` resume probing is not implemented for the elastic backend".into(),
+        ))
+    }
+
     async fn close(&self) -> Result<(), StoreError> {
         Ok(())
     }

--- a/crates/nova-load/src/stores/milvus_store.rs
+++ b/crates/nova-load/src/stores/milvus_store.rs
@@ -819,6 +819,14 @@ impl VectorStore for MilvusStore {
         Ok(())
     }
 
+    async fn point_exists(&self, _id: &PointId) -> Result<bool, StoreError> {
+        // The `--continue` resume probe is Qdrant-only for now; implementing
+        // it here needs a cheap get-by-id (doable, just untested).
+        Err(StoreError::Other(
+            "`--continue` resume probing is not implemented for the milvus backend".into(),
+        ))
+    }
+
     async fn close(&self) -> Result<(), StoreError> {
         Ok(())
     }

--- a/crates/nova-load/src/stores/mod.rs
+++ b/crates/nova-load/src/stores/mod.rs
@@ -75,7 +75,7 @@ pub struct CollectionSchema {
 /// A point id. Backends differ on what they accept (Qdrant: `u64` or a UUID
 /// string; others allow arbitrary strings), so the core models the two shapes
 /// the reader can produce and lets each backend enforce its own rules.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PointId {
     Integer(u64),
@@ -180,6 +180,14 @@ pub trait VectorStore: Send + Sync + std::fmt::Display {
 
     /// Upsert a batch of points.
     async fn upsert_batch(&self, points: Vec<Point>) -> Result<(), StoreError>;
+
+    /// Whether a point with `id` currently exists in the collection. Powers
+    /// the loader's `--continue` resume probe (a binary search over a
+    /// worker's file slice for where a previous run stopped), so it must be
+    /// cheap: a single-id lookup fetching no payload and no vectors. Backends
+    /// without an implementation must return a clear "not supported" error —
+    /// there is no default, so every backend states its behavior.
+    async fn point_exists(&self, id: &PointId) -> Result<bool, StoreError>;
 
     /// Clean up connections.
     async fn close(&self) -> Result<(), StoreError>;

--- a/crates/nova-load/src/stores/qdrant.rs
+++ b/crates/nova-load/src/stores/qdrant.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use qdrant_client::qdrant::{
     BinaryQuantization, BinaryQuantizationEncoding, CollectionStatus, CompressionRatio,
     CreateCollectionBuilder, CreateShardKeyBuilder, CreateShardKeyRequestBuilder, Datatype,
-    Disabled, Distance, HnswConfigDiff, Memory, Modifier, MultiVectorComparator,
+    Disabled, Distance, GetPointsBuilder, HnswConfigDiff, Memory, Modifier, MultiVectorComparator,
     MultiVectorConfigBuilder,
     OptimizersConfigDiff, OptimizersConfigDiffBuilder, PointStruct, ProductQuantization,
     QuantizationType, ScalarQuantization, ShardKey, ShardKeySelector, ShardingMethod,
@@ -838,6 +838,25 @@ impl VectorStore for QdrantStore {
         }
         self.client.upsert_points(request).await?;
         Ok(())
+    }
+
+    async fn point_exists(&self, id: &PointId) -> Result<bool, StoreError> {
+        let qid: qdrant_client::qdrant::PointId = match id {
+            PointId::Integer(n) => (*n).into(),
+            PointId::String(s) => s.clone().into(),
+        };
+        // No payload, no vectors — pure existence. Under custom sharding a
+        // retrieve without a shard-key selector fans out across all shards,
+        // so this works regardless of where the point routed.
+        let resp = self
+            .client
+            .get_points(
+                GetPointsBuilder::new(self.collection_name.as_str(), vec![qid])
+                    .with_payload(false)
+                    .with_vectors(false),
+            )
+            .await?;
+        Ok(!resp.result.is_empty())
     }
 
     async fn close(&self) -> Result<(), StoreError> {

--- a/crates/nova-storm/Cargo.toml
+++ b/crates/nova-storm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-storm"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2024"
 repository = "https://github.com/qdrant-labs/supernova"
 

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -95,6 +95,11 @@ nova dist load configs/loader/test.yaml --num-jobs 50
 
 # 3. controller, after all workers finish: build the index
 nova dist load configs/loader/test.yaml --finalize
+
+# fleet died partway? relaunch it with --continue — every worker probes the
+# store for its slice's progress and resumes where it stopped (finished ranks
+# redo only their final file). Same corpus + --num-jobs required.
+nova dist load configs/loader/test.yaml --num-jobs 50 --continue
 ```
 
 `nova dist load` runs phase 1 locally, then fans out phase 2. Phase 3 is a

--- a/docs/loading/overview.md
+++ b/docs/loading/overview.md
@@ -53,6 +53,56 @@ loader:
 nova load configs/loader/my_dataset.yaml
 ```
 
+## Resuming an interrupted load (`--continue`)
+
+When a worker dies mid-load (spot preemption, the store buckling under load,
+an operator Ctrl-C), rerun the **same** command with `--continue`:
+
+```bash
+nova load load my.yaml --num-jobs 32 --job-rank 17 --continue
+```
+
+The worker finds where its previous run stopped and picks up from there,
+instead of re-upserting its whole slice. No checkpoint files, no coordination
+— the resume point is derived from the store itself:
+
+1. Within a worker, files complete **strictly in order** (batches of file
+   *N+1* never start before file *N* finishes), so the loaded files form a
+   prefix of the slice.
+2. The worker binary-searches its slice (~log2(files) probes), asking for each
+   probed file: *does this file's first point id exist in the collection?*
+3. It resumes **at** the last loaded-looking file — inclusive, because the
+   file in flight at the moment of death can be partially loaded (batches
+   within a file land out of order). Re-upserting it is idempotent: at most
+   one file of redundant work, and no gaps.
+
+Probe cost depends on the `id_expression`. Expressions over only `filename` /
+`file_row_number` — the default `vf_point_id(...)` — are evaluated with **no
+file access at all**: a resume is just a handful of point lookups,
+milliseconds. Expressions referencing data columns (e.g. fineweb's
+`substr(id, 11, 36)`) download one file per probe and read a single row —
+~log2(slice) downloads, typically a couple of minutes.
+
+Properties worth knowing:
+
+- **Safe to pass unconditionally.** A fresh collection probes all-miss and
+  loads from scratch; a finished worker probes all-hit and redoes only its
+  final file. So after a partial fleet failure, just relaunch **all** ranks
+  with `--continue` — no need to work out which ones died.
+- **Pairs with SkyPilot self-healing.** Put `--continue` in the task's `run:`
+  permanently and set `job_recovery: {max_restarts_on_errors: N}` — a worker
+  killed by cluster overload restarts and resumes itself.
+- **Requires** the same corpus (unchanged prefix) and the same `--num-jobs`
+  as the interrupted run — the stride must mean the same thing — and a
+  **deterministic** `id_expression` (a `random()`-based id can never match,
+  so `--continue` degrades to a full reload).
+- Upserts are idempotent overwrites, so `--continue` is a *time* optimization
+  — when in doubt, rerunning without it is always correct, just slower.
+- Files the original run **skipped** (after exhausting `file_retries`) stay
+  skipped, exactly as the original run warned. Resume never un-skips or
+  newly-skips anything.
+- Qdrant-only for now; the other backends return a clear error.
+
 ## Datasources
 
 ### S3

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -58,6 +58,7 @@ lifecycle so a fleet can prepare once, load in parallel, and finalize once.
 nova load run      <config>                          # single machine: all phases
 nova load prepare  <config>                          # master: create collection, defer indexing
 nova load load     <config> --num-jobs N --job-rank R  # worker: load this slice (no indexing mgmt)
+nova load load     <config> --num-jobs N --job-rank R --continue  # resume an interrupted worker
 nova load finalize <config>                          # master: re-enable + await indexing
 nova load reindex  <config>                          # patch HNSW/quantization/optimizers on an existing collection
 nova load delete   <config>                          # delete the collection if it exists
@@ -70,6 +71,12 @@ nova load inspect  <config> [--num-jobs N --job-rank R]  # dry inspection (confi
   stride, so workers need no coordination.
 - `--num-jobs` / `--job-rank` apply to `load` and `inspect` only (the phases that
   operate on a slice).
+- **`--continue`** (alias `--resume`, `load` only) resumes an interrupted worker:
+  it binary-searches the worker's slice — probing the store for each file's
+  first point id — and skips the files already fully loaded, re-upserting only
+  the boundary file (idempotent). Safe to pass on every rank, including ones
+  that finished. Same corpus and `--num-jobs` as the interrupted run required.
+  See [Resuming an interrupted load](../loading/overview.md#resuming-an-interrupted-load-continue).
 - **`reindex`** patches `vectorstore.params.{hnsw,quantization,optimizers}` on an
   *already-existing* collection in place — no data is touched, and it doesn't
   create the collection first. Useful for comparing index/quantization variants

--- a/python/nova-dist/src/nova_dist/cli.py
+++ b/python/nova-dist/src/nova_dist/cli.py
@@ -134,13 +134,15 @@ def embed(config, resources, num_jobs, pool_name, dry_run):
 @click.option("--pool-name", default=None)
 @click.option("--dry-run", is_flag=True)
 @click.option("--finalize", is_flag=True, help="Re-enable + await indexing on the controller (run after all workers finish). Does not launch a fleet.")
-def load(config, resources, num_jobs, pool_name, dry_run, finalize):
+@click.option("--continue", "continue_", is_flag=True, help="Resume an interrupted fleet: every worker gets `nova-load load --continue`, probing the store for its slice's progress and skipping files already loaded. Safe on every rank (finished ranks redo only their final file). Requires the same corpus and --num-jobs as the interrupted run.")
+def load(config, resources, num_jobs, pool_name, dry_run, finalize, continue_):
     """
     Load pre-embedded parquet across a pool.
 
     Lifecycle: this command runs `prepare` on the controller, then fans out N
     `load` workers (each takes its file slice). When they've all finished, run
-    `nova dist load <config> --finalize` to build the index.
+    `nova dist load <config> --finalize` to build the index. If the fleet dies
+    partway, relaunch with `--continue` — workers resume where they stopped.
     """
     if finalize:
         _run_local("nova-load", ["finalize", config])
@@ -148,7 +150,9 @@ def load(config, resources, num_jobs, pool_name, dry_run, finalize):
     if num_jobs is None:
         raise click.UsageError("--num-jobs is required (unless --finalize).")
 
-    # 1. Master creates the collection + defers indexing.
+    # 1. Master creates the collection + defers indexing. Idempotent, so it
+    #    also runs on --continue (re-deferring indexing is exactly right when
+    #    resuming a bulk load).
     if not dry_run:
         _run_local("nova-load", ["prepare", config])
 
@@ -156,7 +160,8 @@ def load(config, resources, num_jobs, pool_name, dry_run, finalize):
     #    so pass it explicitly from the env SkyPilot sets per job.
     _fanout(
         "load", config, resources, num_jobs, pool_name, dry_run,
-        run_cmd="nova-load load {cfg} --num-jobs {n} --job-rank $SKYPILOT_JOB_RANK",
+        run_cmd="nova-load load {cfg} --num-jobs {n} --job-rank $SKYPILOT_JOB_RANK"
+        + (" --continue" if continue_ else ""),
         env_extra=["QDRANT_URL", "QDRANT_API_KEY"],
     )
 


### PR DESCRIPTION
Adds a new `--continue` flag to `nova-load` that introspects the current load state and will "recover" if a loader/worker failed.

At a high level, it simply looks at which point-ids have been loaded and which are still left to upsert, and skips anything in the database already.

This is achieved using a combination of binary search across file point ids and the `retrieve` API in qdrant.

This makes it possible to recover a run if it died halfway through for some reason