### PR TITLE
`nova-load` rate limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "nova-inspect"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "clap",
  "duckdb",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "nova-load"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "async-trait",
  "clap",
@@ -2136,6 +2136,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tonic 0.14.6",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2143,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "nova-storm"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
     "crates/nova-load",
     "crates/nova-inspect",
 ]
-version = "0.0.11"
+version = "0.0.12"
 
 # Shrink debug-build artifacts (the `target/` dir was filling the disk). These are
 # profile keys, so they must live under [profile.*], not [workspace].

--- a/configs/loader/example.yaml
+++ b/configs/loader/example.yaml
@@ -59,6 +59,11 @@ vectorstore:
   url: ${QDRANT_URL}
   api_key: ${QDRANT_API_KEY}
   upsert_wait: false
+  # Per-request / connect timeouts in seconds (defaults 120 / 10). The client's
+  # own default is 5s — too short for upserts into a loaded cluster (the server
+  # still applies the write; the retry re-sends it). Raise under backpressure.
+  # timeout_s: 300
+  # connect_timeout_s: 10
   # --- custom (user-defined) sharding, Qdrant-only (uncomment to try) ---
   # `shard_key` is a DuckDB expression evaluated per row, in the same context
   # as payload_fields (source columns, filename, file_row_number, macros). It
@@ -105,3 +110,7 @@ vectorstore:
 loader:
   batch_size: 256
   concurrency: 4
+  # Per-WORKER upsert ceiling (points/sec; unset = unlimited). An upper bound,
+  # not a target. A fleet of N workers presents N× this to the store — the
+  # startup log prints that fleet-wide figure.
+  # max_points_per_sec: 5000

--- a/crates/nova-inspect/Cargo.toml
+++ b/crates/nova-inspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-inspect"
-version = "0.0.11"
+version = "0.0.12"
 edition = "2024"
 repository = "https://github.com/qdrant-labs/supernova"
 

--- a/crates/nova-load/Cargo.toml
+++ b/crates/nova-load/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-load"
-version = "0.0.11"
+version = "0.0.12"
 edition = "2024"
 repository = "https://github.com/qdrant-labs/supernova"
 
@@ -54,3 +54,8 @@ milvus = ["dep:milvus", "dep:reqwest"]
 
 [dev-dependencies]
 rstest = "0.26.1"
+# Constructing tonic::Status values in the retryability tests; must track
+# qdrant-client's tonic major (compile error on drift, not silent skew).
+tonic = "0.14"
+# `start_paused` tokio tests for the rate limiter (virtual time).
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/nova-load/src/config.rs
+++ b/crates/nova-load/src/config.rs
@@ -44,6 +44,15 @@ pub struct LoaderConfig {
     /// silently skipping the whole corpus.
     #[serde(default)]
     pub max_failed_files: Option<usize>,
+    /// Ceiling on points upserted per second **by this process** — an upper
+    /// bound, not a target: the loader gets as close as it can and never
+    /// exceeds it (token bucket, one second of burst). Unset = unlimited. It
+    /// applies per worker like every other `loader:` knob, so a fleet of N
+    /// workers presents N× this rate to the store; the startup log and
+    /// `inspect` print that fleet-wide figure. Use it to hold a cluster under
+    /// the ingest rate at which it starts timing out.
+    #[serde(default)]
+    pub max_points_per_sec: Option<u64>,
 }
 
 impl Default for LoaderConfig {
@@ -55,6 +64,7 @@ impl Default for LoaderConfig {
             file_retries: default_file_retries(),
             upsert_retries: default_upsert_retries(),
             max_failed_files: None,
+            max_points_per_sec: None,
         }
     }
 }
@@ -398,5 +408,16 @@ mod tests {
             expand("x: ${UNCLOSED", &[]).unwrap_err(),
             ConfigError::UnterminatedPlaceholder
         ));
+    }
+
+    /// `max_points_per_sec` is optional (unlimited when absent) and parses as
+    /// a plain integer when set.
+    #[test]
+    fn loader_rate_limit_parses_and_defaults_to_unlimited() {
+        let unset: LoaderConfig = serde_yaml::from_str("batch_size: 10").unwrap();
+        assert_eq!(unset.max_points_per_sec, None);
+        assert_eq!(LoaderConfig::default().max_points_per_sec, None);
+        let set: LoaderConfig = serde_yaml::from_str("max_points_per_sec: 2500").unwrap();
+        assert_eq!(set.max_points_per_sec, Some(2500));
     }
 }

--- a/crates/nova-load/src/lib.rs
+++ b/crates/nova-load/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod engine;
 pub mod plan;
+pub mod rate;
 pub mod sources;
 pub mod stores;
 
@@ -280,6 +281,9 @@ pub async fn inspect(config: LoadConfig, partition: Partition) -> Result<(), Loa
     println!("== nova-load inspect ==\n");
     println!("partition:   job_rank={} num_jobs={}", partition.rank, partition.num_jobs);
     println!("loader:      {:?}", config.loader);
+    if let Some(rate) = config.loader.max_points_per_sec {
+        println!("rate limit:  {}", describe_rate_limit(rate, partition.num_jobs));
+    }
     println!("vectorstore: {:?}", config.vectorstore);
     println!("datasource:  {:?}", config.datasource);
     println!("vectors:     {:?}", config.vectors);
@@ -399,6 +403,13 @@ async fn load_files(
     let batch_size = loader.batch_size.max(1);
     let concurrency = loader.concurrency.max(1);
     let look_ahead = loader.file_look_ahead.max(1);
+    // Per-worker upsert ceiling (see `rate`). Every attempt draws tokens, so
+    // retries can't push the store past the cap either.
+    let limiter = loader.max_points_per_sec.map(|r| rate::RateLimiter::new(r, batch_size));
+    if let Some(r) = loader.max_points_per_sec {
+        tracing::info!("rate limit: {}", describe_rate_limit(r, partition.num_jobs));
+    }
+    let cap = loader.max_points_per_sec.map(|r| format!(" (cap {r})")).unwrap_or_default();
     let file_retries = loader.file_retries;
     let upsert_retries = loader.upsert_retries;
     let max_failed_files = loader.max_failed_files;
@@ -516,6 +527,8 @@ async fn load_files(
     let progress = &progress;
     let points_done = &points_done;
     let rate_window = &rate_window;
+    let limiter = &limiter;
+    let cap = &cap;
 
     let mut skipped = 0u64;
     let mut fragmentation_warned = false;
@@ -571,9 +584,19 @@ async fn load_files(
                 // (store down / misconfigured) aborts the run via `?` on try_collect.
                 let mut attempt = 0u32;
                 loop {
+                    if let Some(limiter) = limiter {
+                        limiter.acquire(chunk.len()).await;
+                    }
                     match store.upsert_batch(chunk.to_vec()).await {
                         Ok(()) => break,
                         Err(err) => {
+                            // A bad request / auth / missing collection can't
+                            // succeed on retry — don't burn the budget (and
+                            // don't keep re-sending the same points).
+                            if !err.is_retryable() {
+                                tracing::error!("upsert batch failed with a non-retryable error: {err}");
+                                return Err(err);
+                            }
                             attempt += 1;
                             if attempt > upsert_retries as u32 {
                                 return Err(err);
@@ -601,9 +624,9 @@ async fn load_files(
                     *w = (Instant::now(), done);
                     drop(w);
                     if tty {
-                        progress.set_message(format!("{done} pts · {rate:.0} pts/s"));
+                        progress.set_message(format!("{done} pts · {rate:.0} pts/s{cap}"));
                     } else {
-                        tracing::info!("{done} pts · {rate:.0} pts/s");
+                        tracing::info!("{done} pts · {rate:.0} pts/s{cap}");
                     }
                 }
                 Ok::<(), StoreError>(())
@@ -650,6 +673,20 @@ fn shard_chunks(points: &[Point], batch_size: usize) -> Vec<&[Point]> {
         start += len;
     }
     chunks
+}
+
+/// The rate cap as configured (per worker) plus what that means for the
+/// whole fleet — so both the "this process" and "the cluster sees" mental
+/// models get their number without changing the knob's semantics.
+fn describe_rate_limit(per_worker: u64, num_jobs: usize) -> String {
+    if num_jobs > 1 {
+        format!(
+            "{per_worker} pts/s per worker (× {num_jobs} workers = {} pts/s fleet-wide)",
+            per_worker as u128 * num_jobs as u128
+        )
+    } else {
+        format!("{per_worker} pts/s")
+    }
 }
 
 /// Human-readable byte count (e.g. `2.4 MB`).
@@ -753,6 +790,15 @@ mod tests {
         .unwrap();
         assert_eq!(got, Some(boundary - 1));
         assert!(calls.get() <= 2 + n.ilog2() as usize, "{} probes for n={n}", calls.get());
+    }
+
+    #[test]
+    fn rate_limit_description_shows_fleet_math_only_for_fleets() {
+        assert_eq!(describe_rate_limit(5000, 1), "5000 pts/s");
+        assert_eq!(
+            describe_rate_limit(5000, 32),
+            "5000 pts/s per worker (× 32 workers = 160000 pts/s fleet-wide)"
+        );
     }
 
     /// Numbers sort before keywords (enum variant order) — the exact order is

--- a/crates/nova-load/src/rate.rs
+++ b/crates/nova-load/src/rate.rs
@@ -1,0 +1,114 @@
+//! Per-process upsert throttle: a token bucket denominated in points.
+//!
+//! `loader.max_points_per_sec` is an upper bound, not a target — the loader
+//! gets as close to it as the store allows and never exceeds it. The bucket
+//! holds one second of the rate (or one batch, whichever is larger, so a
+//! single batch can always proceed), starts full, and refills continuously.
+//! Every upsert *attempt* draws its batch's worth of tokens — retries are
+//! load on the store too. Shared by all of a worker's concurrent upsert tasks.
+//!
+//! Uses `tokio::time::Instant` so tests can run under tokio's paused clock.
+
+use std::time::Duration;
+
+use tokio::time::Instant;
+
+pub struct RateLimiter {
+    /// Tokens (points) added per second.
+    rate: f64,
+    /// Burst ceiling: tokens the bucket can hold.
+    capacity: f64,
+    state: tokio::sync::Mutex<Bucket>,
+}
+
+struct Bucket {
+    tokens: f64,
+    refilled_at: Instant,
+}
+
+impl RateLimiter {
+    /// `points_per_sec` is the sustained ceiling (clamped to ≥ 1);
+    /// `batch_size` guarantees the bucket can hold at least one batch.
+    pub fn new(points_per_sec: u64, batch_size: usize) -> Self {
+        let rate = points_per_sec.max(1) as f64;
+        let capacity = rate.max(batch_size as f64);
+        Self {
+            rate,
+            capacity,
+            state: tokio::sync::Mutex::new(Bucket { tokens: capacity, refilled_at: Instant::now() }),
+        }
+    }
+
+    /// Wait until `points` tokens are available, then take them. A request
+    /// larger than the bucket is clamped to its capacity rather than blocking
+    /// forever — it just drains the bucket.
+    pub async fn acquire(&self, points: usize) {
+        let need = (points as f64).min(self.capacity);
+        loop {
+            let wait = {
+                let mut b = self.state.lock().await;
+                let now = Instant::now();
+                let elapsed = now.duration_since(b.refilled_at).as_secs_f64();
+                b.tokens = (b.tokens + elapsed * self.rate).min(self.capacity);
+                b.refilled_at = now;
+                if b.tokens >= need {
+                    b.tokens -= need;
+                    return;
+                }
+                Duration::from_secs_f64((need - b.tokens) / self.rate)
+            };
+            tokio::time::sleep(wait).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Under tokio's paused clock, sleeps advance virtual time instantly, so
+    /// elapsed time measures exactly how long the limiter *would* have held
+    /// the caller.
+    #[tokio::test(start_paused = true)]
+    async fn sustained_rate_is_capped() {
+        let limiter = RateLimiter::new(100, 10);
+        let start = Instant::now();
+
+        // The bucket starts full: one second's worth is free.
+        limiter.acquire(100).await;
+        assert_eq!(start.elapsed(), Duration::ZERO);
+
+        // The next 100 need a full second of refill.
+        limiter.acquire(100).await;
+        assert!(start.elapsed() >= Duration::from_millis(999), "{:?}", start.elapsed());
+
+        // 500 more points ≈ 5 more seconds, regardless of batch shape.
+        for _ in 0..50 {
+            limiter.acquire(10).await;
+        }
+        let elapsed = start.elapsed();
+        assert!(elapsed >= Duration::from_millis(5_990), "{elapsed:?}");
+        assert!(elapsed < Duration::from_millis(6_100), "{elapsed:?}");
+    }
+
+    /// A batch bigger than the bucket drains it and proceeds — it must never
+    /// deadlock waiting for tokens that can't exist.
+    #[tokio::test(start_paused = true)]
+    async fn oversized_batch_never_deadlocks() {
+        let limiter = RateLimiter::new(10, 5); // capacity 10
+        let start = Instant::now();
+        limiter.acquire(1_000).await; // clamps to 10: instant
+        assert_eq!(start.elapsed(), Duration::ZERO);
+        limiter.acquire(1_000).await; // clamps to 10: one second of refill
+        assert!(start.elapsed() >= Duration::from_millis(999), "{:?}", start.elapsed());
+    }
+
+    /// The capacity is at least one batch even when the rate is tiny.
+    #[tokio::test(start_paused = true)]
+    async fn capacity_covers_one_batch() {
+        let limiter = RateLimiter::new(1, 256);
+        let start = Instant::now();
+        limiter.acquire(256).await; // full batch from the initial fill: instant
+        assert_eq!(start.elapsed(), Duration::ZERO);
+    }
+}

--- a/crates/nova-load/src/stores/mod.rs
+++ b/crates/nova-load/src/stores/mod.rs
@@ -32,6 +32,29 @@ impl From<qdrant_client::QdrantError> for StoreError {
     }
 }
 
+impl StoreError {
+    /// Whether retrying the identical request could plausibly succeed.
+    /// Transient conditions — timeouts, unavailable, overloaded, dropped
+    /// connections — can; request, auth, and schema problems cannot, and
+    /// retrying those only burns the retry budget while re-sending work to a
+    /// store that already rejected it. Backend-agnostic `Other` errors carry
+    /// no status, so they keep the historical assume-transient behavior.
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            StoreError::Qdrant(err) => match err.as_ref() {
+                qdrant_client::QdrantError::ResponseError { status } => !matches!(
+                    status.code() as i32,
+                    // INVALID_ARGUMENT | NOT_FOUND | PERMISSION_DENIED |
+                    // UNIMPLEMENTED | UNAUTHENTICATED
+                    3 | 5 | 7 | 12 | 16
+                ),
+                _ => true,
+            },
+            StoreError::Other(_) => true,
+        }
+    }
+}
+
 /// Vectorstore backend config, dispatched on `type:`. Each backend owns its
 /// config struct in its own module; the variant is gated on the same feature.
 #[derive(Debug, Deserialize)]
@@ -252,4 +275,39 @@ pub trait VectorStore: Send + Sync + std::fmt::Display {
 
     /// Delete the collection if it exists. A no-op if it doesn't.
     async fn delete_collection(&self) -> Result<(), StoreError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn status_err(status: tonic::Status) -> StoreError {
+        StoreError::from(qdrant_client::QdrantError::ResponseError { status })
+    }
+
+    /// Transient gRPC statuses retry; request/auth problems abort immediately.
+    #[test]
+    fn retryability_follows_grpc_status() {
+        for transient in [
+            tonic::Status::deadline_exceeded("slow"),
+            tonic::Status::cancelled("Timeout expired"),
+            tonic::Status::unavailable("connect refused"),
+            tonic::Status::resource_exhausted("too many requests"),
+            tonic::Status::internal("service internal error"),
+            tonic::Status::unknown("?"),
+        ] {
+            assert!(status_err(transient.clone()).is_retryable(), "{transient:?}");
+        }
+        for fatal in [
+            tonic::Status::invalid_argument("Unable to parse UUID"),
+            tonic::Status::not_found("collection missing"),
+            tonic::Status::unauthenticated("bad api key"),
+            tonic::Status::permission_denied("nope"),
+            tonic::Status::unimplemented("no"),
+        ] {
+            assert!(!status_err(fatal.clone()).is_retryable(), "{fatal:?}");
+        }
+        // No status to inspect → assume transient (other backends' behavior).
+        assert!(StoreError::Other("bulk upsert failed".into()).is_retryable());
+    }
 }

--- a/crates/nova-load/src/stores/qdrant.rs
+++ b/crates/nova-load/src/stores/qdrant.rs
@@ -45,6 +45,17 @@ pub struct QdrantConfig {
     /// Whether upserts block until the write is applied (slower, stronger).
     #[serde(default)]
     pub upsert_wait: bool,
+    /// Per-request timeout in seconds. qdrant-client's own default is FIVE
+    /// seconds — far too short for upserts into a cluster under load: the
+    /// client gives up, the server most likely still applies the write, and
+    /// the retry re-sends the same points (duplicate work for an already-slow
+    /// cluster), so a tight timeout *amplifies* backpressure instead of
+    /// surviving it. Default 120.
+    #[serde(default = "default_timeout_s")]
+    pub timeout_s: u64,
+    /// Connection-establishment timeout in seconds. Default 10.
+    #[serde(default = "default_connect_timeout_s")]
+    pub connect_timeout_s: u64,
     /// Custom (user-defined) sharding: the collection is created with
     /// `sharding_method: custom` and every point routes to the shard key its
     /// `shard_key` expression evaluates to. See [`CustomSharding`].
@@ -64,6 +75,8 @@ impl fmt::Debug for QdrantConfig {
             .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
             .field("collection_name", &self.collection_name)
             .field("upsert_wait", &self.upsert_wait)
+            .field("timeout_s", &self.timeout_s)
+            .field("connect_timeout_s", &self.connect_timeout_s)
             .field("custom_sharding", &self.custom_sharding)
             .field("params", &self.params)
             .finish()
@@ -509,6 +522,14 @@ fn default_collection() -> String {
     "default".to_string()
 }
 
+fn default_timeout_s() -> u64 {
+    120
+}
+
+fn default_connect_timeout_s() -> u64 {
+    10
+}
+
 /// A connected Qdrant backend. Unlike the data sources (where the config itself
 /// implements the trait), the store holds an initialized client reused across
 /// every `upsert_batch`, so it's a distinct runtime object built once.
@@ -529,6 +550,8 @@ impl QdrantConfig {
     pub async fn connect(self) -> Result<QdrantStore, StoreError> {
         let client = Qdrant::from_url(&self.url)
             .api_key(self.api_key)
+            .timeout(Duration::from_secs(self.timeout_s))
+            .connect_timeout(Duration::from_secs(self.connect_timeout_s))
             // .check_compatibility(false) // skip since the log is annoying
             .build()?;
         Ok(QdrantStore {
@@ -1014,6 +1037,8 @@ mod tests {
         assert_eq!(store.api_key.as_deref(), Some("secret"));
         assert_eq!(store.collection_name, "everything");
         assert!(store.upsert_wait);
+        assert_eq!(store.timeout_s, 240);
+        assert_eq!(store.connect_timeout_s, 20);
         assert!(store.params.as_ref().is_some_and(|p| p.recreate));
 
         // Custom sharding: the expression + per-key knobs parse, and pre_create
@@ -1211,6 +1236,16 @@ mod tests {
             other => panic!("expected ParamsMap, got {other:?}"),
         };
         assert_eq!(dense["d"].size, 768);
+    }
+
+    /// Timeouts default to loader-appropriate values (NOT qdrant-client's 5s)
+    /// when the config omits them.
+    #[test]
+    fn timeouts_default_to_patient_values() {
+        let cfg: QdrantConfig =
+            serde_yaml::from_str("url: http://localhost:6334\ncollection_name: c\n").unwrap();
+        assert_eq!(cfg.timeout_s, 120);
+        assert_eq!(cfg.connect_timeout_s, 10);
     }
 
     /// Without `custom_sharding`, the create request must not set a sharding

--- a/crates/nova-storm/Cargo.toml
+++ b/crates/nova-storm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-storm"
-version = "0.0.11"
+version = "0.0.12"
 edition = "2024"
 repository = "https://github.com/qdrant-labs/supernova"
 

--- a/docs/loading/overview.md
+++ b/docs/loading/overview.md
@@ -45,6 +45,7 @@ loader:
   file_retries: 3                   # per-file download+read retries before skipping the file
   upsert_retries: 3                 # per-batch upsert retries before aborting
   # max_failed_files: 50            # abort if more than N files are skipped (default: unlimited)
+  # max_points_per_sec: 5000        # per-worker upsert ceiling — see "Backpressure" below
 ```
 
 ## Running
@@ -327,13 +328,68 @@ on the same store via `reindex`), not an apples-to-apples cross-system benchmark
   the post-load wait for background merges took (usually ~0). The ingestion cost itself
   shows up in the loader's throughput lines (`… pts/s`).
 
+## Backpressure: timeouts, retries, and rate limiting
+
+A cluster under heavy ingest slows its acks, and a loader that reacts badly
+makes it worse. Three knobs, in the order to reach for them:
+
+**1. `vectorstore.timeout_s` (default 120) / `connect_timeout_s` (default 10).**
+The per-request timeout. qdrant-client's own default is *five seconds*, which
+is a trap for bulk upserts: when the client gives up, the server most likely
+still applies the write, and the loader's retry re-sends the same points —
+duplicate work for a cluster that was already too slow, plus inflated
+segment-level point counts until the optimizers vacuum them. A patient timeout
+turns "timed out, retried, died" into "waited, succeeded".
+
+```yaml
+vectorstore:
+  timeout_s: 300          # seconds per upsert request
+  connect_timeout_s: 10
+```
+
+**2. `loader.upsert_retries` (default 5).** Exponential backoff (250ms → 30s
+cap) between attempts, then the worker aborts — a persistent failure usually
+means the store is down or misconfigured. Non-retryable errors (bad request,
+auth, unknown collection) now abort immediately instead of burning the budget.
+
+**3. `loader.max_points_per_sec`.** A hard ceiling on this worker's upsert
+rate — an upper bound, not a target. A token bucket holding one second of the
+rate (or one batch, whichever is larger) gates every upsert *attempt*,
+retries included, so the store never sees more than the configured rate from
+this process over any sustained window.
+
+```yaml
+loader:
+  max_points_per_sec: 5000
+```
+
+It is **per worker**, like every other `loader:` knob: the config describes
+this process, and the fleet is an orchestration concern layered on top. A
+fleet of 32 workers at `5000` presents 160,000 pts/s to the cluster — the
+startup log and `nova load inspect` print exactly that fleet-wide figure so
+neither mental model gets surprised:
+
+```
+rate limit: 5000 pts/s per worker (× 32 workers = 160000 pts/s fleet-wide)
+```
+
+The three compose: `concurrency` caps in-flight requests, `upsert_wait: true`
+couples each request to server-side completion (natural latency backpressure),
+and `max_points_per_sec` caps throughput independent of both. If the cluster's
+sustainable rate is unknown, start with the observed rate at which timeouts
+began and back off from there — an adaptive controller (slow down on
+timeouts, creep back up when clean) is a natural follow-up on top of this.
+
 ## Tuning
 
 | Parameter | Default | Guidance |
 |-----------|---------|----------|
-| `batch_size` | 1000 | Points per upsert call. Larger = fewer HTTP calls; 1000 is good for 768-1024 dim vectors. |
-| `concurrency` | 8 | In-flight upsert batches. Lower if the store times out. |
+| `batch_size` | 256 | Points per upsert call. Larger = fewer calls; 256–1000 is typical for 768-1024 dim vectors. |
+| `concurrency` | CPUs − 1 | In-flight upsert batches. Lower if the store times out. |
 | `file_look_ahead` | 2 | Files downloaded + read ahead of the uploader. Higher = more overlap, more RAM/disk. |
-| `file_retries` | 3 | Per-file download+read retries (exponential backoff) before the file is skipped. |
-| `upsert_retries` | 3 | Per-batch upsert retries (exponential backoff) before the run aborts. |
+| `file_retries` | 5 | Per-file download+read retries (exponential backoff) before the file is skipped. |
+| `upsert_retries` | 5 | Per-batch upsert retries (exponential backoff) before the run aborts. Non-retryable errors abort immediately. |
 | `max_failed_files` | _(none)_ | Abort once more than this many files are skipped. Unset = skip every failing file and finish. |
+| `max_points_per_sec` | _(unlimited)_ | Per-worker upsert ceiling (token bucket). See [Backpressure](#backpressure-timeouts-retries-and-rate-limiting). |
+| `vectorstore.timeout_s` | 120 | Per-request timeout (seconds). Raise under sustained backpressure; the client's own 5s default is far too short. |
+| `vectorstore.connect_timeout_s` | 10 | Connection-establishment timeout (seconds). |

--- a/python/nova-dist/pyproject.toml
+++ b/python/nova-dist/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nova-dist"
-version = "0.0.10"
+version = "0.0.12"
 description = "Distributed orchestration for the supernova toolset — fan embed/load/storm across a SkyPilot fleet."
 requires-python = ">=3.11"
 # This package IS the SkyPilot orchestrator, so the SDK is a core dep (not an

--- a/python/nova-embed/pyproject.toml
+++ b/python/nova-embed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nova-embed"
-version = "0.0.10"
+version = "0.0.12"
 description = "Embedding generation for the supernova toolset — stream datasets, embed at scale, write parquet."
 requires-python = ">=3.11"
 # Base deps are light enough to import the config layer and the CLI scaffolding.

--- a/tests/configs/qdrant_all_params.yaml
+++ b/tests/configs/qdrant_all_params.yaml
@@ -10,6 +10,7 @@
 loader:
   batch_size: 256
   concurrency: 4
+  max_points_per_sec: 5000   # per-worker upsert ceiling (unset = unlimited)
 
 datasource:
   type: local
@@ -46,6 +47,10 @@ vectorstore:
   url: http://localhost:6334
   api_key: secret
   upsert_wait: true
+  # Per-request / connect timeouts in seconds (defaults 120 / 10; the client's
+  # own 5s default is too short for upserts into a loaded cluster).
+  timeout_s: 240
+  connect_timeout_s: 20
   # Custom (user-defined) sharding. `shard_key` is a DuckDB expression
   # evaluated per row in the same context as payload_fields. With custom
   # sharding, `params.shard_number` means shards PER KEY; `shards_number` /


### PR DESCRIPTION
The `nova-load` command/crate currently operates in a closed-loop manner. That is, it runs unbounded trying to insert as many points as possible.

However, there are instances where one might want to control the upsert rate for a given worker. To that end, this PR adds the ability to set a maximum points upserted rate (1/s). It similarly makes the cluster timeout a configurable parameter as well.

You can use them both like so:
```yaml
vectorstore:
  timeout_s: 300            # patient under load

loader:
  max_points_per_sec: 5000  # per worker → 160k/s across 32; tune to where timeouts stopped
```